### PR TITLE
sync remote status after landing (knit)

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,8 +157,9 @@ knit publish github <create|sync|status> ...   # back-compat alias
 knit land
 knit land plan [--provider github|gitlab|forgejo] [--out <path>] [--force]
 knit land update [--push] [--continue-merge] [repo-id-or-path...]
-knit land apply [--plan <path>]
-knit land resume [--run <path>]
+knit land apply [--plan <path>] [--remote <remote>] [--no-remote]
+knit land resume [--run <path>] [--remote <remote>] [--no-remote]
+knit land sync [--remote <remote>]
 knit land status [--run <path>]
 knit merge <source-bundle-or-ref> --into <target-branch-or-bundle> [--fetch] [--push] [--set-upstream] [--manual]
 knit merge status [--run <id-or-path>]
@@ -487,7 +488,7 @@ Bare `knit land` is safe: it creates or shows the default plan and stops. It nev
 
 `knit land update` prepares published PR branches for landing by fetching each PR's base branch, merging that base into the feature checkout, and recording the movement as a first-class `land.update` bundle node. This is the preferred way to resolve routine "base moved" landing conflicts because the integration merge is attributed to landing prep instead of appearing later as an incidental `git.observed` movement. Pass `--push` to push the updated feature branches after recording the node. If a merge conflicts, resolve and commit it in the feature checkout, then run `knit land update --continue-merge` to record the already-resolved movement as `land.update`.
 
