### PR TITLE
bundle start enter option (knit)

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ knit project list
 knit project show [name]
 knit project remove <name> --force
 knit bundle
-knit bundle start "<title>" [--project <name>] [--repo <repo-id>]... [--all-repos] [--no-worktree] [--in-place] [--force] [--agents] [--enter [<repo>]]
+knit bundle start "<title>" [--project <name>] [--repo <repo-id>]... [--all-repos] [--no-worktree] [--in-place] [--force] [--agents] [--cd [<repo>]]
 knit bundle add <repo-path-or-project-repo-id>... [--base <branch>] [--in-place] [--no-worktree]
 knit bundle remove [<repo-id>...] [--repo <repo-id>]...
 knit bundle list [--all] [--archived] [--deleted]
@@ -249,7 +249,7 @@ knit bundle add docs
 
 Bundles are the branch-like feature units. The same source repo can appear in many bundles at once. Knit creates separate feature branches and generated worktrees, for example `.knit/worktrees/fix-a/backend` and `.knit/worktrees/fix-b/backend`.
 
-Use `knit bundle start "<title>" --project <project> --enter` to create the bundle with the project's default repos and immediately start your shell in `.knit/worktrees/<bundle>`. Pass `--repo` only when you want to limit which repos are included; pass an `--enter` value such as `--enter backend` only when you want to enter a specific repo checkout instead.
+Use `knit bundle start "<title>" --cd` to create the bundle from the current workspace project's default repos and immediately start your shell in `.knit/worktrees/<bundle>`. Pass `--project` when you want a project other than the current one, pass `--repo` only when you want to limit which repos are included, and pass a `--cd` value such as `--cd backend` only when you want a specific repo checkout instead.
 
 For parallel agent work, move each agent into the generated checkout it owns, such as `.knit/worktrees/fix-a/backend`. Commands run from inside a generated checkout resolve that checkout's bundle from the path, independent of the shared workspace fallback.
 

--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ knit bundle add docs
 
 Bundles are the branch-like feature units. The same source repo can appear in many bundles at once. Knit creates separate feature branches and generated worktrees, for example `.knit/worktrees/fix-a/backend` and `.knit/worktrees/fix-b/backend`.
 
-Use `knit bundle start "<title>" --enter` to create the bundle and immediately start your shell in `.knit/worktrees/<bundle>`. Pass a repo selector such as `--enter backend` when you want to enter a specific repo checkout instead.
+Use `knit bundle start "<title>" --project <project> --enter` to create the bundle with the project's default repos and immediately start your shell in `.knit/worktrees/<bundle>`. Pass `--repo` only when you want to limit which repos are included; pass an `--enter` value such as `--enter backend` only when you want to enter a specific repo checkout instead.
 
 For parallel agent work, move each agent into the generated checkout it owns, such as `.knit/worktrees/fix-a/backend`. Commands run from inside a generated checkout resolve that checkout's bundle from the path, independent of the shared workspace fallback.
 

--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ knit bundle add docs
 
 Bundles are the branch-like feature units. The same source repo can appear in many bundles at once. Knit creates separate feature branches and generated worktrees, for example `.knit/worktrees/fix-a/backend` and `.knit/worktrees/fix-b/backend`.
 
-Use `knit bundle start "<title>" --enter` to create the bundle and immediately start your shell in the created checkout. If the bundle tracks more than one repo, pass a repo selector such as `--enter backend`; without a selector Knit enters `.knit/worktrees/<bundle>`.
+Use `knit bundle start "<title>" --enter` to create the bundle and immediately start your shell in `.knit/worktrees/<bundle>`. Pass a repo selector such as `--enter backend` when you want to enter a specific repo checkout instead.
 
 For parallel agent work, move each agent into the generated checkout it owns, such as `.knit/worktrees/fix-a/backend`. Commands run from inside a generated checkout resolve that checkout's bundle from the path, independent of the shared workspace fallback.
 

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ knit project list
 knit project show [name]
 knit project remove <name> --force
 knit bundle
