### PR TITLE
revert landed pr groups (knit)

### DIFF
--- a/README.md
+++ b/README.md
@@ -561,7 +561,7 @@ knit merge x-y-compat --into feature-y
 
 `knit show <target>` uses the same bundle log selectors as `knit revert`: `HEAD`, `HEAD~1`, full node ids, unique node id prefixes, commit group ids, and recorded git commit SHAs. Commit and revert group nodes show `git show --stat --oneline` for each repo commit. Observed git nodes show the branch movement and the relevant added or dropped commits when those commits are still available locally.
 
-`knit revert <target>` resolves bundle log selectors like `HEAD`, `HEAD~1`, full node ids, unique node id prefixes, and git commit SHAs shown in `knit log`. A commit SHA resolves to the latest bundle node that mentions that commit, so if a commit was later observed as dropped by a reset, reverting by that SHA restores it from the latest rewind node. By default it writes a checked revert plan under `.knit/revert-plans/` and prints the per-repo operations. `knit revert <target> --apply` requires that plan to exist, verifies each affected worktree is still clean and at the planned head, then creates one revert commit per affected repo and appends a `revert.group` node.
+`knit revert <target>` resolves bundle log selectors like `HEAD`, `HEAD~1`, full node ids, unique node id prefixes, and git commit SHAs shown in `knit log`. A commit SHA resolves to the latest bundle node that mentions that commit, so if a commit was later observed as dropped by a reset, reverting by that SHA restores it from the latest rewind node. By default it writes a checked revert plan under `.knit/revert-plans/` and prints the per-repo operations. `knit revert <target> --apply` requires that plan to exist. For local git entries, it verifies each affected worktree is still clean and at the planned head, then creates one revert commit per affected repo and appends a `revert.group` node. For a landed PR group, it verifies the recorded PRs are merged, runs the provider-native PR revert for each repo (`gh pr revert` for GitHub), records the newly opened revert PRs as the current publications, and appends a `pr.revert` node so the group can be landed through Knit.
 
 Revert behavior is based on the target node:
 
@@ -569,6 +569,7 @@ Revert behavior is based on the target node:
 - `git.observed` with `advanced`: revert the observed commits.
 - `git.observed` with `rewound`: cherry-pick the dropped commits back.
 - `git.observed` with `diverged`: revert added commits, then cherry-pick dropped commits.
+- `feature.landed`: create provider-native revert PRs for the landed PR group across repos.
 
 `knit git` passes arguments directly to git in tracked checkouts. With no repo selector it runs against every tracked repo:
 
@@ -624,6 +625,7 @@ Typical node types:
 - `git.observed`
 - `revert.group`
 - `feature.landed`
+- `pr.revert`
 - `land.update`
 - `repo.removed`
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -93,7 +93,7 @@ The bundle carries both current state and history:
 
 - `repos`: current tracked repos, checkout modes, branches, and checkout paths.
 - `commitGroups`: flat list of logical commits across repos.
-- `nodes`: ordered ledger entries such as `feature.created`, `feature.closed`, `feature.landed`, `repo.added`, `worktree.materialized`, `checkpoint`, `commit.group`, `git.observed`, `revert.group`, and `repo.removed`.
+- `nodes`: ordered ledger entries such as `feature.created`, `feature.closed`, `feature.landed`, `pr.revert`, `repo.added`, `worktree.materialized`, `checkpoint`, `commit.group`, `git.observed`, `revert.group`, and `repo.removed`.
 - `publications`: provider metadata for PRs or other forge review objects created or synced by Knit.
 - `headNodeId`: the latest node in the ledger.
 

--- a/docs/change-group-schema.md
+++ b/docs/change-group-schema.md
@@ -94,10 +94,11 @@ Current node types:
 - `land.update`
 - `revert.group`
 - `feature.landed`
+- `pr.revert`
 - `feature.closed`
 - `repo.removed`
 
-`commit.group` nodes include `commitGroupId`, `message`, `commits`, and `repoChanges`. `revert.group` nodes include the same fields plus `targetNodeId`, pointing at the bundle node that was reverted. `git.observed` nodes include `repoChanges`. `land.update` nodes include `provider` and `repoChanges` for feature-branch updates performed during landing preparation. Repo/worktree nodes include `repoIds`. `feature.landed` nodes include `planId`, `runId`, `provider`, `repoIds`, and `publicationUrls`. `feature.closed` nodes include an optional `reason`.
+`commit.group` nodes include `commitGroupId`, `message`, `commits`, and `repoChanges`. `revert.group` nodes include the same fields plus `targetNodeId`, pointing at the bundle node that was reverted. `git.observed` nodes include `repoChanges`. `land.update` nodes include `provider` and `repoChanges` for feature-branch updates performed during landing preparation. Repo/worktree nodes include `repoIds`. `feature.landed` nodes include `planId`, `runId`, `provider`, `repoIds`, and `publicationUrls`. `pr.revert` nodes include `targetNodeId`, `provider`, `repoIds`, and the newly created revert PR `publicationUrls`. `feature.closed` nodes include an optional `reason`.
 
 `repoChanges` records how a repo moved:
 
