### PR TITLE
land check readiness (knit)

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,10 +152,11 @@ knit run [--repo <repo>] [--all] -- <command> [args...]
 knit run --list
 knit publish create [--base <branch>|--base <repo=branch>] [--draft] [--sync|--no-sync] [--set-upstream] [--remote <name>] [--no-remote] [repo-id-or-path...]
 knit publish sync [repo-id-or-path...]
-knit publish status [repo-id-or-path...]
+knit publish status [--live] [repo-id-or-path...]
 knit publish github <create|sync|status> ...   # back-compat alias
 knit land
 knit land plan [--provider github|gitlab|forgejo] [--out <path>] [--force]
+knit land check
 knit land update [--push] [--continue-merge] [repo-id-or-path...]
 knit land apply [--plan <path>] [--remote <remote>] [--no-remote]
 knit land resume [--run <path>] [--remote <remote>] [--no-remote]
@@ -478,11 +479,14 @@ Do not merge the host review objects directly (for example `gh pr merge`) for Kn
 
 ```sh
 knit land plan
+knit land check
 knit land update --push
 knit land apply
 knit land status
 knit land resume
 ```
+
+`knit land check` is a read-only preflight: it fetches each recorded PR once and prints a readiness table (state, mergeable, checks, review decision, and a verdict) so you can see whether `knit land apply` will succeed and why not. A `conflict` verdict points you at `knit land update`; an already-merged PR shows `already landed`. `knit publish status --live` shows the same live columns alongside the recorded review objects. Both are non-mutating.
 
 `knit land plan` writes an editable JSON plan to `.knit/land-plans/<bundle-id>.land.json`. Without a project landing template, the default plan is linear in bundle repo order, merges each recorded GitHub PR into that PR's GitHub base branch with `merge`, waits for required checks, and does not delete feature branches. With a project landing template, Knit uses the configured merge priority, merge defaults, and deployment list. In Knit, a PR with no required checks has passed the required-check gate. You can edit the generated bundle plan to change merge order, use `squash` or `rebase`, insert `wait_checks` steps, insert local `run` steps, or tune typed `deploy` steps before applying.
 
@@ -490,7 +494,7 @@ Bare `knit land` is safe: it creates or shows the default plan and stops. It nev
 
 `knit land update` prepares published PR branches for landing by fetching each PR's base branch, merging that base into the feature checkout, and recording the movement as a first-class `land.update` bundle node. This is the preferred way to resolve routine "base moved" landing conflicts because the integration merge is attributed to landing prep instead of appearing later as an incidental `git.observed` movement. Pass `--push` to push the updated feature branches after recording the node. If a merge conflicts, resolve and commit it in the feature checkout, then run `knit land update --continue-merge` to record the already-resolved movement as `land.update`.
 