-knit bundle start "<title>" [--project <name>] [--repo <repo-id>]... [--all-repos] [--no-worktree] [--in-place] [--force] [--agents]
+knit bundle start "<title>" [--project <name>] [--repo <repo-id>]... [--all-repos] [--no-worktree] [--in-place] [--force] [--agents] [--enter [<repo>]]
 knit bundle add <repo-path-or-project-repo-id>... [--base <branch>] [--in-place] [--no-worktree]
 knit bundle remove [<repo-id>...] [--repo <repo-id>]...
 knit bundle list [--all] [--archived] [--deleted]
@@ -248,6 +248,8 @@ knit bundle add docs
 ```
 
 Bundles are the branch-like feature units. The same source repo can appear in many bundles at once. Knit creates separate feature branches and generated worktrees, for example `.knit/worktrees/fix-a/backend` and `.knit/worktrees/fix-b/backend`.
+
+Use `knit bundle start "<title>" --enter` to create the bundle and immediately start your shell in the created checkout. If the bundle tracks more than one repo, pass a repo selector such as `--enter backend`; without a selector Knit enters `.knit/worktrees/<bundle>`.
 
 For parallel agent work, move each agent into the generated checkout it owns, such as `.knit/worktrees/fix-a/backend`. Commands run from inside a generated checkout resolve that checkout's bundle from the path, independent of the shared workspace fallback.
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -489,7 +489,7 @@ pub enum BundleCommand {
         /// Write an AGENTS.md tutorial for agents working in this Knit workspace.
         #[arg(long)]
         agents: bool,
-        /// Start a shell in the created checkout. Pass a repo selector when the bundle has several repos.
+        /// Start a shell in .knit/worktrees/<bundle>. Pass a repo selector to enter that repo checkout instead.
         #[arg(long, value_name = "REPO", num_args = 0..=1, default_missing_value = "", conflicts_with = "no_worktree")]
         enter: Option<String>,
     },

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -489,6 +489,9 @@ pub enum BundleCommand {
         /// Write an AGENTS.md tutorial for agents working in this Knit workspace.
         #[arg(long)]
         agents: bool,
+        /// Start a shell in the created checkout. Pass a repo selector when the bundle has several repos.
+        #[arg(long, value_name = "REPO", num_args = 0..=1, default_missing_value = "", conflicts_with = "no_worktree")]
+        enter: Option<String>,
     },
     /// Add repos or project repo ids to the current bundle.
     Add {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -489,9 +489,9 @@ pub enum BundleCommand {
         /// Write an AGENTS.md tutorial for agents working in this Knit workspace.
         #[arg(long)]
         agents: bool,
-        /// Start a shell in .knit/worktrees/<bundle>. Pass a repo selector to enter that repo checkout instead.
+        /// Start a shell in .knit/worktrees/<bundle>. Pass a repo selector to cd into that repo checkout instead.
         #[arg(long, value_name = "REPO", num_args = 0..=1, default_missing_value = "", conflicts_with = "no_worktree")]
-        enter: Option<String>,
+        cd: Option<String>,
     },
     /// Add repos or project repo ids to the current bundle.
     Add {

--- a/src/commands/cherrypick.rs
+++ b/src/commands/cherrypick.rs
@@ -90,6 +90,7 @@ pub fn split_bundle(
         false,
         force,
         false,
+        None,
     )?;
     set_bundle_override(Some(bundle_id));
     cherrypick_from_bundle(source_bundle_id, targets, &repo_ids, false)

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -292,7 +292,7 @@ knit bundle start "feature a" --repo backend
 knit bundle start "feature b" --repo backend
 ```
 
