### PR TITLE
knit reset command (knit)

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,7 @@ knit log [-<count>]
 knit log [-n [count]]
 knit revert <sha|node|HEAD|HEAD~N> [--plan]
 knit revert <sha|node|HEAD|HEAD~N> --apply
+knit reset [--soft|--mixed|--hard] [<commit>] [--repo <repo>] [--all]
 knit git [--repo <repo>] [--all] <git-args...> [repo-selector...]
 knit show <sha|node|HEAD|HEAD~N>
 ```
@@ -535,6 +536,15 @@ knit git --repo backend diff --stat
 ```
 
 Repo selectors can be repo ids, original repo paths, or worktree paths. Quote `'*'` when you want Knit to receive the literal all-repos selector instead of your shell expanding it. If a git argument is ambiguous with a repo id, use `--repo`.
+
+`knit reset` runs `git reset` across tracked checkouts, mirroring git's own modes: `--soft` moves the branch pointer only, `--mixed` (the default) resets the index but keeps the working tree, and `--hard` resets the index and working tree. The optional `<commit>` defaults to `HEAD`. Scope is context-aware: when a bundle is resolved explicitly (`--bundle`), via `KNIT_BUNDLE`, a worktree cwd, or folder context, reset targets that bundle's checkouts; run from the workspace root it instead resets the active project's source repo checkouts, which is the fast way to discard changes a tool made directly on the source branches without a bundle. Like git, `--hard` does not remove untracked files; follow up with `knit git --all clean -fd` if you also need to drop new untracked files.
+
+```sh
+knit reset --hard --all          # discard tracked changes in every source repo (from workspace root)
+knit reset --hard --repo knit    # just one repo
+knit --bundle feature-a reset --hard --all
+knit reset --soft HEAD~1         # undo the last commit, keep the changes
+```
 
 Knit colors interactive terminal output for scanability. It disables color automatically when output is piped, when `NO_COLOR` is set, or when `TERM=dumb`. Use `KNIT_COLOR=always` or `KNIT_COLOR=never` to force a mode.
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -405,6 +405,26 @@ pub enum Commands {
         #[arg(long)]
         apply: bool,
     },