-`knit land apply` preflights referenced PRs, refuses draft/closed/missing PRs, writes a durable run file under `.knit/land-runs/`, then executes the plan step by step. `deploy` steps support `deploymentMode: "command"` for real deployment commands and `deploymentMode: "push"` for deployments that are triggered by the PR merge itself. A command deployment can specify a `checkout` branch; Knit creates or refreshes a managed detached checkout under `.knit/land-worktrees/` before running the command. If a step fails, the run stops and records the exact step status, stdout/stderr for `run` and command `deploy` steps, and failure detail. `knit land resume` continues that run from pending or failed steps only; succeeded steps are not repeated. A fully successful run appends a `feature.landed` node to the bundle with the plan id, run id, provider, repo ids, and publication URLs.
+`knit land apply` preflights referenced PRs, refuses draft/closed/missing PRs, writes a durable run file under `.knit/land-runs/`, then executes the plan step by step. `deploy` steps support `deploymentMode: "command"` for real deployment commands and `deploymentMode: "push"` for deployments that are triggered by the PR merge itself. A command deployment can specify a `checkout` branch; Knit creates or refreshes a managed detached checkout under `.knit/land-worktrees/` before running the command. If a step fails, the run stops and records the exact step status, stdout/stderr for `run` and command `deploy` steps, and failure detail. `knit land resume` continues that run from pending or failed steps only; succeeded steps are not repeated. A fully successful run appends a `feature.landed` node to the bundle with the plan id, run id, provider, repo ids, and publication URLs, then syncs the updated bundle artifact to the configured KnitHub remote when push-sync is enabled. Use `--remote <name>` to force a remote, `--no-remote` to skip this sync, or `knit land sync` to push the landed artifact later.
 
 `knit merge` is for local branch integration that is not a PR landing. It can merge a bundle or git ref into a target branch, or into another bundle's feature branches:
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1057,12 +1057,30 @@ pub enum LandCommand {
         /// When omitted, the updated artifact is printed to stdout.
         #[arg(long)]
         out: Option<PathBuf>,
+        /// Also push the landed bundle artifact to this KnitHub remote. Overrides the push-sync config.
+        #[arg(long, value_name = "REMOTE")]
+        remote: Option<String>,
+        /// Skip the KnitHub bundle sync after landing.
+        #[arg(long, conflicts_with = "remote")]
+        no_remote: bool,
     },
     /// Resume a failed or incomplete landing run.
     Resume {
         /// Run file to resume. Defaults to the latest run.
         #[arg(long)]
         run: Option<PathBuf>,
+        /// Also push the landed bundle artifact to this KnitHub remote. Overrides the push-sync config.
+        #[arg(long, value_name = "REMOTE")]
+        remote: Option<String>,
+        /// Skip the KnitHub bundle sync after landing.
+        #[arg(long, conflicts_with = "remote")]
+        no_remote: bool,
+    },
+    /// Push the current landed bundle artifact to a KnitHub remote.
+    Sync {
+        /// Named KnitHub remote. Defaults to sync_remote or `knithub`.
+        #[arg(long, value_name = "REMOTE")]
+        remote: Option<String>,
     },
     /// Show the latest landing run or default plan status.
     Status {

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -295,6 +295,7 @@ Inspect or edit the plan, then execute it explicitly:
 ```sh
 knit land apply
 knit land status
+knit land sync
 ```
 
 Land from a bundle artifact JSON (merge-only, no local workspace):
@@ -303,7 +304,7 @@ Land from a bundle artifact JSON (merge-only, no local workspace):
 knit land apply --from-artifact bundle.published.json --out bundle.landed.json
 ```
 
-Bare `knit land` creates or shows the default plan and stops. It never merges PRs, deploys, waits, or runs plan commands. `knit land apply` executes the plan and lands each recorded PR into its GitHub PR base branch, then executes any generated or edited deployment steps. Project JSON can define a default `landing` template with merge priority and deployments, while `.knit/land-plans/<bundle>.land.json` remains the editable per-bundle plan. A PR with no required checks has passed Knit’s required-check gate. Do not use `gh pr merge` for Knit-owned bundles. Do not use `knit merge --into main` as a substitute for PR landing unless the user explicitly asks for direct branch integration instead of PR landing.
+Bare `knit land` creates or shows the default plan and stops. It never merges PRs, deploys, waits, or runs plan commands. `knit land apply` executes the plan and lands each recorded PR into its GitHub PR base branch, then executes any generated or edited deployment steps. When push-sync is enabled, a successful land also syncs the updated bundle artifact to the configured KnitHub remote; use `knit land sync` to push the landed artifact later. Project JSON can define a default `landing` template with merge priority and deployments, while `.knit/land-plans/<bundle>.land.json` remains the editable per-bundle plan. A PR with no required checks has passed Knit’s required-check gate. Do not use `gh pr merge` for Knit-owned bundles. Do not use `knit merge --into main` as a substitute for PR landing unless the user explicitly asks for direct branch integration instead of PR landing.
 
 Use `knit merge` for local integration into staging branches or compatibility bundles:
 
@@ -355,6 +356,7 @@ knit cherrypick --from feature-a --repo backend abc123
 - `knit merge status` and `knit merge show` inspect recorded merge runs.
 - `knit merge <bundle> --into <branch-or-bundle> --manual` leaves conflicts for manual resolution, followed by `knit merge --continue` or `knit merge --abort`.
 - `knit land` creates or shows the landing plan; `knit land apply` executes it.
+- `knit land sync` pushes the current landed bundle artifact to the configured KnitHub remote.
 - `knit doctor` checks workspace JSON, stale locks, and missing paths.
 - `knit migrate --check` reports additive JSON migrations; `knit migrate` applies them.
 - `knit config set advice false` disables sparse `Next:` advice.

--- a/src/commands/land/mod.rs
+++ b/src/commands/land/mod.rs
@@ -318,7 +318,11 @@ pub fn land_default() -> Result<()> {
     generate_land_plan(None, None, false)
 }
 
-pub fn apply_land_plan(plan_path: Option<&Path>) -> Result<()> {
+pub fn apply_land_plan(
+    plan_path: Option<&Path>,
+    remote: Option<&str>,
+    no_remote: bool,
+) -> Result<()> {
     let mut active = load_active_bundle_for_update()?;
     let path = resolve_land_plan_path(&active, plan_path)?;
     if !path.exists() {
@@ -339,10 +343,16 @@ pub fn apply_land_plan(plan_path: Option<&Path>) -> Result<()> {
     }
     let mut run = execute::new_run(&active, &plan, &path);
     write_json(&run_path, &run)?;
-    execute::execute_run(&mut active, &plan, &order, &mut run, &run_path)
+    execute::execute_run(&mut active, &plan, &order, &mut run, &run_path)?;
+    crate::commands::remote::sync_bundle_to_remote_if_enabled(remote, no_remote)?;
+    Ok(())
 }
 
-pub fn resume_land_run(run_path: Option<&Path>) -> Result<()> {
+pub fn resume_land_run(
+    run_path: Option<&Path>,
+    remote: Option<&str>,
+    no_remote: bool,
+) -> Result<()> {
     let mut active = load_active_bundle_for_update()?;
     let path = resolve_land_run_path(&active, run_path)?
         .with_context(|| "No land run found. Run `knit land apply` first.")?;
@@ -363,7 +373,21 @@ pub fn resume_land_run(run_path: Option<&Path>) -> Result<()> {
     run.status = STATUS_RUNNING.to_string();
     run.updated_at = now_iso();
     write_json(&path, &run)?;
-    execute::execute_run(&mut active, &plan, &order, &mut run, &path)
+    execute::execute_run(&mut active, &plan, &order, &mut run, &path)?;
+    crate::commands::remote::sync_bundle_to_remote_if_enabled(remote, no_remote)?;
+    Ok(())
+}
+
+pub fn sync_landed_bundle(remote: Option<&str>) -> Result<()> {
+    let active = load_active_bundle()?;
+    if crate::commands::bundle::bundle_state(&active.bundle) != "landed" {
+        bail!(
+            "Bundle {} is not landed yet. Run `knit land apply` first.",
+            active.bundle.id
+        );
+    }
+    drop(active);
+    crate::commands::remote::sync_bundle_to_remote(remote)
 }
 
 pub fn show_land_status(run_path: Option<&Path>) -> Result<()> {

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -50,7 +50,7 @@ pub use git_passthrough::run_git;
 pub use init::{init_bundle, start_bundle};
 pub use land::{
     apply_land_from_artifact, apply_land_plan, generate_land_plan, land_default, resume_land_run,
-    show_land_status,
+    show_land_status, sync_landed_bundle,
     update_land_branches,
 };
 pub use log::{show_log, show_target};

--- a/src/commands/remote/mod.rs
+++ b/src/commands/remote/mod.rs
@@ -19,7 +19,8 @@ pub use pull::{
 };
 pub use push::{
     add_remote, list_remotes, maybe_sync_bundle_to_remote, push_bundle_to_remote,
-    push_project_to_remote, remove_remote, set_remote_token, show_remote,
+    push_project_to_remote, remove_remote, set_remote_token, show_remote, sync_bundle_to_remote,
+    sync_bundle_to_remote_if_enabled,
 };
 
 use crate::model::KnitProject;

--- a/src/commands/remote/push.rs
+++ b/src/commands/remote/push.rs
@@ -210,6 +210,64 @@ pub fn maybe_sync_bundle_to_remote(remote_override: Option<&str>, no_remote: boo
     Ok(())
 }
 
+/// Push the resolved bundle artifact to KnitHub when push-sync is enabled.
+///
+/// Unlike `maybe_sync_bundle_to_remote`, sync failures are returned to the
+/// caller. This is used after landing so a stale remote lifecycle state is
+/// visible instead of being hidden behind a best-effort warning.
+pub fn sync_bundle_to_remote_if_enabled(
+    remote_override: Option<&str>,
+    no_remote: bool,
+) -> Result<()> {
+    if no_remote {
+        return Ok(());
+    }
+    let Ok((_, config)) = workspace_config() else {
+        return Ok(());
+    };
+    if !config.push_sync && remote_override.is_none() {
+        return Ok(());
+    }
+    let Some(remote_name) = remote_override
+        .map(slugify)
+        .or_else(|| config.sync_remote.clone())
+        .or_else(|| {
+            config
+                .remotes
+                .contains_key("knithub")
+                .then(|| "knithub".to_string())
+        })
+    else {
+        return Ok(());
+    };
+    if resolve_remote(&config, &remote_name).is_err() {
+        if remote_override.is_some() {
+            resolve_remote(&config, &remote_name)?;
+        }
+        return Ok(());
+    }
+
+    push_bundle_to_remote(&remote_name, None)
+}
+
+/// Push the resolved bundle artifact to KnitHub, failing if no remote is
+/// configured or if the sync cannot complete.
+pub fn sync_bundle_to_remote(remote_override: Option<&str>) -> Result<()> {
+    let (_, config) = workspace_config()?;
+    let remote_name = remote_override
+        .map(slugify)
+        .or_else(|| config.sync_remote.clone())
+        .or_else(|| {
+            config
+                .remotes
+                .contains_key("knithub")
+                .then(|| "knithub".to_string())
+        })
+        .context("No KnitHub remote configured. Run `knit remote add knithub <url>` first.")?;
+    resolve_remote(&config, &remote_name)?;
+    push_bundle_to_remote(&remote_name, None)
+}
+
 fn upsert_project(
     remote: &KnitRemote,
     token: &str,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -525,11 +525,18 @@ pub fn run(cli: Cli) -> Result<()> {
                 plan,
                 from_artifact,
                 out,
+                remote,
+                no_remote,
             }) => match from_artifact {
                 Some(path) => commands::apply_land_from_artifact(&path, out.as_deref()),
-                None => commands::apply_land_plan(plan.as_deref()),
+                None => commands::apply_land_plan(plan.as_deref(), remote.as_deref(), no_remote),
             },
-            Some(LandCommand::Resume { run }) => commands::resume_land_run(run.as_deref()),
+            Some(LandCommand::Resume {
+                run,
+                remote,
+                no_remote,
+            }) => commands::resume_land_run(run.as_deref(), remote.as_deref(), no_remote),
+            Some(LandCommand::Sync { remote }) => commands::sync_landed_bundle(remote.as_deref()),
             Some(LandCommand::Status { run }) => commands::show_land_status(run.as_deref()),
             Some(LandCommand::Update {
                 repos,

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -1978,7 +1978,12 @@ fn land_plan_and_apply_merges_recorded_publications_with_fake_gh() {
     assert!(existing_plan.contains("Land plan"));
     assert!(!fake_gh_dir.join("merge-order.txt").exists());
 
-    let apply = knit_with_fake_gh(&workspace, ["land", "apply"], &fake_bin, &fake_gh_dir);
+    let apply = knit_with_fake_gh(
+        &workspace,
+        ["land", "apply", "--no-remote"],
+        &fake_bin,
+        &fake_gh_dir,
+    );
     assert!(apply.contains("Feature landed"));
     // This plan sets no repoOrder, so merges share a wave and run in parallel;
     // their relative order is unspecified, so compare as a set.
@@ -2003,6 +2008,8 @@ fn land_plan_and_apply_merges_recorded_publications_with_fake_gh() {
     assert!(workspace.join(".knit/land-runs").exists());
     assert!(knit(&workspace, ["bundle", "validate"]).contains("Bundle valid"));
     assert!(knit(&workspace, ["log", "-1"]).contains("landed"));
+    let sync_error = knit_fails(&workspace, ["land", "sync"]);
+    assert!(sync_error.contains("No KnitHub remote configured"));
 
     let mut stale_bundle = read_bundle(&workspace);
     stale_bundle["publications"] = json!([]);


### PR DESCRIPTION
Generated by Knit. Cross-links will be refreshed after all review objects are created.

<!-- BEGIN KNIT BUNDLE -->
## Knit Bundle

This PR is part of Knit bundle `sync-remote-status-after-landing`.

See the other review objects in this bundle:
- `knit`: https://github.com/marc-merino/knit/pull/28 (this PR)

Bundle id: `sync-remote-status-after-landing`
Bundle title: sync remote status after landing
<!-- END KNIT BUNDLE -->