-Use `knit bundle start "feature title" --enter` to create the bundle and immediately start your shell in `.knit/worktrees/<bundle>`. Pass a repo selector such as `--enter backend` when you want to enter a specific repo checkout instead.
+Use `knit bundle start "feature title" --project <project> --enter` to create the bundle with the project's default repos and immediately start your shell in `.knit/worktrees/<bundle>`. Pass `--repo` only when you want to limit which repos are included; pass an `--enter` value such as `--enter backend` only when you want to enter a specific repo checkout instead.
 
 For coding agents in the source workspace, moving into a checkout means each shell/tool call must actually run with that checkout as its cwd/workdir. A narrated `cd`, or a `cd` from a previous non-persistent shell command, is not enough. If this agent is working on one feature, open the generated worktree folder and keep tool calls rooted there. If several agents or features are active, open a separate folder or agent rooted at each new worktree. From the source workspace, use explicit `--bundle <bundle>` on bundle-scoped Knit commands for the feature being changed:
 

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -28,7 +28,7 @@ pub fn start_bundle(
     in_place: bool,
     force: bool,
     agents: bool,
-    enter: Option<&str>,
+    cd: Option<&str>,
 ) -> Result<()> {
     if all_repos && !repo_ids.is_empty() {
         bail!("Use either --all-repos or --repo, not both.");
@@ -42,7 +42,7 @@ pub fn start_bundle(
     let worktree_dir = knit_dir.join("worktrees").join(&bundle_id);
     let bundle_path = stored_bundle_path(&root, &bundle_id);
     if bundle_path.exists() && !force {
-        if agents && enter.is_none() {
+        if agents && cd.is_none() {
             let bundle: ChangeGroup = read_json(&bundle_path)?;
             let active = ActiveBundle::unlocked(root.clone(), bundle_path.clone(), bundle);
             let agents_path = write_agents_md(&root)?;
@@ -115,17 +115,17 @@ pub fn start_bundle(
     let worktree_agents = write_worktree_agents_md(&active)?;
     print_worktree_agents_summary(&worktree_agents);
 
-    if let Some(selector) = enter {
-        let path = enter_target_dir(&active, selector)?;
-        enter_shell(&active, &path)?;
+    if let Some(selector) = cd {
+        let path = cd_target_dir(&active, selector)?;
+        start_shell_in(&active, &path)?;
     }
 
     Ok(())
 }
 
-fn enter_target_dir(active: &ActiveBundle, selector: &str) -> Result<PathBuf> {
+fn cd_target_dir(active: &ActiveBundle, selector: &str) -> Result<PathBuf> {
     if active.bundle.repos.is_empty() {
-        bail!("Cannot enter a checkout because the bundle has no tracked repos.");
+        bail!("Cannot cd into a checkout because the bundle has no tracked repos.");
     }
 
     if selector.trim().is_empty() {
@@ -150,13 +150,9 @@ fn checkout_for_repo(active: &ActiveBundle, index: usize) -> Result<PathBuf> {
     })
 }
 
-fn enter_shell(active: &ActiveBundle, path: &Path) -> Result<()> {
+fn start_shell_in(active: &ActiveBundle, path: &Path) -> Result<()> {
     let shell = std::env::var_os("SHELL").unwrap_or_else(default_shell);
-    println!(
-        "{} {}",
-        out::heading("Entering:"),
-        out::path(path.display())
-    );
+    println!("{} {}", out::heading("cd:"), out::path(path.display()));
     let status = Command::new(&shell)
         .current_dir(path)
         .env("KNIT_ROOT", &active.root)
@@ -292,7 +288,7 @@ knit bundle start "feature a" --repo backend
 knit bundle start "feature b" --repo backend
 ```
 
-Use `knit bundle start "feature title" --project <project> --enter` to create the bundle with the project's default repos and immediately start your shell in `.knit/worktrees/<bundle>`. Pass `--repo` only when you want to limit which repos are included; pass an `--enter` value such as `--enter backend` only when you want to enter a specific repo checkout instead.
+Use `knit bundle start "feature title" --cd` to create the bundle from the current workspace project's default repos and immediately start your shell in `.knit/worktrees/<bundle>`. Pass `--project` when you want a project other than the current one, pass `--repo` only when you want to limit which repos are included, and pass a `--cd` value such as `--cd backend` only when you want a specific repo checkout instead.
 
 For coding agents in the source workspace, moving into a checkout means each shell/tool call must actually run with that checkout as its cwd/workdir. A narrated `cd`, or a `cd` from a previous non-persistent shell command, is not enough. If this agent is working on one feature, open the generated worktree folder and keep tool calls rooted there. If several agents or features are active, open a separate folder or agent rooted at each new worktree. From the source workspace, use explicit `--bundle <bundle>` on bundle-scoped Knit commands for the feature being changed:
 
@@ -398,7 +394,7 @@ knit cherrypick --from feature-a --repo backend abc123
 
 - `knit bundle` shows the resolved bundle and where it came from.
 - `knit bundle start "Feature title"` creates a bundle.
-- `knit bundle start "Feature title" --enter` creates a bundle and starts a shell in its generated checkout.
+- `knit bundle start "Feature title" --cd` creates a bundle and starts a shell in `.knit/worktrees/<bundle>`.
 - `knit bundle add <repo-or-project-repo>` adds repos to the current bundle.
 - `knit bundle remove --repo <repo-id>` removes repos from the current bundle while leaving branches and checkouts in place.
 - `knit bundle compat <bundle> <bundle>` creates an ordinary compatibility bundle from source bundle repos.

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -129,10 +129,6 @@ fn enter_target_dir(active: &ActiveBundle, selector: &str) -> Result<PathBuf> {
     }
 
     if selector.trim().is_empty() {
-        if active.bundle.repos.len() == 1 {
-            return checkout_for_repo(active, 0);
-        }
-
         return Ok(active.root.join(".knit/worktrees").join(&active.bundle.id));
     }
 
@@ -296,7 +292,7 @@ knit bundle start "feature a" --repo backend
 knit bundle start "feature b" --repo backend
 ```
 
-Use `knit bundle start "feature title" --enter` to create the bundle and immediately start your shell in the created checkout. If the bundle tracks more than one repo, pass a repo selector such as `--enter backend`; without a selector Knit enters `.knit/worktrees/<bundle>`.
+Use `knit bundle start "feature title" --enter` to create the bundle and immediately start your shell in `.knit/worktrees/<bundle>`. Pass a repo selector such as `--enter backend` when you want to enter a specific repo checkout instead.
 
 For coding agents in the source workspace, moving into a checkout means each shell/tool call must actually run with that checkout as its cwd/workdir. A narrated `cd`, or a `cd` from a previous non-persistent shell command, is not enough. If this agent is working on one feature, open the generated worktree folder and keep tool calls rooted there. If several agents or features are active, open a separate folder or agent rooted at each new worktree. From the source workspace, use explicit `--bundle <bundle>` on bundle-scoped Knit commands for the feature being changed:
 

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -1,3 +1,4 @@
+use crate::checkout::checkout_dir;
 use crate::commands::agents::{
     print_worktree_agents_summary, upsert_managed_section, write_worktree_agents_md,
 };
@@ -11,10 +12,11 @@ use crate::store::{
 use crate::time::now_iso;
 use anyhow::{bail, Context, Result};
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
+use std::process::Command;
 
 pub fn init_bundle(title: &str, force: bool, agents: bool) -> Result<()> {
-    start_bundle(title, None, &[], false, true, false, force, agents)
+    start_bundle(title, None, &[], false, true, false, force, agents, None)
 }
 
 pub fn start_bundle(
@@ -26,6 +28,7 @@ pub fn start_bundle(
     in_place: bool,
     force: bool,
     agents: bool,
+    enter: Option<&str>,
 ) -> Result<()> {
     if all_repos && !repo_ids.is_empty() {
         bail!("Use either --all-repos or --repo, not both.");
@@ -39,7 +42,7 @@ pub fn start_bundle(
     let worktree_dir = knit_dir.join("worktrees").join(&bundle_id);
     let bundle_path = stored_bundle_path(&root, &bundle_id);
     if bundle_path.exists() && !force {
-        if agents {
+        if agents && enter.is_none() {
             let bundle: ChangeGroup = read_json(&bundle_path)?;
             let active = ActiveBundle::unlocked(root.clone(), bundle_path.clone(), bundle);
             let agents_path = write_agents_md(&root)?;
@@ -112,7 +115,76 @@ pub fn start_bundle(
     let worktree_agents = write_worktree_agents_md(&active)?;
     print_worktree_agents_summary(&worktree_agents);
 
+    if let Some(selector) = enter {
+        let path = enter_target_dir(&active, selector)?;
+        enter_shell(&active, &path)?;
+    }
+
     Ok(())
+}
+
+fn enter_target_dir(active: &ActiveBundle, selector: &str) -> Result<PathBuf> {
+    if active.bundle.repos.is_empty() {
+        bail!("Cannot enter a checkout because the bundle has no tracked repos.");
+    }
+
+    if selector.trim().is_empty() {
+        if active.bundle.repos.len() == 1 {
+            return checkout_for_repo(active, 0);
+        }
+
+        return Ok(active.root.join(".knit/worktrees").join(&active.bundle.id));
+    }
+
+    let selectors = [selector.to_string()];
+    let indexes = crate::repo_selectors::resolve_repo_indexes(active, &selectors, false)?;
+    if indexes.len() != 1 {
+        bail!("Repo selector `{selector}` matched multiple repos; pass a more specific repo id.");
+    }
+    checkout_for_repo(active, indexes[0])
+}
+
+fn checkout_for_repo(active: &ActiveBundle, index: usize) -> Result<PathBuf> {
+    let repo = &active.bundle.repos[index];
+    checkout_dir(active, repo).with_context(|| {
+        format!(
+            "{} has no materialized checkout. Run `knit worktree` first.",
+            repo.id
+        )
+    })
+}
+
+fn enter_shell(active: &ActiveBundle, path: &Path) -> Result<()> {
+    let shell = std::env::var_os("SHELL").unwrap_or_else(default_shell);
+    println!(
+        "{} {}",
+        out::heading("Entering:"),
+        out::path(path.display())
+    );
+    let status = Command::new(&shell)
+        .current_dir(path)
+        .env("KNIT_ROOT", &active.root)
+        .env("KNIT_BUNDLE", &active.bundle.id)
+        .status()
+        .with_context(|| {
+            format!(
+                "failed to start shell {} in {}",
+                PathBuf::from(&shell).display(),
+                path.display()
+            )
+        })?;
+    if !status.success() {
+        bail!("shell exited with {status}");
+    }
+    Ok(())
+}
+
+fn default_shell() -> std::ffi::OsString {
+    if cfg!(windows) {
+        std::ffi::OsString::from("cmd")
+    } else {
+        std::ffi::OsString::from("/bin/sh")
+    }
 }
 
 fn resolve_start_project(
@@ -224,6 +296,8 @@ knit bundle start "feature a" --repo backend
 knit bundle start "feature b" --repo backend
 ```
 
+Use `knit bundle start "feature title" --enter` to create the bundle and immediately start your shell in the created checkout. If the bundle tracks more than one repo, pass a repo selector such as `--enter backend`; without a selector Knit enters `.knit/worktrees/<bundle>`.
+
 For coding agents in the source workspace, moving into a checkout means each shell/tool call must actually run with that checkout as its cwd/workdir. A narrated `cd`, or a `cd` from a previous non-persistent shell command, is not enough. If this agent is working on one feature, open the generated worktree folder and keep tool calls rooted there. If several agents or features are active, open a separate folder or agent rooted at each new worktree. From the source workspace, use explicit `--bundle <bundle>` on bundle-scoped Knit commands for the feature being changed:
 
 ```sh
@@ -328,6 +402,7 @@ knit cherrypick --from feature-a --repo backend abc123
 
 - `knit bundle` shows the resolved bundle and where it came from.
 - `knit bundle start "Feature title"` creates a bundle.
+- `knit bundle start "Feature title" --enter` creates a bundle and starts a shell in its generated checkout.
 - `knit bundle add <repo-or-project-repo>` adds repos to the current bundle.
 - `knit bundle remove --repo <repo-id>` removes repos from the current bundle while leaving branches and checkouts in place.
 - `knit bundle compat <bundle> <bundle>` creates an ordinary compatibility bundle from source bundle repos.

--- a/src/commands/merge/mod.rs
+++ b/src/commands/merge/mod.rs
@@ -233,6 +233,7 @@ pub fn create_compat_bundle(
             in_place,
             force,
             false,
+            None,
         );
     }
 

--- a/src/commands/workitem.rs
+++ b/src/commands/workitem.rs
@@ -234,6 +234,7 @@ pub fn start_work_item(id: &str, target: Option<&str>) -> Result<()> {
         false,
         false,
         true,
+        None,
     )?;
     let bundle_id = slugify(&title);
     let bundle_path = bundle_path(&root, &bundle_id);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -205,7 +205,7 @@ pub fn run(cli: Cli) -> Result<()> {
                 in_place,
                 force,
                 agents,
-                enter,
+                cd,
             }) => commands::start_bundle(
                 &title,
                 project.as_deref(),
@@ -215,7 +215,7 @@ pub fn run(cli: Cli) -> Result<()> {
                 in_place,
                 force,
                 agents,
-                enter.as_deref(),
+                cd.as_deref(),
             ),
             Some(BundleCommand::Add {
                 repos,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -205,6 +205,7 @@ pub fn run(cli: Cli) -> Result<()> {
                 in_place,
                 force,
                 agents,
+                enter,
             }) => commands::start_bundle(
                 &title,
                 project.as_deref(),
@@ -214,6 +215,7 @@ pub fn run(cli: Cli) -> Result<()> {
                 in_place,
                 force,
                 agents,
+                enter.as_deref(),
             ),
             Some(BundleCommand::Add {
                 repos,

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -127,17 +127,23 @@ fn project_default_repos_start_bundle_without_track() {
 
 #[cfg(unix)]
 #[test]
-fn bundle_start_can_enter_created_worktree() {
+fn bundle_start_enter_opens_project_worktree_root() {
     let root = unique_temp_dir();
     let backend = root.join("backend");
+    let frontend = root.join("frontend");
     let workspace = root.join("workspace");
     fs::create_dir_all(&workspace).unwrap();
 
     init_repo(&backend, "backend");
+    init_repo(&frontend, "frontend");
     knit(&workspace, ["project", "init", "arbient"]);
     knit(
         &workspace,
         ["project", "add", "backend", backend.to_str().unwrap()],
+    );
+    knit(
+        &workspace,
+        ["project", "add", "frontend", frontend.to_str().unwrap()],
     );
 
     let output = knit_with_env(
@@ -149,6 +155,8 @@ fn bundle_start_can_enter_created_worktree() {
         .join(".knit/worktrees/project-feature")
         .canonicalize()
         .unwrap();
+    assert!(checkout.join("backend").exists());
+    assert!(checkout.join("frontend").exists());
     assert!(output.contains("Entering:"));
     assert!(
         output

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -125,6 +125,81 @@ fn project_default_repos_start_bundle_without_track() {
     fs::remove_dir_all(root).unwrap();
 }
 
+#[cfg(unix)]
+#[test]
+fn bundle_start_can_enter_created_worktree() {
+    let root = unique_temp_dir();
+    let backend = root.join("backend");
+    let workspace = root.join("workspace");
+    fs::create_dir_all(&workspace).unwrap();
+
+    init_repo(&backend, "backend");
+    knit(&workspace, ["project", "init", "arbient"]);
+    knit(
+        &workspace,
+        ["project", "add", "backend", backend.to_str().unwrap()],
+    );
+
+    let output = knit_with_env(
+        &workspace,
+        ["bundle", "start", "project feature", "--enter"],
+        &[("SHELL", "/bin/pwd")],
+    );
+    let checkout = workspace
+        .join(".knit/worktrees/project-feature/backend")
+        .canonicalize()
+        .unwrap();
+    assert!(output.contains("Entering:"));
+    assert!(
+        output
+            .lines()
+            .any(|line| line.trim() == checkout.to_str().unwrap()),
+        "{output}"
+    );
+
+    fs::remove_dir_all(root).unwrap();
+}
+
+#[cfg(unix)]
+#[test]
+fn bundle_start_enter_accepts_repo_selector() {
+    let root = unique_temp_dir();
+    let backend = root.join("backend");
+    let frontend = root.join("frontend");
+    let workspace = root.join("workspace");
+    fs::create_dir_all(&workspace).unwrap();
+
+    init_repo(&backend, "backend");
+    init_repo(&frontend, "frontend");
+    knit(&workspace, ["project", "init", "arbient"]);
+    knit(
+        &workspace,
+        ["project", "add", "backend", backend.to_str().unwrap()],
+    );
+    knit(
+        &workspace,
+        ["project", "add", "frontend", frontend.to_str().unwrap()],
+    );
+
+    let output = knit_with_env(
+        &workspace,
+        ["bundle", "start", "project feature", "--enter", "frontend"],
+        &[("SHELL", "/bin/pwd")],
+    );
+    let checkout = workspace
+        .join(".knit/worktrees/project-feature/frontend")
+        .canonicalize()
+        .unwrap();
+    assert!(
+        output
+            .lines()
+            .any(|line| line.trim() == checkout.to_str().unwrap()),
+        "{output}"
+    );
+
+    fs::remove_dir_all(root).unwrap();
+}
+
 #[test]
 fn work_item_start_links_bundle_and_writes_prompt() {
     let root = unique_temp_dir();

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -127,7 +127,7 @@ fn project_default_repos_start_bundle_without_track() {
 
 #[cfg(unix)]
 #[test]
-fn bundle_start_enter_opens_project_worktree_root() {
+fn bundle_start_cd_opens_project_worktree_root() {
     let root = unique_temp_dir();
     let backend = root.join("backend");
     let frontend = root.join("frontend");
@@ -148,7 +148,7 @@ fn bundle_start_enter_opens_project_worktree_root() {
 
     let output = knit_with_env(
         &workspace,
-        ["bundle", "start", "project feature", "--enter"],
+        ["bundle", "start", "project feature", "--cd"],
         &[("SHELL", "/bin/pwd")],
     );
     let checkout = workspace
@@ -157,7 +157,7 @@ fn bundle_start_enter_opens_project_worktree_root() {
         .unwrap();
     assert!(checkout.join("backend").exists());
     assert!(checkout.join("frontend").exists());
-    assert!(output.contains("Entering:"));
+    assert!(output.contains("cd:"));
     assert!(
         output
             .lines()
@@ -170,7 +170,7 @@ fn bundle_start_enter_opens_project_worktree_root() {
 
 #[cfg(unix)]
 #[test]
-fn bundle_start_enter_accepts_repo_selector() {
+fn bundle_start_cd_accepts_repo_selector() {
     let root = unique_temp_dir();
     let backend = root.join("backend");
     let frontend = root.join("frontend");
@@ -191,7 +191,7 @@ fn bundle_start_enter_accepts_repo_selector() {
 
     let output = knit_with_env(
         &workspace,
-        ["bundle", "start", "project feature", "--enter", "frontend"],
+        ["bundle", "start", "project feature", "--cd", "frontend"],
         &[("SHELL", "/bin/pwd")],
     );
     let checkout = workspace

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -146,7 +146,7 @@ fn bundle_start_can_enter_created_worktree() {
         &[("SHELL", "/bin/pwd")],
     );
     let checkout = workspace
-        .join(".knit/worktrees/project-feature/backend")
+        .join(".knit/worktrees/project-feature")
         .canonicalize()
         .unwrap();
     assert!(output.contains("Entering:"));


### PR DESCRIPTION
Generated by Knit. Cross-links will be refreshed after all review objects are created.

<!-- BEGIN KNIT BUNDLE -->
## Knit Bundle

This PR is part of Knit bundle `bundle-start-enter-option`.

See the other review objects in this bundle:
- `knit`: https://github.com/marc-merino/knit/pull/27 (this PR)

Bundle id: `bundle-start-enter-option`
Bundle title: bundle start enter option
<!-- END KNIT BUNDLE -->