+    /// Run git reset across tracked checkouts (resolved bundle, or project source repos from the workspace root).
+    Reset {
+        /// Do not touch the index or working tree (git reset --soft).
+        #[arg(long, conflicts_with_all = ["mixed", "hard"])]
+        soft: bool,
+        /// Reset the index but keep the working tree. This is the default (git reset --mixed).
+        #[arg(long, conflicts_with_all = ["soft", "hard"])]
+        mixed: bool,
+        /// Reset the index and working tree, discarding tracked changes (git reset --hard).
+        #[arg(long, conflicts_with_all = ["soft", "mixed"])]
+        hard: bool,
+        /// Commit-ish to reset to. Defaults to HEAD.
+        commit: Option<String>,
+        /// Target repo id or path. Repeat for multiple repos.
+        #[arg(short = 'r', long = "repo", value_name = "REPO")]
+        repos: Vec<String>,
+        /// Run against every tracked repo.
+        #[arg(long)]
+        all: bool,
+    },
     /// Run a git command in tracked checkouts.
     Git {
         /// Target repo id or path. Repeat for multiple repos.

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -21,6 +21,7 @@ pub mod pull;
 pub mod push;
 pub mod remote;
 pub mod remove;
+pub mod reset;
 pub mod revert;
 pub mod run;
 pub mod runtime;
@@ -72,6 +73,7 @@ pub use remote::{
     push_bundle_to_remote, push_project_to_remote, remove_remote, set_remote_token, show_remote,
 };
 pub use remove::remove_repos;
+pub use reset::reset_checkouts;
 pub use revert::revert_target;
 pub use run::run_project_command;
 pub use schema::print_schema;

--- a/src/commands/reset.rs
+++ b/src/commands/reset.rs
@@ -1,0 +1,241 @@
+use crate::checkout::checkout_dir;
+use crate::model::{KnitProject, ProjectRepoEntry};
+use crate::output as out;
+use crate::repo_selectors::resolve_repo_indexes;
+use crate::store::{
+    find_knit_root, load_active_bundle, load_config, project_path, read_json, ActiveBundle,
+    BundleResolutionSource,
+};
+use anyhow::{bail, Context, Result};
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+
+/// Which `git reset` mode to run. Mirrors git's own modes.
+#[derive(Clone, Copy)]
+enum ResetMode {
+    Soft,
+    Mixed,
+    Hard,
+}
+
+impl ResetMode {
+    fn resolve(soft: bool, hard: bool) -> Self {
+        match (soft, hard) {
+            (true, _) => Self::Soft,
+            (_, true) => Self::Hard,
+            _ => Self::Mixed,
+        }
+    }
+
+    fn flag(self) -> &'static str {
+        match self {
+            Self::Soft => "--soft",
+            Self::Mixed => "--mixed",
+            Self::Hard => "--hard",
+        }
+    }
+}
+
+/// Run `git reset <mode> <commit>` across tracked checkouts.
+///
+/// Scope is context-aware, matching how Knit already resolves bundles:
+/// when a bundle is resolved explicitly, through `KNIT_BUNDLE`, a worktree cwd,
+/// or folder context, the bundle's checkouts are reset. When the only thing
+/// available is the shared workspace fallback (running from the source root),
+/// the active project's source repo checkouts are reset instead.
+pub fn reset_checkouts(
+    soft: bool,
+    hard: bool,
+    commit: Option<&str>,
+    repos: &[String],
+    all: bool,
+) -> Result<()> {
+    let mode = ResetMode::resolve(soft, hard);
+    let commit = commit.unwrap_or("HEAD");
+
+    let active = load_active_bundle().ok();
+    let use_bundle = active
+        .as_ref()
+        .is_some_and(|active| active.resolution_source != BundleResolutionSource::Config);
+
+    if use_bundle {
+        reset_bundle_checkouts(&active.expect("bundle present"), mode, commit, repos, all)
+    } else {
+        let root = match active {
+            Some(active) => active.root,
+            None => {
+                let cwd = std::env::current_dir().context("failed to read current directory")?;
+                find_knit_root(&cwd)
+                    .context("Not inside a Knit workspace. Run this from a Knit workspace.")?
+            }
+        };
+        reset_project_sources(&root, mode, commit, repos, all)
+    }
+}
+
+fn reset_bundle_checkouts(
+    active: &ActiveBundle,
+    mode: ResetMode,
+    commit: &str,
+    repos: &[String],
+    all: bool,
+) -> Result<()> {
+    if active.bundle.repos.is_empty() {
+        bail!("The resolved bundle has no repos. Run `knit bundle add <repo-path>` first.");
+    }
+
+    let indexes = resolve_repo_indexes(active, repos, all)?;
+    let multiple = indexes.len() > 1;
+    let mut failures = Vec::new();
+
+    for index in indexes {
+        let repo = &active.bundle.repos[index];
+        let cwd = match checkout_dir(active, repo) {
+            Some(cwd) => cwd,
+            None => {
+                failures.push(format!(
+                    "{}: no active checkout. Run `knit worktree` to materialize it.",
+                    repo.id
+                ));
+                continue;
+            }
+        };
+        run_reset(&repo.id, &cwd, mode, commit, multiple, &mut failures);
+    }
+
+    finish(&failures)
+}
+
+fn reset_project_sources(
+    root: &Path,
+    mode: ResetMode,
+    commit: &str,
+    repos: &[String],
+    all: bool,
+) -> Result<()> {
+    let project = load_active_project(root)?;
+    if project.repos.is_empty() {
+        bail!(
+            "Project `{}` has no repos. Run `knit project add <repo-id> <path>` first.",
+            project.id
+        );
+    }
+
+    let selected = select_project_repos(&project, repos, all)?;
+    let multiple = selected.len() > 1;
+    let mut failures = Vec::new();
+
+    println!(
+        "{}",
+        out::muted(format!(
+            "resetting source checkouts for project {}",
+            project.id
+        ))
+    );
+
+    for repo in selected {
+        let cwd = PathBuf::from(&repo.path);
+        if !cwd.exists() {
+            failures.push(format!(
+                "{}: source path {} does not exist",
+                repo.id,
+                cwd.display()
+            ));
+            continue;
+        }
+        run_reset(&repo.id, &cwd, mode, commit, multiple, &mut failures);
+    }
+
+    finish(&failures)
+}
+
+fn run_reset(
+    repo_id: &str,
+    cwd: &Path,
+    mode: ResetMode,
+    commit: &str,
+    show_header: bool,
+    failures: &mut Vec<String>,
+) {
+    if show_header {
+        println!("== {} ({}) ==", out::repo(repo_id), out::path(cwd.display()));
+    }
+
+    let status = Command::new("git")
+        .args(["reset", mode.flag(), commit])
+        .current_dir(cwd)
+        .stdin(Stdio::inherit())
+        .stdout(Stdio::inherit())
+        .stderr(Stdio::inherit())
+        .status();
+
+    match status {
+        Ok(status) if status.success() => {}
+        Ok(status) => failures.push(match status.code() {
+            Some(code) => format!("{repo_id} exited {code}"),
+            None => format!("{repo_id} terminated by signal"),
+        }),
+        Err(error) => failures.push(format!("{repo_id}: failed to run git reset: {error}")),
+    }
+}
+
+fn finish(failures: &[String]) -> Result<()> {
+    if !failures.is_empty() {
+        bail!("git reset failed: {}", failures.join(", "));
+    }
+    Ok(())
+}
+
+fn load_active_project(root: &Path) -> Result<KnitProject> {
+    let config = load_config(root)?;
+    let project_id = config.active_project.context(
+        "No active project to reset. Set one with `knit project set <name>` or run from a bundle worktree to reset its checkouts.",
+    )?;
+    read_json(&project_path(root, &project_id))
+        .with_context(|| format!("failed to load project `{project_id}`"))
+}
+
+fn select_project_repos<'a>(
+    project: &'a KnitProject,
+    selectors: &[String],
+    all: bool,
+) -> Result<Vec<&'a ProjectRepoEntry>> {
+    if all && !selectors.is_empty() {
+        bail!("Use either --all or repo selectors, not both.");
+    }
+    if all || selectors.is_empty() {
+        return Ok(project.repos.iter().collect());
+    }
+
+    let mut selected = Vec::new();
+    for selector in selectors {
+        let Some(repo) = project
+            .repos
+            .iter()
+            .find(|repo| project_repo_matches(repo, selector))
+        else {
+            bail!("No project repo matched `{selector}`.");
+        };
+        if !selected.iter().any(|existing: &&ProjectRepoEntry| {
+            std::ptr::eq(*existing as *const _, repo as *const _)
+        }) {
+            selected.push(repo);
+        }
+    }
+    Ok(selected)
+}
+
+fn project_repo_matches(repo: &ProjectRepoEntry, selector: &str) -> bool {
+    if selector == repo.id || selector == repo.path {
+        return true;
+    }
+    let selector_path = Path::new(selector);
+    selector_path.exists()
+        && canonical(selector_path)
+            .zip(canonical(Path::new(&repo.path)))
+            .is_some_and(|(selector_abs, repo_abs)| selector_abs == repo_abs)
+}
+
+fn canonical(path: &Path) -> Option<PathBuf> {
+    path.canonicalize().ok()
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -579,6 +579,14 @@ pub fn run(cli: Cli) -> Result<()> {
             plan: _,
             apply,
         } => commands::revert_target(&target, apply),
+        Commands::Reset {
+            soft,
+            mixed: _,
+            hard,
+            commit,
+            repos,
+            all,
+        } => commands::reset_checkouts(soft, hard, commit.as_deref(), &repos, all),
         Commands::Git { repos, all, args } => commands::run_git(&args, &repos, all),
         Commands::Show { target } => commands::show_target(&target),
         Commands::Config { command } => match command {

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -696,6 +696,64 @@ fn commit_from_worktree_uses_worktree_bundle_not_workspace_fallback() {
 }
 
 #[test]
+fn reset_hard_restores_tracked_changes_in_project_source_repos() {
+    let root = unique_temp_dir();
+    let backend = root.join("backend");
+    let workspace = root.join("workspace");
+    fs::create_dir_all(&workspace).unwrap();
+
+    init_repo(&backend, "backend");
+
+    knit(&workspace, ["project", "init", "demo"]);
+    knit(
+        &workspace,
+        ["project", "add", "backend", backend.to_str().unwrap()],
+    );
+
+    // Dirty the canonical source checkout the way an external tool would.
+    fs::write(backend.join("app.txt"), "tampered\n").unwrap();
+    fs::write(backend.join("untracked.txt"), "new\n").unwrap();
+
+    let output = knit(&workspace, ["reset", "--hard", "--all"]);
+    assert!(output.contains("resetting source checkouts for project demo"));
+
+    // Tracked change is discarded; the untracked file survives, mirroring `git reset --hard`.
+    assert_eq!(
+        fs::read_to_string(backend.join("app.txt")).unwrap(),
+        "backend\n"
+    );
+    assert!(backend.join("untracked.txt").exists());
+
+    fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
+fn reset_hard_resets_bundle_worktree_when_resolved_from_worktree() {
+    let root = unique_temp_dir();
+    let backend = root.join("backend");
+    let workspace = root.join("workspace");
+    fs::create_dir_all(&workspace).unwrap();
+
+    init_repo(&backend, "backend");
+
+    knit(&workspace, ["bundle", "start", "feature"]);
+    knit(&workspace, ["bundle", "add", backend.to_str().unwrap()]);
+
+    let checkout = workspace.join(".knit/worktrees/feature/backend");
+    fs::write(checkout.join("app.txt"), "tampered\n").unwrap();
+
+    // Resolved from the worktree cwd, reset targets the bundle checkout, not project sources.
+    let output = knit(&checkout, ["reset", "--hard"]);
+    assert!(!output.contains("resetting source checkouts"));
+    assert_eq!(
+        fs::read_to_string(checkout.join("app.txt")).unwrap(),
+        "backend\n"
+    );
+
+    fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
 fn run_executes_named_project_commands_in_bundle_worktrees() {
     let root = unique_temp_dir();
     let backend = root.join("backend");


### PR DESCRIPTION
Generated by Knit. Cross-links will be refreshed after all review objects are created.

<!-- BEGIN KNIT BUNDLE -->
## Knit Bundle

This PR is part of Knit bundle `knit-reset-command`.

See the other review objects in this bundle:
- `knit`: https://github.com/marc-merino/knit/pull/22 (this PR)

Bundle id: `knit-reset-command`
Bundle title: knit reset command
<!-- END KNIT BUNDLE -->