### PR TITLE
clearer landing failure messages (knit)

### DIFF
--- a/src/commands/land.rs
+++ b/src/commands/land.rs
@@ -90,7 +90,8 @@ pub fn apply_land_from_artifact(artifact_path: &Path, out_path: Option<&Path>) -
             DEFAULT_LANDING_MERGE_METHOD,
             false,
             pr.head_ref_oid.as_deref(),
-        )?;
+        )
+        .with_context(|| format!("{}: merging {}", repo.id, publication.url))?;
 
         let refreshed = forge.view(&target, &publication.url)?;
         providers::upsert_publication(&mut bundle, repo, forge.as_ref(), &refreshed);


### PR DESCRIPTION
Generated by Knit. Cross-links will be refreshed after all review objects are created.

<!-- BEGIN KNIT BUNDLE -->
## Knit Bundle

This PR is part of Knit bundle `clearer-landing-failure-messages`.

See the other review objects in this bundle:
- `knithub`: https://github.com/Marc-Merino/knithub/pull/15
- `knit`: https://github.com/Marc-Merino/knit/pull/21 (this PR)

Bundle id: `clearer-landing-failure-messages`
Bundle title: clearer landing failure messages
<!-- END KNIT BUNDLE -->