### PR TITLE
Prune detects remote orphans and tolerates bad checkouts (knit)

### DIFF
--- a/src/commands/bundle.rs
+++ b/src/commands/bundle.rs
@@ -145,6 +145,20 @@ struct OrphanWorktree {
     path: PathBuf,
 }
 
+/// A bundle that exists on the KnitHub sync remote but has no local artifact and
+/// whose recorded pull requests are all merged or closed, so prune can never reach
+/// it through the local `.knit/bundles/` scan.
+struct RemoteOrphan {
+    remote_id: String,
+    slug: String,
+    reason: &'static str,
+}
+
+/// Surface a non-fatal prune problem on stderr without aborting the whole run.
+fn print_prune_warning(message: impl std::fmt::Display) {
+    eprintln!("{}", out::warn(message));
+}
+
 pub fn prune_merged_bundles(
     apply: bool,
     refresh: bool,
@@ -181,14 +195,30 @@ pub fn prune_merged_bundles(
     let mut entries = bundle_json_paths(&dir)?;
     entries.sort();
     let mut candidates = Vec::new();
+    let mut local_ids = BTreeSet::new();
     for path in entries {
-        let mut bundle: ChangeGroup = read_json(&path)?;
-        if let Some(reason) = dead_work_candidate(&root, &path, &mut bundle, refresh)? {
-            candidates.push(PruneCandidate {
+        let mut bundle: ChangeGroup = match read_json(&path) {
+            Ok(bundle) => bundle,
+            Err(err) => {
+                print_prune_warning(format!(
+                    "skipped unreadable bundle {}: {err:#}",
+                    path.display()
+                ));
+                continue;
+            }
+        };
+        local_ids.insert(bundle.id.clone());
+        match dead_work_candidate(&root, &path, &mut bundle, refresh) {
+            Ok(Some(reason)) => candidates.push(PruneCandidate {
                 id: bundle.id.clone(),
                 repo_count: bundle.repos.len(),
                 reason,
-            });
+            }),
+            Ok(None) => {}
+            Err(err) => print_prune_warning(format!(
+                "{}: skipped during prune scan: {err:#}",
+                bundle.id
+            )),
         }
     }
     let orphan_worktrees = if worktrees {
@@ -196,11 +226,16 @@ pub fn prune_merged_bundles(
     } else {
         Vec::new()
     };
+    let remote_orphans = if remote_bundles {
+        remote_orphan_candidates(config.as_ref(), &local_ids, &root, refresh)
+    } else {
+        Vec::new()
+    };
 
-    if candidates.is_empty() && orphan_worktrees.is_empty() {
+    if candidates.is_empty() && orphan_worktrees.is_empty() && remote_orphans.is_empty() {
         println!(
             "{}",
-            out::muted("No dead bundles or orphan worktrees to prune.")
+            out::muted("No dead bundles, orphan worktrees, or remote orphan records to prune.")
         );
         return Ok(());
     }
@@ -223,6 +258,17 @@ pub fn prune_merged_bundles(
                 "  {} {}",
                 out::node(&orphan.id),
                 out::path(orphan.path.display())
+            );
+        }
+    }
+    if !remote_orphans.is_empty() {
+        println!("{}", out::heading("Remote orphan bundle candidates:"));
+        for orphan in &remote_orphans {
+            println!(
+                "  {} {} ({})",
+                out::node(&orphan.slug),
+                out::muted("KnitHub record with no local bundle"),
+                out::muted(orphan.reason)
             );
         }
     }
@@ -264,6 +310,26 @@ pub fn prune_merged_bundles(
         remove_orphan_worktree(&orphan, force_branches)?;
         removed_orphans += 1;
     }
+    let mut removed_remote = 0usize;
+    if let Some(config) = config.as_ref() {
+        for orphan in remote_orphans {
+            match crate::commands::remote::delete_remote_bundle_by_id(config, &orphan.remote_id) {
+                Ok(slug) => {
+                    println!(
+                        "{}: {} {}",
+                        out::node(&orphan.slug),
+                        out::movement("deleted remote bundle"),
+                        out::muted(slug)
+                    );
+                    removed_remote += 1;
+                }
+                Err(err) => print_prune_warning(format!(
+                    "{}: failed to delete remote bundle record: {err:#}",
+                    orphan.slug
+                )),
+            }
+        }
+    }
 
     println!("{} {} bundle(s)", out::heading("Pruned:"), pruned);
     if removed_orphans > 0 {
@@ -271,6 +337,13 @@ pub fn prune_merged_bundles(
             "{} {} orphan worktree dir(s)",
             out::heading("Removed:"),
             removed_orphans
+        );
+    }
+    if removed_remote > 0 {
+        println!(
+            "{} {} remote orphan record(s)",
+            out::heading("Removed:"),
+            removed_remote
         );
     }
     Ok(())
@@ -293,30 +366,41 @@ fn dead_work_candidate(
 
         if refresh {
             if let Some(existing) = publication.as_ref() {
-                let pr =
-                    github::view_pr(Path::new(&repo.path), &existing.url).with_context(|| {
-                        format!("{}: failed to refresh {}", bundle.id, existing.url)
-                    })?;
-                github::upsert_publication(bundle, &repo, &pr);
-                publication = github::publication_for_repo(bundle, &repo.id).cloned();
+                match github::view_pr(Path::new(&repo.path), &existing.url) {
+                    Ok(pr) => {
+                        github::upsert_publication(bundle, &repo, &pr);
+                        publication = github::publication_for_repo(bundle, &repo.id).cloned();
+                    }
+                    Err(err) => print_prune_warning(format!(
+                        "{}/{}: could not refresh {} ({err:#}); using last recorded state",
+                        bundle.id, repo.id, existing.url
+                    )),
+                }
             } else if let Some(branch) = branch {
-                if let Some(pr) =
-                    github::find_existing_pr(Path::new(&repo.path), branch, &repo.base_branch)
-                        .with_context(|| {
-                            format!(
-                                "{}: failed to check for an existing PR for {}",
-                                bundle.id, branch
-                            )
-                        })?
-                {
-                    github::upsert_publication(bundle, &repo, &pr);
-                    publication = github::publication_for_repo(bundle, &repo.id).cloned();
+                match github::find_existing_pr(Path::new(&repo.path), branch, &repo.base_branch) {
+                    Ok(Some(pr)) => {
+                        github::upsert_publication(bundle, &repo, &pr);
+                        publication = github::publication_for_repo(bundle, &repo.id).cloned();
+                    }
+                    Ok(None) => {}
+                    Err(err) => print_prune_warning(format!(
+                        "{}/{}: could not check for an open PR on {branch} ({err:#}); using last recorded state",
+                        bundle.id, repo.id
+                    )),
                 }
             }
         }
 
-        if checkout_has_pending_changes(root, &repo)? {
-            saw_pending_changes = true;
+        match checkout_has_pending_changes(root, &repo) {
+            Ok(true) => saw_pending_changes = true,
+            Ok(false) => {}
+            Err(err) => {
+                print_prune_warning(format!(
+                    "{}/{}: could not inspect checkout for pending changes ({err:#}); keeping the bundle to be safe",
+                    bundle.id, repo.id
+                ));
+                saw_pending_changes = true;
+            }
         }
 
         let Some(publication) = publication else {
@@ -348,6 +432,96 @@ fn dead_work_candidate(
         return Ok(Some("no open PRs and no pending changes"));
     }
     Ok(Some("no recorded PRs and no pending changes"))
+}
+
+/// Find KnitHub remote bundle records that have no local artifact and whose recorded
+/// PRs are all merged or closed. These can never be reached by the local `.knit/bundles/`
+/// scan once their local artifact is gone, so prune would otherwise leave them forever.
+fn remote_orphan_candidates(
+    config: Option<&crate::model::KnitConfig>,
+    local_ids: &BTreeSet<String>,
+    root: &Path,
+    refresh: bool,
+) -> Vec<RemoteOrphan> {
+    let Some(config) = config else {
+        return Vec::new();
+    };
+    let Some(project_id) = config.active_project.clone() else {
+        print_prune_warning(
+            "no active project configured; skipping KnitHub remote orphan detection",
+        );
+        return Vec::new();
+    };
+    let records = match crate::commands::remote::list_remote_bundles(config, &project_id) {
+        Ok(records) => records,
+        Err(err) => {
+            print_prune_warning(format!(
+                "could not list KnitHub remote bundles ({err:#}); skipping remote orphan detection"
+            ));
+            return Vec::new();
+        }
+    };
+    let mut orphans = Vec::new();
+    for record in records {
+        if record.lifecycle_state == "deleted" || local_ids.contains(&record.slug) {
+            continue;
+        }
+        let Some(payload) = record.payload.as_ref() else {
+            continue;
+        };
+        if let Some(reason) = remote_payload_dead_reason(root, payload, refresh) {
+            orphans.push(RemoteOrphan {
+                remote_id: record.remote_id,
+                slug: record.slug,
+                reason,
+            });
+        }
+    }
+    orphans
+}
+
+/// Classify an orphaned remote bundle's pull requests. The remote's stored artifact can be
+/// stale (it was pushed before the PR merged), so with `refresh` on we re-check each PR's
+/// live state from GitHub by URL, falling back to the last synced state only when the lookup
+/// fails. A bundle is dead only when it has publications and none of them are still open; one
+/// with no recorded PRs is left alone in case it is unpublished work in progress.
+fn remote_payload_dead_reason(
+    root: &Path,
+    payload: &ChangeGroup,
+    refresh: bool,
+) -> Option<&'static str> {
+    let mut saw_publication = false;
+    let mut saw_merged = false;
+    for publication in &payload.publications {
+        saw_publication = true;
+        let state = if refresh {
+            match github::view_pr(root, &publication.url) {
+                Ok(pr) => pr.state.unwrap_or_else(|| publication.state.clone()),
+                Err(err) => {
+                    print_prune_warning(format!(
+                        "{}: could not refresh remote PR {} ({err:#}); using last synced state",
+                        payload.id, publication.url
+                    ));
+                    publication.state.clone()
+                }
+            }
+        } else {
+            publication.state.clone()
+        };
+        if publication_state_is_merged(&state) {
+            saw_merged = true;
+        } else if !publication_state_is_closed(&state) {
+            return None;
+        }
+    }
+    if !saw_publication {
+        return None;
+    }
+    if saw_merged {
+        Some("remote PRs are merged")
+    } else {
+        Some("remote PRs are closed")
+    }
 }
 
 fn publication_state_is_merged(state: &str) -> bool {
@@ -1172,5 +1346,67 @@ fn validate_commit_ref(
         errors.push(format!(
             "{owner_kind} `{owner_id}` commit sha must not be empty"
         ));
+    }
+}
+
+#[cfg(test)]
+mod prune_tests {
+    use super::*;
+    use crate::model::PublicationEntry;
+
+    fn bundle_with_publication_states(states: &[&str]) -> ChangeGroup {
+        let mut bundle = ChangeGroup::new(
+            "feature".to_string(),
+            "feature".to_string(),
+            "2026-05-05T00:00:00.000Z".to_string(),
+        );
+        bundle.publications = states
+            .iter()
+            .enumerate()
+            .map(|(index, state)| PublicationEntry {
+                repo_id: format!("repo{index}"),
+                provider: github::PROVIDER.to_string(),
+                kind: github::PULL_REQUEST_KIND.to_string(),
+                number: index as u64 + 1,
+                url: format!("https://github.com/acme/repo{index}/pull/{}", index + 1),
+                base_branch: "main".to_string(),
+                head_branch: format!("knit/feature-{index}"),
+                state: (*state).to_string(),
+                title: None,
+                updated_at: "2026-05-05T00:00:00.000Z".to_string(),
+            })
+            .collect();
+        bundle
+    }
+
+    // refresh=false keeps these pure (no GitHub lookups), exercising the classification of
+    // an orphan remote bundle from its recorded publication states.
+    fn dead_reason(states: &[&str]) -> Option<&'static str> {
+        remote_payload_dead_reason(Path::new("/nonexistent"), &bundle_with_publication_states(states), false)
+    }
+
+    #[test]
+    fn all_merged_publications_are_dead() {
+        assert_eq!(dead_reason(&["MERGED", "merged"]), Some("remote PRs are merged"));
+    }
+
+    #[test]
+    fn all_closed_publications_are_dead() {
+        assert_eq!(dead_reason(&["CLOSED"]), Some("remote PRs are closed"));
+    }
+
+    #[test]
+    fn merged_and_closed_without_open_is_dead() {
+        assert_eq!(dead_reason(&["MERGED", "CLOSED"]), Some("remote PRs are merged"));
+    }
+
+    #[test]
+    fn any_open_publication_keeps_the_bundle() {
+        assert_eq!(dead_reason(&["MERGED", "OPEN"]), None);
+    }
+
+    #[test]
+    fn no_publications_is_not_an_orphan() {
+        assert_eq!(dead_reason(&[]), None);
     }
 }

--- a/src/commands/remote.rs
+++ b/src/commands/remote.rs
@@ -389,16 +389,67 @@ pub fn pull_remote_state(remote_name: Option<&str>, skip_remote: bool) -> Result
     Ok(())
 }
 
+/// A bundle as it exists on the configured KnitHub sync remote, with its current
+/// artifact payload decoded into a `ChangeGroup` when one is present.
+pub struct RemoteBundleRecord {
+    pub remote_id: String,
+    pub slug: String,
+    pub lifecycle_state: String,
+    pub payload: Option<ChangeGroup>,
+}
+
+/// Resolve the name of the KnitHub sync remote, preferring an explicit `sync_remote`
+/// and otherwise falling back to a remote literally named `knithub`.
+fn resolve_sync_remote_name(config: &KnitConfig) -> Result<String> {
+    config
+        .sync_remote
+        .clone()
+        .or_else(|| config.remotes.contains_key("knithub").then(|| "knithub".to_string()))
+        .context("No KnitHub sync remote configured. Run `knit remote add knithub <url>` or use explicit prune flags instead of --all.")
+}
+
+/// List the bundle records the sync remote holds for `project_id`, decoding each
+/// bundle's current artifact payload when it is a supported Knit bundle.
+pub fn list_remote_bundles(config: &KnitConfig, project_id: &str) -> Result<Vec<RemoteBundleRecord>> {
+    let remote_name = resolve_sync_remote_name(config)?;
+    let remote = resolve_remote(config, &remote_name)?;
+    let token = resolve_token(&remote_name, remote)?;
+    let export = fetch_project_export(remote, &token, project_id)?;
+    Ok(export
+        .bundles
+        .into_iter()
+        .map(|bundle| {
+            let payload = bundle
+                .current_artifact
+                .as_ref()
+                .and_then(|artifact| decode_bundle_payload(&artifact.payload, &bundle.slug).ok());
+            RemoteBundleRecord {
+                remote_id: bundle.id,
+                slug: bundle.slug,
+                lifecycle_state: bundle.lifecycle_state,
+                payload,
+            }
+        })
+        .collect())
+}
+
+/// Delete a single bundle record from the sync remote by its remote id, returning the
+/// deleted bundle's slug.
+pub fn delete_remote_bundle_by_id(config: &KnitConfig, remote_id: &str) -> Result<String> {
+    let remote_name = resolve_sync_remote_name(config)?;
+    let remote = resolve_remote(config, &remote_name)?;
+    let token = resolve_token(&remote_name, remote)?;
+    let deleted: RemoteBundle =
+        request_json(remote, &token, "DELETE", &format!("/bundles/{remote_id}"), None)?;
+    Ok(deleted.slug)
+}
+
 pub fn delete_bundle_from_remote(
     _root: &Path,
     config: &KnitConfig,
     bundle: &ChangeGroup,
 ) -> Result<()> {
-    let remote_name = config
-        .sync_remote
-        .clone()
-        .or_else(|| config.remotes.contains_key("knithub").then(|| "knithub".to_string()))
-        .context("No KnitHub sync remote configured. Run `knit remote add knithub <url>` or use explicit prune flags instead of --all.")?;
+    let remote_name = resolve_sync_remote_name(config)?;
     let remote = resolve_remote(config, &remote_name)?;
     let token = resolve_token(&remote_name, remote)?;
     let project_id = bundle


### PR DESCRIPTION
Generated by Knit. Cross-links will be refreshed after all PRs are created.

<!-- BEGIN KNIT BUNDLE -->
## Knit Bundle

This PR is part of Knit bundle `prune-detects-remote-orphans-and-tolerates-bad-checkouts`.

See the other PRs in this bundle:
- `knit`: https://github.com/Marc-Merino/knit/pull/16 (this PR)

Bundle id: `prune-detects-remote-orphans-and-tolerates-bad-checkouts`
Bundle title: Prune detects remote orphans and tolerates bad checkouts
<!-- END KNIT BUNDLE -->