-`knit land apply` preflights referenced PRs, refuses draft/closed/missing PRs, writes a durable run file under `.knit/land-runs/`, then executes the plan step by step. `deploy` steps support `deploymentMode: "command"` for real deployment commands and `deploymentMode: "push"` for deployments that are triggered by the PR merge itself. A command deployment can specify a `checkout` branch; Knit creates or refreshes a managed detached checkout under `.knit/land-worktrees/` before running the command. If a step fails, the run stops and records the exact step status, stdout/stderr for `run` and command `deploy` steps, and failure detail. `knit land resume` continues that run from pending or failed steps only; succeeded steps are not repeated. A fully successful run appends a `feature.landed` node to the bundle with the plan id, run id, provider, repo ids, and publication URLs, then syncs the updated bundle artifact to the configured KnitHub remote when push-sync is enabled. Use `--remote <name>` to force a remote, `--no-remote` to skip this sync, or `knit land sync` to push the landed artifact later.
+`knit land apply` preflights referenced PRs, refuses draft/closed/missing PRs, writes a durable run file under `.knit/land-runs/`, then executes the plan step by step. Already-merged PRs are treated as satisfied and skipped (whether or not a prior run exists), and an open PR that conflicts with its base is rejected with guidance to run `knit land update` first. `deploy` steps support `deploymentMode: "command"` for real deployment commands and `deploymentMode: "push"` for deployments that are triggered by the PR merge itself. A command deployment can specify a `checkout` branch; Knit creates or refreshes a managed detached checkout under `.knit/land-worktrees/` before running the command. If a step fails, the run stops and records the exact step status, stdout/stderr for `run` and command `deploy` steps, and failure detail. `knit land resume` continues that run from pending or failed steps only; succeeded steps are not repeated. A fully successful run appends a `feature.landed` node to the bundle with the plan id, run id, provider, repo ids, and publication URLs, then syncs the updated bundle artifact to the configured KnitHub remote when push-sync is enabled. Use `--remote <name>` to force a remote, `--no-remote` to skip this sync, or `knit land sync` to push the landed artifact later.
 
 `knit merge` is for local branch integration that is not a PR landing. It can merge a bundle or git ref into a target branch, or into another bundle's feature branches:
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1026,6 +1026,9 @@ pub enum PublishCommand {
         /// Show every tracked repo. This is the default when no repos are passed.
         #[arg(long)]
         all: bool,
+        /// Fetch live mergeability, checks, and review state from the host.
+        #[arg(long)]
+        live: bool,
     },
     /// Publish to GitHub explicitly. Alias kept for back-compat; prefer `knit publish create`.
     Github {
@@ -1091,6 +1094,8 @@ pub enum LandCommand {
         #[arg(long)]
         run: Option<PathBuf>,
     },
+    /// Preflight each recorded PR's live landing readiness before applying.
+    Check,
     /// Merge current PR base branches into feature branches and record the integration.
     Update {
         /// Optional repo ids or paths to limit the update.
@@ -1168,5 +1173,8 @@ pub enum GithubPublishCommand {
         /// Show every tracked repo. This is the default when no repos are passed.
         #[arg(long)]
         all: bool,
+        /// Fetch live mergeability, checks, and review state from the host.
+        #[arg(long)]
+        live: bool,
     },
 }

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -359,10 +359,13 @@ knit land
 Inspect or edit the plan, then execute it explicitly:
 
 ```sh
+knit land check
 knit land apply
 knit land status
 knit land sync
 ```
+
+`knit land check` is a read-only preflight: it shows each recorded PR's live state, mergeability, checks, review decision, and a landing verdict, so you can tell whether `knit land apply` will succeed before running it. When it reports a `conflict`, run `knit land update` to merge the base in and resolve, then land again. `knit publish status --live` shows the same live columns.
 
 Land from a bundle artifact JSON (merge-only, no local workspace):
 
@@ -423,6 +426,7 @@ knit cherrypick --from feature-a --repo backend abc123
 - `knit merge status` and `knit merge show` inspect recorded merge runs.
 - `knit merge <bundle> --into <branch-or-bundle> --manual` leaves conflicts for manual resolution, followed by `knit merge --continue` or `knit merge --abort`.
 - `knit land` creates or shows the landing plan; `knit land apply` executes it.
+- `knit land check` previews each recorded PR's live landing readiness (state, mergeable, checks, review, verdict) without mutating anything; `knit publish status --live` shows the same columns.
 - `knit land sync` pushes the current landed bundle artifact to the configured KnitHub remote.
 - `knit doctor` checks workspace JSON, stale locks, and missing paths.
 - `knit migrate --check` reports additive JSON migrations; `knit migrate` applies them.

--- a/src/commands/land/check.rs
+++ b/src/commands/land/check.rs
@@ -1,0 +1,256 @@
+//! `knit land check` — a live landing-readiness preflight.
+//!
+//! For each recorded review publication it fetches the host PR once and reports
+//! state, mergeability, checks, review decision, and a verdict, so you can see
+//! whether `knit land apply` will succeed (and why not) before running it. The
+//! per-repo assessment is shared with `knit publish status --live`.
+
+use crate::checkout::checkout_dir;
+use crate::output as out;
+use crate::providers::{self, publication_for_repo, CheckRun, PrTarget};
+use crate::store::{load_active_bundle, ActiveBundle};
+use anyhow::{bail, Result};
+use std::path::PathBuf;
+
+/// Live landing readiness for one repo's review publication.
+pub(crate) struct LandReadiness {
+    pub repo_id: String,
+    pub number: u64,
+    pub state: String,
+    /// `clean`, `conflict`, `unknown`, or `-` for terminal states.
+    pub mergeable: String,
+    /// `passed`, `failed`, `pending`, `none`, or `-`.
+    pub checks: String,
+    /// `approved`, `changes`, `none`, or `-`.
+    pub review: String,
+    pub verdict: String,
+    /// True when the PR is not landable yet (so callers can color/aggregate).
+    pub blocked: bool,
+}
+
+pub fn check_landing() -> Result<()> {
+    let active = load_active_bundle()?;
+    if active.bundle.repos.is_empty() {
+        bail!("The resolved bundle has no repos. Run `knit bundle add <repo-path>` first.");
+    }
+
+    let publications: Vec<(usize, String)> = active
+        .bundle
+        .repos
+        .iter()
+        .enumerate()
+        .filter_map(|(index, repo)| {
+            publication_for_repo(&active.bundle, &repo.id)
+                .map(|publication| (index, publication.url.clone()))
+        })
+        .collect();
+
+    if publications.is_empty() {
+        println!(
+            "{}",
+            out::muted("No review publications recorded. Run `knit publish` first.")
+        );
+        return Ok(());
+    }
+
+    println!("Bundle: {}\n", out::heading(&active.bundle.id));
+    println!(
+        "{}  {}  {}  {}  {}  {}  {}",
+        out::header_field("repo", 16),
+        out::header_field("pr", 6),
+        out::header_field("state", 8),
+        out::header_field("mergeable", 10),
+        out::header_field("checks", 9),
+        out::header_field("review", 9),
+        out::heading("verdict")
+    );
+
+    let mut ready = 0usize;
+    let mut blocked = 0usize;
+    let mut landed = 0usize;
+    for (index, url) in &publications {
+        let readiness = assess_landing_readiness(&active, &active.bundle.repos[*index], url);
+        print_readiness_row(&readiness);
+        if readiness.state == "MERGED" {
+            landed += 1;
+        } else if readiness.blocked {
+            blocked += 1;
+        } else {
+            ready += 1;
+        }
+    }
+
+    println!();
+    println!(
+        "{} {ready} ready, {blocked} blocked, {landed} already landed",
+        out::heading("Readiness:")
+    );
+    if blocked == 0 {
+        println!(
+            "{} when ready, run `knit land` then `knit land apply`.",
+            out::heading("Next:")
+        );
+    }
+    Ok(())
+}
+
+/// Render one readiness row, coloring the verdict by landability.
+pub(crate) fn print_readiness_row(r: &LandReadiness) {
+    let verdict = if r.state == "MERGED" {
+        out::ok(&r.verdict)
+    } else if r.blocked {
+        out::warn(&r.verdict)
+    } else {
+        out::ok(&r.verdict)
+    };
+    println!(
+        "{}  {}  {}  {}  {}  {}  {}",
+        out::repo_field(&r.repo_id, 16),
+        out::sha(format!("{:<6}", format!("#{}", r.number))),
+        out::status(&format!("{:<8}", r.state.to_lowercase())),
+        format!("{:<10}", r.mergeable),
+        format!("{:<9}", r.checks),
+        format!("{:<9}", r.review),
+        verdict
+    );
+}
+
+/// Fetch a publication's live PR state and classify its landing readiness. Forge
+/// errors are captured into the verdict rather than aborting the whole table.
+pub(crate) fn assess_landing_readiness(
+    active: &ActiveBundle,
+    repo: &crate::model::RepoEntry,
+    publication_url: &str,
+) -> LandReadiness {
+    let base = LandReadiness {
+        repo_id: repo.id.clone(),
+        number: providers::pr_number_from_url(publication_url).unwrap_or(0),
+        state: "?".to_string(),
+        mergeable: "-".to_string(),
+        checks: "-".to_string(),
+        review: "-".to_string(),
+        verdict: String::new(),
+        blocked: true,
+    };
+
+    let forge = match providers::for_repo(repo) {
+        Ok(forge) => forge,
+        Err(error) => {
+            return LandReadiness {
+                verdict: format!("provider unavailable: {error}"),
+                ..base
+            }
+        }
+    };
+    let cwd = checkout_dir(active, repo).unwrap_or_else(|| PathBuf::from(&repo.path));
+    let target = PrTarget::checkout(&cwd);
+
+    let pr = match forge.view(&target, publication_url) {
+        Ok(pr) => pr,
+        Err(error) => {
+            return LandReadiness {
+                verdict: format!("PR unavailable: {error}"),
+                ..base
+            }
+        }
+    };
+    let state = pr.state.clone().unwrap_or_else(|| "UNKNOWN".to_string());
+
+    // Terminal states: nothing to assess.
+    match state.as_str() {
+        "MERGED" => {
+            return LandReadiness {
+                state,
+                verdict: "already landed".to_string(),
+                blocked: false,
+                ..base
+            }
+        }
+        "CLOSED" => {
+            return LandReadiness {
+                state,
+                verdict: "closed".to_string(),
+                ..base
+            }
+        }
+        _ => {}
+    }
+
+    if pr.is_draft.unwrap_or(false) {
+        return LandReadiness {
+            state,
+            verdict: "draft".to_string(),
+            ..base
+        };
+    }
+
+    let mergeable = if pr.is_conflicting() {
+        "conflict"
+    } else if pr.mergeable.as_deref() == Some("MERGEABLE") {
+        "clean"
+    } else {
+        "unknown"
+    };
+    let review = match pr.review_decision.as_deref() {
+        Some("APPROVED") => "approved",
+        Some("CHANGES_REQUESTED") => "changes",
+        _ => "none",
+    };
+    let (checks, checks_outcome) = match forge.check_runs(&target, publication_url, true) {
+        Ok(runs) => checks_label(&runs),
+        Err(_) => ("unknown".to_string(), ChecksOutcome::Unknown),
+    };
+
+    let (verdict, blocked) = if pr.is_conflicting() {
+        ("conflict — run knit land update".to_string(), true)
+    } else if matches!(checks_outcome, ChecksOutcome::Failed) {
+        ("checks failing".to_string(), true)
+    } else if matches!(checks_outcome, ChecksOutcome::Pending) {
+        ("checks pending".to_string(), true)
+    } else if review == "changes" {
+        ("changes requested".to_string(), true)
+    } else {
+        ("ready".to_string(), false)
+    };
+
+    LandReadiness {
+        repo_id: repo.id.clone(),
+        number: pr.number,
+        state,
+        mergeable: mergeable.to_string(),
+        checks,
+        review: review.to_string(),
+        verdict,
+        blocked,
+    }
+}
+
+enum ChecksOutcome {
+    None,
+    Passed,
+    Pending,
+    Failed,
+    Unknown,
+}
+
+fn checks_label(runs: &[CheckRun]) -> (String, ChecksOutcome) {
+    if runs.is_empty() {
+        return ("none".to_string(), ChecksOutcome::None);
+    }
+    let failed = runs.iter().any(|run| {
+        matches!(run.bucket.as_deref(), Some("fail" | "cancel"))
+            || matches!(run.state.as_deref(), Some("FAILURE" | "CANCELLED"))
+    });
+    if failed {
+        return ("failed".to_string(), ChecksOutcome::Failed);
+    }
+    let pending = runs.iter().any(|run| {
+        !matches!(run.bucket.as_deref(), Some("pass" | "skipping"))
+            && !matches!(run.state.as_deref(), Some("SUCCESS" | "SKIPPED"))
+    });
+    if pending {
+        ("pending".to_string(), ChecksOutcome::Pending)
+    } else {
+        ("passed".to_string(), ChecksOutcome::Passed)
+    }
+}

--- a/src/commands/land/mod.rs
+++ b/src/commands/land/mod.rs
@@ -5,16 +5,21 @@
 //! lifting lives in focused submodules:
 //!
 //! - [`plan`] builds the default plan from the bundle and project landing template
+//! - [`check`] live landing-readiness preflight (`knit land check`)
 //! - [`validate`] validates a plan and preflights its PRs
 //! - [`execute`] schedules and runs the plan, recording progress
 //! - [`update`] implements `knit land update` (merge base into feature branches)
 //! - [`display`] renders plans, run status, and PR/check state
 
+mod check;
 mod display;
 mod execute;
 mod plan;
 mod update;
 mod validate;
+
+pub use check::check_landing;
+pub(crate) use check::{assess_landing_readiness, print_readiness_row};
 
 use crate::advice;
 use crate::checkout::{checkout_dir, ensure_expected_branch};
@@ -517,7 +522,15 @@ fn ensure_open_and_ready(repo_id: &str, pr: &PullRequest) -> Result<()> {
         bail!("{repo_id}: PR #{} is a draft.", pr.number);
     }
     match pr.state.as_deref().unwrap_or("UNKNOWN") {
-        "OPEN" => Ok(()),
+        "OPEN" => {
+            if pr.is_conflicting() {
+                bail!(
+                    "{repo_id}: PR #{} has merge conflicts with its base branch. Run `knit land update` to merge the base in and resolve them, then land again.",
+                    pr.number
+                );
+            }
+            Ok(())
+        }
         state => bail!("{repo_id}: PR #{} is {state}, expected OPEN.", pr.number),
     }
 }