@@ -232,6 +233,6 @@ Knit ships JSON Schema files under `schemas/` and prints them with `knit schema 
 
 Project files can carry a reusable `landing` template with merge priority, merge defaults, and deployment entries. The generated land plan is still bundle-local and editable, so a one-off release can alter dependencies, commands, checkout branches, or deployment modes without changing the project default. `deploy` steps are structured: `deploymentMode: "command"` runs an argv command, while `deploymentMode: "push"` records a deployment triggered by the merge itself.
 
-`knit land apply` and `knit land resume` write run logs under `.knit/land-runs/`. Run files are operational logs, not the source of truth for code state. The bundle records only the final `feature.landed` summary node after every step succeeds.
+`knit land apply` and `knit land resume` write run logs under `.knit/land-runs/`. Run files are operational logs, not the source of truth for code state. The bundle records only the final `feature.landed` summary node after every step succeeds. A later `knit revert <feature.landed> --apply` can create provider-native revert PRs across the landed repos and records that follow-up review group as `pr.revert`.
 
 Gloss should treat the bundle as read-only input. Gloss can analyze the current `headNodeId`, a specific `commit.group` node, or the full current bundle.

--- a/docs/manual-test.md
+++ b/docs/manual-test.md
@@ -65,7 +65,7 @@ Expected result:
 - `knit commit` creates one commit in each staged checkout.
 - `knit log -1` shows one logical commit group with both repo SHAs, and the bundle has a `commit.group` node.
 - `knit show HEAD` shows the node details and git stats for the latest logical group.
-- `knit revert HEAD` writes a plan, and `knit revert HEAD --apply` creates one revert commit per affected repo plus a `revert.group` node.
+- `knit revert HEAD` writes a plan, and `knit revert HEAD --apply` creates one revert commit per affected repo plus a `revert.group` node. When `HEAD` is a `feature.landed` node, the plan uses provider-native PR reverts and records the newly opened cross-repo review group as `pr.revert`.
 
 To test a raw git commit outside Knit:
 

--- a/src/commands/bundle/mod.rs
+++ b/src/commands/bundle/mod.rs
@@ -834,6 +834,26 @@ fn validate_node(node: &BundleNode, node_ids: &mut BTreeSet<String>, errors: &mu
                 errors.push(format!("node `{}` must record publicationUrls", node.id));
             }
         }
+        "pr.revert" => {
+            if node
+                .target_node_id
+                .as_deref()
+                .unwrap_or("")
+                .trim()
+                .is_empty()
+            {
+                errors.push(format!("node `{}` must record targetNodeId", node.id));
+            }
+            if node.provider.as_deref().unwrap_or("").trim().is_empty() {
+                errors.push(format!("node `{}` must record provider", node.id));
+            }
+            if node.repo_ids.as_ref().is_none_or(Vec::is_empty) {
+                errors.push(format!("node `{}` must record repoIds", node.id));
+            }
+            if node.publication_urls.is_empty() {
+                errors.push(format!("node `{}` must record publicationUrls", node.id));
+            }
+        }
         "feature.closed" => {}
         _ => {}
     }

--- a/src/commands/log.rs
+++ b/src/commands/log.rs
@@ -229,6 +229,19 @@ fn print_node(node: &BundleNode) {
                 }
             }
         }
+        "pr.revert" => {
+            println!(
+                "{}  {}  {}",
+                out::node(&node.id),
+                out::movement("pr revert"),
+                node.provider.as_deref().unwrap_or("provider")
+            );
+            if let Some(repo_ids) = &node.repo_ids {
+                for repo_id in repo_ids {
+                    println!("  {}", out::repo(repo_id));
+                }
+            }
+        }
         "repo.removed" => {
             println!("{}  {}", out::node(&node.id), out::danger("removed repos"));
             if let Some(repo_ids) = &node.repo_ids {
@@ -267,7 +280,10 @@ fn show_node(active: &ActiveBundle, node: &BundleNode) -> Result<()> {
             }
             Ok(())
         }
-        "feature.landed" => {
+        "feature.landed" | "pr.revert" => {
+            if let Some(target_node_id) = &node.target_node_id {
+                println!("{} {}", out::heading("Reverts:"), out::node(target_node_id));
+            }
             if let Some(plan_id) = &node.plan_id {
                 println!("{} {}", out::heading("Plan:"), out::node(plan_id));
             }

--- a/src/commands/revert.rs
+++ b/src/commands/revert.rs
@@ -3,6 +3,7 @@ use crate::git::{git_output, rev_parse};
 use crate::ids::{revert_group_id, revert_plan_id, short_sha};
 use crate::model::{BundleNode, CommitGroup, CommitRef, RepoChange, SCHEMA_VERSION};
 use crate::output as out;
+use crate::providers::{self, pr_number_from_url, publication_for_repo, PrTarget, PullRequest};
 use crate::selectors::resolve_log_node;
 use crate::store::{
     load_active_bundle, load_active_bundle_for_update, read_json, save_active_bundle, write_json,
@@ -11,7 +12,7 @@ use crate::store::{
 use crate::time::now_iso;
 use anyhow::{bail, Context, Result};
 use serde::{Deserialize, Serialize};
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::ffi::OsString;
 use std::fs;
 use std::path::PathBuf;
@@ -19,6 +20,7 @@ use std::path::PathBuf;
 const REVERT_PLAN_KIND: &str = "KnitRevertPlan";
 const OP_REVERT: &str = "revert";
 const OP_CHERRY_PICK: &str = "cherryPick";
+const OP_PR_REVERT: &str = "prRevert";
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -27,6 +29,8 @@ struct RevertPlan {
     kind: String,
     id: String,
     bundle_id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    provider: Option<String>,
     target_ref: String,
     target_node_id: String,
     target_node_type: String,
@@ -40,7 +44,8 @@ struct RevertPlan {
 struct RepoRevertPlan {
     repo_id: String,
     worktree_path: String,
-    expected_head_sha: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    expected_head_sha: Option<String>,
     operations: Vec<RevertOperation>,
 }
 
@@ -48,7 +53,10 @@ struct RepoRevertPlan {
 #[serde(rename_all = "camelCase")]
 struct RevertOperation {
     kind: String,
-    sha: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    sha: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    selector: Option<String>,
 }
 
 pub fn revert_target(target: &str, apply: bool) -> Result<()> {
@@ -103,6 +111,14 @@ fn apply_revert(target: &str) -> Result<()> {
     }
 
     preflight_plan(&active, &plan)?;
+    if plan_uses_provider_revert(&plan) {
+        return apply_provider_revert(&mut active, &plan, path);
+    }
+
+    apply_local_revert(&mut active, &plan, path)
+}
+
+fn apply_local_revert(active: &mut ActiveBundle, plan: &RevertPlan, path: PathBuf) -> Result<()> {
     let group_id = revert_group_id();
     let created_at = now_iso();
     let logical_message = format!("Revert {}", plan.target_message);
@@ -114,7 +130,7 @@ fn apply_revert(target: &str) -> Result<()> {
     let mut repo_changes = Vec::new();
 
     for repo_plan in &plan.repos {
-        let (repo_index, worktree) = repo_context(&active, &repo_plan.repo_id)?;
+        let (repo_index, worktree) = repo_context(active, &repo_plan.repo_id)?;
         let before_sha = rev_parse(&worktree, "HEAD")
             .with_context(|| format!("{}: failed to read current HEAD", repo_plan.repo_id))?;
 
@@ -187,7 +203,7 @@ fn apply_revert(target: &str) -> Result<()> {
     ));
     active.bundle.head_node_id = active.bundle.nodes.last().map(|node| node.id.clone());
     active.bundle.updated_at = now_iso();
-    save_active_bundle(&active)?;
+    save_active_bundle(active)?;
     let _ = fs::remove_file(path);
 
     println!(
@@ -198,11 +214,118 @@ fn apply_revert(target: &str) -> Result<()> {
     Ok(())
 }
 
+fn apply_provider_revert(
+    active: &mut ActiveBundle,
+    plan: &RevertPlan,
+    path: PathBuf,
+) -> Result<()> {
+    let group_id = revert_group_id();
+    let created_at = now_iso();
+    let logical_message = format!("Revert {}", plan.target_message);
+    let mut repo_ids = BTreeSet::new();
+    let mut publication_urls = BTreeSet::new();
+    let mut failures = Vec::new();
+
+    for repo_plan in &plan.repos {
+        let (repo_index, target, forge) = provider_context(active, plan, &repo_plan.repo_id)?;
+        let repo = active.bundle.repos[repo_index].clone();
+
+        for operation in &repo_plan.operations {
+            let selector = match operation_selector(operation) {
+                Ok(selector) => selector,
+                Err(error) => {
+                    failures.push(format!("{}: {error:#}", repo_plan.repo_id));
+                    continue;
+                }
+            };
+            let title = format!("Revert {} ({})", active.bundle.title, repo_plan.repo_id);
+            let body = format!(
+                "Reverts {selector}\n\nKnit-Reverts: {}\nKnit-Group: {group_id}\nKnit-Bundle: {}",
+                plan.target_node_id, active.bundle.id
+            );
+            match forge.revert_pull_request(&target, selector, &title, &body) {
+                Ok(url) => {
+                    let summary = forge.view(&target, &url).unwrap_or_else(|_| PullRequest {
+                        number: pr_number_from_url(&url).unwrap_or(0),
+                        url: url.clone(),
+                        state: Some("OPEN".to_string()),
+                        title: Some(title.clone()),
+                        base_ref_name: Some(repo.base_branch.clone()),
+                        head_ref_name: None,
+                        body: None,
+                        is_draft: None,
+                        head_ref_oid: None,
+                        mergeable: None,
+                        merge_state_status: None,
+                        review_decision: None,
+                    });
+                    providers::upsert_publication(
+                        &mut active.bundle,
+                        &repo,
+                        forge.as_ref(),
+                        &summary,
+                    );
+                    repo_ids.insert(repo_plan.repo_id.clone());
+                    publication_urls.insert(summary.url.clone());
+                    println!(
+                        "{}: {} {}",
+                        out::repo(&repo_plan.repo_id),
+                        out::movement("revert PR"),
+                        summary.url
+                    );
+                }
+                Err(error) => failures.push(format!("{}: {error:#}", repo_plan.repo_id)),
+            }
+        }
+    }
+
+    if !failures.is_empty() {
+        save_active_bundle(active)?;
+        bail!(
+            "PR revert completed with failures:\n{}",
+            failures.join("\n")
+        );
+    }
+    if publication_urls.is_empty() {
+        bail!("PR revert produced no review objects.");
+    }
+
+    let provider = plan
+        .provider
+        .clone()
+        .unwrap_or_else(|| "provider".to_string());
+    active.bundle.nodes.push(BundleNode::pr_revert(
+        group_id.clone(),
+        created_at,
+        plan.target_node_id.clone(),
+        logical_message,
+        provider,
+        repo_ids.into_iter().collect(),
+        publication_urls.into_iter().collect(),
+    ));
+    active.bundle.head_node_id = active.bundle.nodes.last().map(|node| node.id.clone());
+    active.bundle.updated_at = now_iso();
+    save_active_bundle(active)?;
+    let _ = fs::remove_file(path);
+
+    println!(
+        "{} {}",
+        out::heading("Recorded PR revert group"),
+        out::node(group_id)
+    );
+    Ok(())
+}
+
 fn build_plan(active: &ActiveBundle, target: &str) -> Result<RevertPlan> {
     let target_node = resolve_log_node(&active.bundle.nodes, target)?;
+    let mut provider = None;
     let mut repos = match target_node.node_type.as_str() {
         "commit.group" | "revert.group" => plans_for_commits(active, &target_node.commits)?,
         "git.observed" | "land.update" => plans_for_observed(active, target_node)?,
+        "feature.landed" => {
+            provider = target_node.provider.clone();
+            plans_for_landed_prs(active, target_node)?
+        }
         "repo.removed" => bail!(
             "{} is a metadata node. Knit cannot safely restore a removed repo entry because bundle nodes do not yet store the full removed repo record.",
             target_node.id
@@ -220,6 +343,7 @@ fn build_plan(active: &ActiveBundle, target: &str) -> Result<RevertPlan> {
         kind: REVERT_PLAN_KIND.to_string(),
         id: revert_plan_id(),
         bundle_id: active.bundle.id.clone(),
+        provider,
         target_ref: target.to_string(),
         target_node_id: target_node.id.clone(),
         target_node_type: target_node.node_type.clone(),
@@ -246,7 +370,8 @@ fn plans_for_commits(active: &ActiveBundle, commits: &[CommitRef]) -> Result<Vec
                 .rev()
                 .map(|sha| RevertOperation {
                     kind: OP_REVERT.to_string(),
-                    sha,
+                    sha: Some(sha),
+                    selector: None,
                 })
                 .collect();
             repo_plan(active, &repo_id, operations)
@@ -263,23 +388,27 @@ fn plans_for_observed(active: &ActiveBundle, node: &BundleNode) -> Result<Vec<Re
                 "advanced" => {
                     operations.extend(change.commits.iter().rev().map(|sha| RevertOperation {
                         kind: OP_REVERT.to_string(),
-                        sha: sha.clone(),
+                        sha: Some(sha.clone()),
+                        selector: None,
                     }));
                 }
                 "rewound" => {
                     operations.extend(change.dropped_commits.iter().map(|sha| RevertOperation {
                         kind: OP_CHERRY_PICK.to_string(),
-                        sha: sha.clone(),
+                        sha: Some(sha.clone()),
+                        selector: None,
                     }));
                 }
                 "diverged" => {
                     operations.extend(change.commits.iter().rev().map(|sha| RevertOperation {
                         kind: OP_REVERT.to_string(),
-                        sha: sha.clone(),
+                        sha: Some(sha.clone()),
+                        selector: None,
                     }));
                     operations.extend(change.dropped_commits.iter().map(|sha| RevertOperation {
                         kind: OP_CHERRY_PICK.to_string(),
-                        sha: sha.clone(),
+                        sha: Some(sha.clone()),
+                        selector: None,
                     }));
                 }
                 movement => bail!(
@@ -288,6 +417,51 @@ fn plans_for_observed(active: &ActiveBundle, node: &BundleNode) -> Result<Vec<Re
                 ),
             }
             repo_plan(active, &change.repo_id, operations)
+        })
+        .collect()
+}
+
+fn plans_for_landed_prs(active: &ActiveBundle, node: &BundleNode) -> Result<Vec<RepoRevertPlan>> {
+    let repo_ids = node
+        .repo_ids
+        .as_ref()
+        .filter(|ids| !ids.is_empty())
+        .with_context(|| format!("landed node {} does not record repo ids", node.id))?;
+    let landed_urls = node
+        .publication_urls
+        .iter()
+        .map(String::as_str)
+        .collect::<BTreeSet<_>>();
+
+    repo_ids
+        .iter()
+        .map(|repo_id| {
+            let publication = publication_for_repo(&active.bundle, repo_id).with_context(|| {
+                format!(
+                    "{repo_id}: no current review publication recorded for landed node {}",
+                    node.id
+                )
+            })?;
+            if !landed_urls.is_empty() && !landed_urls.contains(publication.url.as_str()) {
+                bail!(
+                    "{}: current review publication {} is not one of the PRs recorded on landed node {}. Knit can only provider-revert the current landed PR group.",
+                    repo_id,
+                    publication.url,
+                    node.id
+                );
+            }
+            if let Some(provider) = &node.provider {
+                if publication.provider != *provider {
+                    bail!(
+                        "{}: landed node provider is {}, but publication {} uses {}.",
+                        repo_id,
+                        provider,
+                        publication.url,
+                        publication.provider
+                    );
+                }
+            }
+            pr_revert_repo_plan(active, repo_id, &publication.url)
         })
         .collect()
 }
@@ -313,21 +487,65 @@ fn repo_plan(
             .worktree_path
             .clone()
             .unwrap_or_else(|| worktree.display().to_string()),
-        expected_head_sha,
+        expected_head_sha: Some(expected_head_sha),
         operations,
+    })
+}
+
+fn pr_revert_repo_plan(
+    active: &ActiveBundle,
+    repo_id: &str,
+    selector: &str,
+) -> Result<RepoRevertPlan> {
+    let repo = active
+        .bundle
+        .repos
+        .iter()
+        .find(|repo| repo.id == repo_id)
+        .with_context(|| format!("{repo_id}: repo is no longer tracked in this bundle"))?;
+    let worktree_path = repo
+        .worktree_path
+        .clone()
+        .or_else(|| checkout_dir(active, repo).map(|path| path.display().to_string()))
+        .unwrap_or_else(|| repo.path.clone());
+
+    Ok(RepoRevertPlan {
+        repo_id: repo_id.to_string(),
+        worktree_path,
+        expected_head_sha: None,
+        operations: vec![RevertOperation {
+            kind: OP_PR_REVERT.to_string(),
+            sha: None,
+            selector: Some(selector.to_string()),
+        }],
     })
 }
 
 fn preflight_plan(active: &ActiveBundle, plan: &RevertPlan) -> Result<()> {
     for repo_plan in &plan.repos {
+        if repo_plan
+            .operations
+            .iter()
+            .any(|operation| operation.kind == OP_PR_REVERT)
+        {
+            preflight_provider_revert(active, plan, repo_plan)?;
+            continue;
+        }
+
         let (_, worktree) = repo_context(active, &repo_plan.repo_id)?;
         let current_head = rev_parse(&worktree, "HEAD")
             .with_context(|| format!("{}: failed to read current HEAD", repo_plan.repo_id))?;
-        if current_head != repo_plan.expected_head_sha {
+        let expected_head_sha = repo_plan.expected_head_sha.as_ref().with_context(|| {
+            format!(
+                "{}: revert plan is missing expectedHeadSha for local git operations",
+                repo_plan.repo_id
+            )
+        })?;
+        if current_head != expected_head_sha.as_str() {
             bail!(
                 "{}: HEAD changed since the revert plan was written (expected {}, found {}). Re-run `knit revert {}`.",
                 repo_plan.repo_id,
-                short_sha(&repo_plan.expected_head_sha),
+                short_sha(expected_head_sha),
                 short_sha(&current_head),
                 plan.target_ref
             );
@@ -353,38 +571,75 @@ fn verify_operation(worktree: &PathBuf, repo_id: &str, operation: &RevertOperati
     if !matches!(operation.kind.as_str(), OP_REVERT | OP_CHERRY_PICK) {
         bail!("{repo_id}: unknown revert operation `{}`.", operation.kind);
     }
+    let sha = operation_sha(operation)?;
 
     git_output(
         worktree,
         [
             OsString::from("rev-parse"),
             OsString::from("--verify"),
-            OsString::from(format!("{}^{{commit}}", operation.sha)),
+            OsString::from(format!("{sha}^{{commit}}")),
         ],
     )
     .with_context(|| {
         format!(
             "{repo_id}: commit {} is not available locally",
-            short_sha(&operation.sha)
+            short_sha(sha)
         )
     })?;
     Ok(())
 }
 
+fn preflight_provider_revert(
+    active: &ActiveBundle,
+    plan: &RevertPlan,
+    repo_plan: &RepoRevertPlan,
+) -> Result<()> {
+    if repo_plan
+        .operations
+        .iter()
+        .any(|operation| operation.kind != OP_PR_REVERT)
+    {
+        bail!(
+            "{}: provider PR revert operations cannot be mixed with local git operations.",
+            repo_plan.repo_id
+        );
+    }
+
+    let (_, target, forge) = provider_context(active, plan, &repo_plan.repo_id)?;
+    for operation in &repo_plan.operations {
+        let selector = operation_selector(operation)?;
+        let pr = forge
+            .view(&target, selector)
+            .with_context(|| format!("{}: failed to load {}", repo_plan.repo_id, selector))?;
+        if !pull_request_is_merged(&pr) {
+            bail!(
+                "{}: PR #{} is {}, expected MERGED before provider revert.",
+                repo_plan.repo_id,
+                pr.number,
+                pr.state.as_deref().unwrap_or("UNKNOWN")
+            );
+        }
+    }
+
+    Ok(())
+}
+
 fn apply_operation(worktree: &PathBuf, repo_id: &str, operation: &RevertOperation) -> Result<()> {
+    let sha = operation_sha(operation)?;
     match operation.kind.as_str() {
         OP_REVERT => git_output(
             worktree,
             [
                 OsString::from("revert"),
                 OsString::from("--no-commit"),
-                OsString::from(&operation.sha),
+                OsString::from(sha),
             ],
         )
         .with_context(|| {
             format!(
                 "{repo_id}: failed to revert {}. Resolve the git state manually before retrying.",
-                short_sha(&operation.sha)
+                short_sha(sha)
             )
         })?,
         OP_CHERRY_PICK => git_output(
@@ -392,19 +647,91 @@ fn apply_operation(worktree: &PathBuf, repo_id: &str, operation: &RevertOperatio
             [
                 OsString::from("cherry-pick"),
                 OsString::from("--no-commit"),
-                OsString::from(&operation.sha),
+                OsString::from(sha),
             ],
         )
         .with_context(|| {
             format!(
                 "{repo_id}: failed to cherry-pick {}. Resolve the git state manually before retrying.",
-                short_sha(&operation.sha)
+                short_sha(sha)
             )
         })?,
         kind => bail!("{repo_id}: unknown revert operation `{kind}`."),
     };
 
     Ok(())
+}
+
+fn operation_sha(operation: &RevertOperation) -> Result<&str> {
+    operation
+        .sha
+        .as_deref()
+        .with_context(|| format!("{} operation is missing sha", operation.kind))
+}
+
+fn operation_selector(operation: &RevertOperation) -> Result<&str> {
+    if operation.kind != OP_PR_REVERT {
+        bail!("{} operation is not a provider PR revert", operation.kind);
+    }
+    operation
+        .selector
+        .as_deref()
+        .with_context(|| "provider PR revert operation is missing selector")
+}
+
+fn plan_uses_provider_revert(plan: &RevertPlan) -> bool {
+    plan.repos.iter().any(|repo| {
+        repo.operations
+            .iter()
+            .any(|operation| operation.kind == OP_PR_REVERT)
+    })
+}
+
+fn provider_context(
+    active: &ActiveBundle,
+    plan: &RevertPlan,
+    repo_id: &str,
+) -> Result<(usize, PrTarget, Box<dyn providers::Forge>)> {
+    let (index, repo) = active
+        .bundle
+        .repos
+        .iter()
+        .enumerate()
+        .find(|(_, repo)| repo.id == repo_id)
+        .with_context(|| format!("{repo_id}: repo is no longer tracked in this bundle"))?;
+    let forge = match plan.provider.as_deref() {
+        Some(provider) => providers::by_id(provider)
+            .with_context(|| format!("{repo_id}: unknown provider `{provider}`"))?,
+        None => providers::for_repo(repo)?,
+    };
+    let target = provider_target(active, repo, forge.as_ref())?;
+
+    Ok((index, target, forge))
+}
+
+fn provider_target(
+    active: &ActiveBundle,
+    repo: &crate::model::RepoEntry,
+    forge: &dyn providers::Forge,
+) -> Result<PrTarget> {
+    if let Some(full_name) = repo
+        .remote
+        .as_deref()
+        .and_then(|remote| forge.repo_full_name(remote))
+    {
+        return Ok(PrTarget::explicit(active.root.clone(), full_name));
+    }
+    if let Some(cwd) = checkout_dir(active, repo) {
+        return Ok(PrTarget::checkout(cwd));
+    }
+    bail!(
+        "{}: no checkout or parseable remote is available for provider PR revert.",
+        repo.id
+    );
+}
+
+fn pull_request_is_merged(pr: &PullRequest) -> bool {
+    pr.state.as_deref() == Some("MERGED")
 }
 
 fn repo_context(active: &ActiveBundle, repo_id: &str) -> Result<(usize, PathBuf)> {
@@ -431,6 +758,8 @@ fn node_message(node: &BundleNode) -> String {
     match node.node_type.as_str() {
         "git.observed" => "observed git changes".to_string(),
         "land.update" => "feature branch update".to_string(),
+        "feature.landed" => "landed PR group".to_string(),
+        "pr.revert" => "provider PR revert".to_string(),
         "repo.removed" => "removed repos".to_string(),
         node_type => node_type.to_string(),
     }
@@ -458,21 +787,42 @@ fn print_plan(plan: &RevertPlan, path: &PathBuf) {
         out::path(path.display())
     );
     println!("{} {}", out::heading("Summary:"), plan.target_message);
+    if let Some(provider) = &plan.provider {
+        println!("{} {}", out::heading("Provider:"), provider);
+    }
     println!();
 
     for repo in &plan.repos {
-        println!(
-            "{} {} {}",
-            out::repo(&repo.repo_id),
-            out::muted("at"),
-            out::sha(short_sha(&repo.expected_head_sha))
-        );
-        for operation in &repo.operations {
+        if let Some(expected_head_sha) = &repo.expected_head_sha {
             println!(
-                "  {} {}",
-                out::movement(operation.kind.as_str()),
-                out::sha(short_sha(&operation.sha))
+                "{} {} {}",
+                out::repo(&repo.repo_id),
+                out::muted("at"),
+                out::sha(short_sha(expected_head_sha))
             );
+        } else {
+            println!("{}", out::repo(&repo.repo_id));
+        }
+        for operation in &repo.operations {
+            match operation.kind.as_str() {
+                OP_PR_REVERT => println!(
+                    "  {} {}",
+                    out::movement(operation.kind.as_str()),
+                    operation
+                        .selector
+                        .as_deref()
+                        .unwrap_or("(missing selector)")
+                ),
+                _ => println!(
+                    "  {} {}",
+                    out::movement(operation.kind.as_str()),
+                    operation
+                        .sha
+                        .as_deref()
+                        .map(|sha| out::sha(short_sha(sha)))
+                        .unwrap_or_else(|| out::danger("(missing sha)"))
+                ),
+            }
         }
     }
 

--- a/src/model/bundle.rs
+++ b/src/model/bundle.rs
@@ -399,4 +399,31 @@ impl BundleNode {
             repo_changes: Vec::new(),
         }
     }
+
+    pub fn pr_revert(
+        id: String,
+        created_at: String,
+        target_node_id: String,
+        message: String,
+        provider: String,
+        repo_ids: Vec<String>,
+        publication_urls: Vec<String>,
+    ) -> Self {
+        Self {
+            id,
+            node_type: "pr.revert".to_string(),
+            created_at,
+            title: None,
+            repo_ids: Some(repo_ids),
+            commit_group_id: None,
+            message: Some(message),
+            target_node_id: Some(target_node_id),
+            plan_id: None,
+            run_id: None,
+            provider: Some(provider),
+            publication_urls,
+            commits: Vec::new(),
+            repo_changes: Vec::new(),
+        }
+    }
 }

--- a/src/providers/github.rs
+++ b/src/providers/github.rs
@@ -152,6 +152,30 @@ impl Forge for GitHub {
         Ok(())
     }
 
+    fn revert_pull_request(
+        &self,
+        target: &PrTarget,
+        selector: &str,
+        title: &str,
+        body: &str,
+    ) -> Result<String> {
+        let args = repo_scoped_args(
+            target,
+            "--repo",
+            vec![
+                OsString::from("pr"),
+                OsString::from("revert"),
+                OsString::from(selector),
+                OsString::from("--title"),
+                OsString::from(title),
+                OsString::from("--body-file"),
+                OsString::from("-"),
+            ],
+        );
+        let output = cli_output(CLI, &target.cwd, args, Some(body))?;
+        parse_pr_url(&output).context("`gh pr revert` did not print a PR URL")
+    }
+
     fn check_runs(
         &self,
         target: &PrTarget,
@@ -220,7 +244,10 @@ mod tests {
             full_name("git@github.com:acme/backend.git").as_deref(),
             Some("acme/backend")
         );
-        assert_eq!(full_name("https://example.com/acme/backend").as_deref(), None);
+        assert_eq!(
+            full_name("https://example.com/acme/backend").as_deref(),
+            None
+        );
     }
 
     #[test]

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -137,6 +137,18 @@ pub trait Forge {
         delete_branch: bool,
         match_head: Option<&str>,
     ) -> Result<()>;
+    fn revert_pull_request(
+        &self,
+        _target: &PrTarget,
+        _selector: &str,
+        _title: &str,
+        _body: &str,
+    ) -> Result<String> {
+        bail!(
+            "{} does not support provider-native PR revert in Knit yet.",
+            self.id()
+        );
+    }
     fn check_runs(
         &self,
         target: &PrTarget,
@@ -338,7 +350,12 @@ fn checks_state(runs: &[CheckRun]) -> ChecksState {
 
 /// Run a forge CLI and capture stdout, returning a helpful error when the tool
 /// is missing or exits non-zero.
-pub(crate) fn cli_output<I, S>(bin: &str, cwd: &Path, args: I, stdin: Option<&str>) -> Result<String>
+pub(crate) fn cli_output<I, S>(
+    bin: &str,
+    cwd: &Path,
+    args: I,
+    stdin: Option<&str>,
+) -> Result<String>
 where
     I: IntoIterator<Item = S>,
     S: AsRef<OsStr>,

--- a/src/selectors.rs
+++ b/src/selectors.rs
@@ -10,6 +10,7 @@ pub fn is_loggable_node(node: &BundleNode) -> bool {
             | "feature.landed"
             | "git.observed"
             | "land.update"
+            | "pr.revert"
             | "revert.group"
             | "repo.removed"
     )

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -2231,11 +2231,74 @@ fn land_plan_and_apply_merges_recorded_publications_with_fake_gh() {
     assert_eq!(latest["provider"].as_str(), Some("github"));
     assert_eq!(latest["repoIds"].as_array().unwrap().len(), 2);
     assert_eq!(latest["publicationUrls"].as_array().unwrap().len(), 2);
+    let landed_node_id = latest["id"].as_str().unwrap().to_string();
     assert!(workspace.join(".knit/land-runs").exists());
     assert!(knit(&workspace, ["bundle", "validate"]).contains("Bundle valid"));
     assert!(knit(&workspace, ["log", "-1"]).contains("landed"));
     let sync_error = knit_fails(&workspace, ["land", "sync"]);
     assert!(sync_error.contains("No KnitHub remote configured"));
+
+    let revert_plan = knit_with_fake_gh(&workspace, ["revert", "HEAD"], &fake_bin, &fake_gh_dir);
+    assert!(revert_plan.contains("Revert plan"), "{revert_plan}");
+    assert!(revert_plan.contains("Provider: github"), "{revert_plan}");
+    assert!(revert_plan.contains("prRevert"), "{revert_plan}");
+    assert!(
+        revert_plan.contains("https://github.com/acme/backend/pull/101"),
+        "{revert_plan}"
+    );
+    assert!(
+        revert_plan.contains("https://github.com/acme/frontend/pull/202"),
+        "{revert_plan}"
+    );
+
+    let revert_apply = knit_with_fake_gh(
+        &workspace,
+        ["revert", "HEAD", "--apply"],
+        &fake_bin,
+        &fake_gh_dir,
+    );
+    assert!(
+        revert_apply.contains("Recorded PR revert group"),
+        "{revert_apply}"
+    );
+    let revert_order = fs::read_to_string(fake_gh_dir.join("revert-order.txt")).unwrap();
+    let mut revert_order_lines = revert_order.lines().collect::<Vec<_>>();
+    revert_order_lines.sort_unstable();
+    assert_eq!(revert_order_lines, vec!["backend", "frontend"]);
+    let backend_revert_body = fs::read_to_string(fake_gh_dir.join("revert-backend.md")).unwrap();
+    assert!(
+        backend_revert_body.contains(&format!("Knit-Reverts: {landed_node_id}")),
+        "{backend_revert_body}"
+    );
+
+    let bundle = read_bundle(&workspace);
+    let latest = bundle["nodes"].as_array().unwrap().last().unwrap();
+    assert_eq!(latest["type"].as_str(), Some("pr.revert"));
+    assert_eq!(
+        latest["targetNodeId"].as_str(),
+        Some(landed_node_id.as_str())
+    );
+    assert_eq!(latest["provider"].as_str(), Some("github"));
+    assert_eq!(latest["publicationUrls"].as_array().unwrap().len(), 2);
+    assert!(bundle["publications"].as_array().unwrap().iter().any(|publication| {
+        publication["repoId"].as_str() == Some("backend")
+            && publication["number"].as_u64() == Some(901)
+            && publication["state"].as_str() == Some("OPEN")
+    }));
+    assert!(bundle["publications"].as_array().unwrap().iter().any(|publication| {
+        publication["repoId"].as_str() == Some("frontend")
+            && publication["number"].as_u64() == Some(902)
+            && publication["state"].as_str() == Some("OPEN")
+    }));
+    assert!(knit(&workspace, ["bundle", "validate"]).contains("Bundle valid"));
+    assert!(knit(&workspace, ["log", "-1"]).contains("pr revert"));
+    let show_revert = knit(&workspace, ["show", "HEAD"]);
+    assert!(show_revert.contains("pr.revert"), "{show_revert}");
+    assert!(show_revert.contains(&landed_node_id), "{show_revert}");
+    assert!(
+        show_revert.contains("https://github.com/acme/backend/pull/901"),
+        "{show_revert}"
+    );
 
     let mut stale_bundle = read_bundle(&workspace);
     stale_bundle["publications"] = json!([]);
@@ -3812,7 +3875,13 @@ case "$sub" in
       base="$(cat "$GH_FAKE_DIR/create-$pr_repo.base")"
     fi
     state="OPEN"
-    if [ -f "$GH_FAKE_DIR/merged-$pr_repo" ]; then
+    title="$pr_repo PR"
+    head="knit/venue-capacity"
+    if [ -f "$GH_FAKE_DIR/revert-$pr_repo.number" ] && [ "$number" = "$(cat "$GH_FAKE_DIR/revert-$pr_repo.number")" ]; then
+      state="OPEN"
+      title="Revert $pr_repo PR"
+      head="knit/revert-$pr_repo"
+    elif [ -f "$GH_FAKE_DIR/merged-$pr_repo" ]; then
       state="MERGED"
     fi
     draft="false"
@@ -3826,7 +3895,7 @@ case "$sub" in
       mergestate="DIRTY"
     fi
     review="${GH_FAKE_REVIEW:-}"
-    printf '{"number":%s,"url":"%s","state":"%s","title":"%s PR","baseRefName":"%s","headRefName":"knit/venue-capacity","body":"Existing body","isDraft":%s,"headRefOid":"%s-head","mergeable":"%s","mergeStateStatus":"%s","reviewDecision":"%s"}\n' "$number" "$url" "$state" "$pr_repo" "$base" "$draft" "$pr_repo" "$mergeable" "$mergestate" "$review"
+    printf '{"number":%s,"url":"%s","state":"%s","title":"%s","baseRefName":"%s","headRefName":"%s","body":"Existing body","isDraft":%s,"headRefOid":"%s-head","mergeable":"%s","mergeStateStatus":"%s","reviewDecision":"%s"}\n' "$number" "$url" "$state" "$title" "$base" "$head" "$draft" "$pr_repo" "$mergeable" "$mergestate" "$review"
     ;;
   edit)
     url="$1"
@@ -3834,6 +3903,46 @@ case "$sub" in
     pr_repo="${tail%%/*}"
     cat > "$GH_FAKE_DIR/edit-$pr_repo.md"
     printf '%s\n' "$url"
+    ;;
+  revert)
+    url="$1"
+    shift
+    tail="${url#https://github.com/acme/}"
+    pr_repo="${tail%%/*}"
+    title="Revert $pr_repo PR"
+    body_written=0
+    while [ "$#" -gt 0 ]; do
+      case "$1" in
+        --title)
+          title="$2"
+          shift 2
+          ;;
+        --body-file)
+          if [ "$2" = "-" ]; then
+            cat > "$GH_FAKE_DIR/revert-$pr_repo.md"
+          else
+            cp "$2" "$GH_FAKE_DIR/revert-$pr_repo.md"
+          fi
+          body_written=1
+          shift 2
+          ;;
+        *)
+          shift
+          ;;
+      esac
+    done
+    if [ "$body_written" -eq 0 ]; then
+      : > "$GH_FAKE_DIR/revert-$pr_repo.md"
+    fi
+    case "$pr_repo" in
+      backend) number=901 ;;
+      frontend) number=902 ;;
+      *) number=903 ;;
+    esac
+    printf '%s\n' "$number" > "$GH_FAKE_DIR/revert-$pr_repo.number"
+    printf '%s\n' "$title" > "$GH_FAKE_DIR/revert-$pr_repo.title"
+    printf '%s\n' "$pr_repo" >> "$GH_FAKE_DIR/revert-order.txt"
+    printf 'https://github.com/acme/%s/pull/%s\n' "$pr_repo" "$number"
     ;;
   checks)
     if [ "${GH_FAKE_NO_REQUIRED_CHECKS_ERROR:-0}" = "1" ]; then


### PR DESCRIPTION
Generated by Knit. Cross-links will be refreshed after all review objects are created.

<!-- BEGIN KNIT BUNDLE -->
## Knit Bundle

This PR is part of Knit bundle `revert-landed-pr-groups`.

See the other review objects in this bundle:
- `knit`: https://github.com/marc-merino/knit/pull/33 (this PR)

Bundle id: `revert-landed-pr-groups`
Bundle title: revert landed pr groups
<!-- END KNIT BUNDLE -->