--- a/src/commands/land/validate.rs
+++ b/src/commands/land/validate.rs
@@ -139,7 +139,9 @@ pub(super) fn preflight_publications(
         let publication = publication_for_repo(&active.bundle, repo_id)
             .with_context(|| format!("{repo_id}: missing review publication"))?;
         let pr = forge.view(&target, &publication.url)?;
-        if state_is_merged(&pr) && run.is_some() {
+        // An already-merged PR is a satisfied step regardless of whether a prior
+        // run exists; the executor and the from-artifact path both skip it.
+        if state_is_merged(&pr) {
             continue;
         }
         ensure_open_and_ready(repo_id, &pr)?;

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -49,9 +49,8 @@ pub use fetch::fetch_repos;
 pub use git_passthrough::run_git;
 pub use init::{init_bundle, start_bundle};
 pub use land::{
-    apply_land_from_artifact, apply_land_plan, generate_land_plan, land_default, resume_land_run,
-    show_land_status, sync_landed_bundle,
-    update_land_branches,
+    apply_land_from_artifact, apply_land_plan, check_landing, generate_land_plan, land_default,
+    resume_land_run, show_land_status, sync_landed_bundle, update_land_branches,
 };
 pub use log::{show_log, show_target};
 pub use merge::{create_compat_bundle, merge_command};

--- a/src/commands/publish/mod.rs
+++ b/src/commands/publish/mod.rs
@@ -179,7 +179,7 @@ pub fn sync_publications_from_artifact(
     Ok(())
 }
 
-pub fn show_publication_status(selectors: &[String], all: bool) -> Result<()> {
+pub fn show_publication_status(selectors: &[String], all: bool, live: bool) -> Result<()> {
     let active = load_active_bundle()?;
     if active.bundle.repos.is_empty() {
         bail!("The resolved bundle has no repos. Run `knit bundle add <repo-path>` first.");
@@ -187,6 +187,38 @@ pub fn show_publication_status(selectors: &[String], all: bool) -> Result<()> {
 
     let indexes = resolve_repo_indexes(&active, selectors, all)?;
     println!("Bundle: {}\n", out::heading(&active.bundle.id));
+
+    if live {
+        // Fetch live state from the host and report landing-readiness columns.
+        println!(
+            "{}  {}  {}  {}  {}  {}  {}",
+            out::header_field("repo", 16),
+            out::header_field("pr", 6),
+            out::header_field("state", 8),
+            out::header_field("mergeable", 10),
+            out::header_field("checks", 9),
+            out::header_field("review", 9),
+            out::heading("verdict")
+        );
+        for index in indexes {
+            let repo = &active.bundle.repos[index];
+            match publication_for_repo(&active.bundle, &repo.id) {
+                Some(pr) => {
+                    let readiness =
+                        crate::commands::land::assess_landing_readiness(&active, repo, &pr.url);
+                    crate::commands::land::print_readiness_row(&readiness);
+                }
+                None => println!(
+                    "{}  {}",
+                    out::repo_field(&repo.id, 16),
+                    out::muted("(no PR)")
+                ),
+            }
+        }
+        print_landing_advice(&active);
+        return Ok(());
+    }
+
     println!(
         "{}  {}  {}  {}",
         out::header_field("repo", 14),
@@ -425,6 +457,9 @@ fn create_or_reuse_pr(
         body: None,
         is_draft: None,
         head_ref_oid: None,
+        mergeable: None,
+        merge_state_status: None,
+        review_decision: None,
     });
     providers::upsert_publication(&mut active.bundle, repo, forge.as_ref(), &summary);
 
@@ -504,6 +539,9 @@ fn create_or_reuse_pr_from_artifact(
         body: None,
         is_draft: None,
         head_ref_oid: None,
+        mergeable: None,
+        merge_state_status: None,
+        review_decision: None,
     });
     providers::upsert_publication(bundle, repo, forge.as_ref(), &summary);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -463,8 +463,8 @@ pub fn run(cli: Cli) -> Result<()> {
                 }
                 None => commands::sync_publications(&repos, all),
             },
-            PublishCommand::Status { repos, all } => {
-                commands::show_publication_status(&repos, all)
+            PublishCommand::Status { repos, all, live } => {
+                commands::show_publication_status(&repos, all, live)
             }
             PublishCommand::Github { command } => match command {
                 GithubPublishCommand::Create {
@@ -511,8 +511,8 @@ pub fn run(cli: Cli) -> Result<()> {
                     }
                     None => commands::sync_publications(&repos, all),
                 },
-                GithubPublishCommand::Status { repos, all } => {
-                    commands::show_publication_status(&repos, all)
+                GithubPublishCommand::Status { repos, all, live } => {
+                    commands::show_publication_status(&repos, all, live)
                 }
             },
         },
@@ -540,6 +540,7 @@ pub fn run(cli: Cli) -> Result<()> {
             }) => commands::resume_land_run(run.as_deref(), remote.as_deref(), no_remote),
             Some(LandCommand::Sync { remote }) => commands::sync_landed_bundle(remote.as_deref()),
             Some(LandCommand::Status { run }) => commands::show_land_status(run.as_deref()),
+            Some(LandCommand::Check) => commands::check_landing(),
             Some(LandCommand::Update {
                 repos,
                 all,

--- a/src/providers/forgejo.rs
+++ b/src/providers/forgejo.rs
@@ -198,6 +198,9 @@ fn into_pull_request(pr: TeaPr) -> PullRequest {
         body: None,
         is_draft: Some(false),
         head_ref_oid: None,
+        mergeable: None,
+        merge_state_status: None,
+        review_decision: None,
     }
 }
 

--- a/src/providers/github.rs
+++ b/src/providers/github.rs
@@ -7,7 +7,7 @@ use std::ffi::OsString;
 
 const CLI: &str = "gh";
 const PR_JSON_FIELDS: &str =
-    "number,url,state,title,baseRefName,headRefName,body,isDraft,headRefOid";
+    "number,url,state,title,baseRefName,headRefName,body,isDraft,headRefOid,mergeable,mergeStateStatus,reviewDecision";
 
 /// GitHub forge adapter, backed by the `gh` CLI.
 pub struct GitHub;

--- a/src/providers/gitlab.rs
+++ b/src/providers/gitlab.rs
@@ -240,6 +240,9 @@ fn into_pull_request(mr: GlabMr) -> PullRequest {
         body: mr.description,
         is_draft: Some(draft),
         head_ref_oid: mr.sha,
+        mergeable: None,
+        merge_state_status: None,
+        review_decision: None,
     }
 }
 

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -40,6 +40,23 @@ pub struct PullRequest {
     pub is_draft: Option<bool>,
     #[serde(default)]
     pub head_ref_oid: Option<String>,
+    /// Mergeability as reported by the host: `MERGEABLE`, `CONFLICTING`, `UNKNOWN`.
+    #[serde(default)]
+    pub mergeable: Option<String>,
+    /// Finer merge-state hint (`CLEAN`, `DIRTY`, `BLOCKED`, `BEHIND`, ...). GitHub only.
+    #[serde(default)]
+    pub merge_state_status: Option<String>,
+    /// Review decision: `APPROVED`, `CHANGES_REQUESTED`, `REVIEW_REQUIRED`, or empty.
+    #[serde(default)]
+    pub review_decision: Option<String>,
+}
+
+impl PullRequest {
+    /// True when the host reports the PR conflicts with its base branch.
+    pub fn is_conflicting(&self) -> bool {
+        self.mergeable.as_deref() == Some("CONFLICTING")
+            || self.merge_state_status.as_deref() == Some("DIRTY")
+    }
 }
 
 /// A single status/check result for a review object.

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -2109,6 +2109,116 @@ fn land_plan_and_apply_merges_recorded_publications_with_fake_gh() {
     fs::remove_dir_all(root).unwrap();
 }
 
+/// Create a two-repo bundle and publish its PRs through the fake `gh`, returning
+/// the workspace plus the fake-gh paths so tests can toggle PR state via markers.
+fn publish_two_repo_bundle(root: &Path) -> (PathBuf, PathBuf, PathBuf) {
+    let (_backend_remote, backend, _backend_collaborator) = init_remote_repo(root, "backend");
+    let (_frontend_remote, frontend, _frontend_collaborator) = init_remote_repo(root, "frontend");
+    let workspace = root.join("workspace");
+    fs::create_dir_all(&workspace).unwrap();
+
+    knit(&workspace, ["init", "venue capacity"]);
+    knit(
+        &workspace,
+        ["track", backend.to_str().unwrap(), frontend.to_str().unwrap()],
+    );
+    append_line(
+        &workspace.join(".knit/worktrees/venue-capacity/backend/app.txt"),
+        "backend land",
+    );
+    append_line(
+        &workspace.join(".knit/worktrees/venue-capacity/frontend/app.txt"),
+        "frontend land",
+    );
+    knit(&workspace, ["commit", "--stage", "-m", "Landing change"]);
+
+    let fake_gh_dir = root.join("fake-gh");
+    let fake_bin = root.join("fake-bin");
+    write_fake_gh(&fake_bin, &fake_gh_dir);
+    knit_with_fake_gh(
+        &workspace,
+        ["publish", "github", "create", "--no-sync"],
+        &fake_bin,
+        &fake_gh_dir,
+    );
+    (workspace, fake_bin, fake_gh_dir)
+}
+
+#[test]
+fn land_apply_skips_already_merged_pr() {
+    let root = unique_temp_dir();
+    let (workspace, fake_bin, fake_gh_dir) = publish_two_repo_bundle(&root);
+    knit_with_fake_gh(&workspace, ["land"], &fake_bin, &fake_gh_dir);
+
+    // backend is already merged with no prior run recorded; a fresh land apply
+    // must treat it as a satisfied step, not bail with "expected OPEN".
+    fs::write(fake_gh_dir.join("merged-backend"), "").unwrap();
+    let apply = knit_with_fake_gh(
+        &workspace,
+        ["land", "apply", "--no-remote"],
+        &fake_bin,
+        &fake_gh_dir,
+    );
+    assert!(apply.contains("Feature landed"), "{apply}");
+    // Only frontend should be merged; backend was skipped as already merged.
+    let order = fs::read_to_string(fake_gh_dir.join("merge-order.txt")).unwrap();
+    assert_eq!(order.lines().collect::<Vec<_>>(), vec!["frontend"], "{order}");
+
+    fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
+fn land_check_reports_pr_readiness() {
+    let root = unique_temp_dir();
+    let (workspace, fake_bin, fake_gh_dir) = publish_two_repo_bundle(&root);
+
+    // Both PRs open, clean, no required checks -> ready.
+    let check = knit_with_fake_gh(&workspace, ["land", "check"], &fake_bin, &fake_gh_dir);
+    assert!(check.contains("Readiness:"), "{check}");
+    assert!(check.contains("backend"), "{check}");
+    assert!(check.contains("frontend"), "{check}");
+    assert!(check.contains("ready"), "{check}");
+
+    // backend merged, frontend conflicting -> distinct verdicts + update hint.
+    fs::write(fake_gh_dir.join("merged-backend"), "").unwrap();
+    fs::write(fake_gh_dir.join("conflict-frontend"), "").unwrap();
+    let check2 = knit_with_fake_gh(&workspace, ["land", "check"], &fake_bin, &fake_gh_dir);
+    assert!(check2.contains("already landed"), "{check2}");
+    assert!(check2.contains("conflict"), "{check2}");
+    assert!(check2.contains("knit land update"), "{check2}");
+
+    // `publish status --live` surfaces the same readiness columns.
+    let live = knit_with_fake_gh(
+        &workspace,
+        ["publish", "status", "--live"],
+        &fake_bin,
+        &fake_gh_dir,
+    );
+    assert!(live.contains("verdict"), "{live}");
+    assert!(live.contains("conflict"), "{live}");
+
+    fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
+fn land_apply_conflict_points_to_land_update() {
+    let root = unique_temp_dir();
+    let (workspace, fake_bin, fake_gh_dir) = publish_two_repo_bundle(&root);
+    knit_with_fake_gh(&workspace, ["land"], &fake_bin, &fake_gh_dir);
+
+    fs::write(fake_gh_dir.join("conflict-backend"), "").unwrap();
+    let error = knit_fails_with_fake_gh(
+        &workspace,
+        ["land", "apply", "--no-remote"],
+        &fake_bin,
+        &fake_gh_dir,
+    );
+    assert!(error.contains("merge conflicts"), "{error}");
+    assert!(error.contains("knit land update"), "{error}");
+
+    fs::remove_dir_all(root).unwrap();
+}
+
 #[test]
 fn project_landing_template_orders_merges_and_runs_deploy_from_base_checkout() {
     let root = unique_temp_dir();
@@ -3566,7 +3676,14 @@ case "$sub" in
     if [ "${GH_FAKE_DRAFT:-0}" = "1" ]; then
       draft="true"
     fi
-    printf '{"number":%s,"url":"%s","state":"%s","title":"%s PR","baseRefName":"%s","headRefName":"knit/venue-capacity","body":"Existing body","isDraft":%s,"headRefOid":"%s-head"}\n' "$number" "$url" "$state" "$pr_repo" "$base" "$draft" "$pr_repo"
+    mergeable="MERGEABLE"
+    mergestate="CLEAN"
+    if [ -f "$GH_FAKE_DIR/conflict-$pr_repo" ]; then
+      mergeable="CONFLICTING"
+      mergestate="DIRTY"
+    fi
+    review="${GH_FAKE_REVIEW:-}"
+    printf '{"number":%s,"url":"%s","state":"%s","title":"%s PR","baseRefName":"%s","headRefName":"knit/venue-capacity","body":"Existing body","isDraft":%s,"headRefOid":"%s-head","mergeable":"%s","mergeStateStatus":"%s","reviewDecision":"%s"}\n' "$number" "$url" "$state" "$pr_repo" "$base" "$draft" "$pr_repo" "$mergeable" "$mergestate" "$review"
     ;;
   edit)
     url="$1"


### PR DESCRIPTION
Generated by Knit. Cross-links will be refreshed after all review objects are created.

<!-- BEGIN KNIT BUNDLE -->
## Knit Bundle

This PR is part of Knit bundle `land-check-readiness`.

See the other review objects in this bundle:
- `knit`: https://github.com/marc-merino/knit/pull/30 (this PR)

Bundle id: `land-check-readiness`
Bundle title: land check readiness
<!-- END KNIT BUNDLE -->