### PR TITLE
Add user-global Knit config merged with workspace overrides.

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ Knit stores local state under the directory where `knit project init`, `knit bun
 
 The bundle file is the source of truth for a feature. `config.json` tracks workspace fallback state, while generated worktree paths and optional folder contexts let multiple agents work in parallel bundles without fighting over one global active bundle.
 
+User-global Knit config lives outside the workspace at `$KNIT_HOME/config.json`, `$XDG_CONFIG_HOME/knit/config.json`, or `~/.config/knit/config.json`. Workspace `.knit/config.json` overrides global values of the same name.
+
 ## Quickstart
 
 From a workspace folder that sits beside your local repos:
@@ -504,10 +506,21 @@ knit publish status
 
 When KnitHub sync remotes are configured, `knit publish create` and `knit push` also push the bundle artifact to those remotes so the host and KnitHub stay in sync. This is on by default; disable it globally with `knit config set push-sync false`, skip it for one command with `--no-remote`, or force one or more remotes with repeated `--remote <name>`.
 
+Remotes can be workspace-local or user-global. Workspace `.knit/config.json` remotes override global remotes of the same name; otherwise commands fall back to the user-level config at `$KNIT_HOME/config.json`, `$XDG_CONFIG_HOME/knit/config.json`, or `~/.config/knit/config.json`. This lets every workspace share the same hosted KnitHub remote unless a workspace deliberately points that name somewhere else:
+
+```sh
+knit remote add --global knithub https://api.knithub.dev
+export KNIT_REMOTE_KNITHUB_TOKEN="<KnitHub API token>"
+knit config set --global sync-remotes knithub
+knit config show
+knit remote show knithub
+```
+
+Workspace-only overrides stay local:
+
 ```sh
 knit remote add local http://localhost:4000
-knit remote add prod https://knithub.dev
-knit config set sync-remotes local,prod
+knit config set sync-remotes local,knithub
 knit push
 ```
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1089,18 +1089,31 @@ pub enum RemoteCommand {
         /// Optional KnitHub token. Prefer KNITHUB_TOKEN or KNIT_REMOTE_<NAME>_TOKEN for shared workspaces.
         #[arg(long)]
         token: Option<String>,
+        /// Store this remote in the user-level Knit config instead of the workspace.
+        #[arg(long)]
+        global: bool,
     },
     /// List configured remotes.
-    List,
+    List {
+        /// Show only user-level remotes.
+        #[arg(long)]
+        global: bool,
+    },
     /// Show a configured remote.
     Show {
         /// Remote name.
         name: String,
+        /// Show only the user-level remote.
+        #[arg(long)]
+        global: bool,
     },
     /// Remove a configured remote.
     Remove {
         /// Remote name.
         name: String,
+        /// Remove the user-level remote instead of the workspace remote.
+        #[arg(long)]
+        global: bool,
     },
     /// Store or clear a token for a remote.
     Token {
@@ -1111,17 +1124,29 @@ pub enum RemoteCommand {
         /// Remove the stored token.
         #[arg(long)]
         clear: bool,
+        /// Store or clear the token in the user-level Knit config.
+        #[arg(long)]
+        global: bool,
     },
 }
 
 #[derive(Subcommand)]
 pub enum ConfigCommand {
+    /// Show Knit config (global, workspace, and effective when inside a workspace).
+    Show {
+        /// Show only the user-level config.
+        #[arg(long)]
+        global: bool,
+    },
     /// Set a Knit config value.
     Set {
         /// Config key: advice, push-sync, sync-remote, or sync-remotes.
         key: String,
         /// Config value.
         value: String,
+        /// Store the value in the user-level Knit config instead of the workspace.
+        #[arg(long)]
+        global: bool,
     },
 }
 

--- a/src/commands/bundle/mod.rs
+++ b/src/commands/bundle/mod.rs
@@ -293,7 +293,7 @@ pub fn delete_bundle(
         let config = match config {
             Some(config) => config,
             None => {
-                loaded_config = load_config(&root)?;
+                loaded_config = crate::store::load_effective_config(&root)?;
                 &loaded_config
             }
         };

--- a/src/commands/bundle/prune.rs
+++ b/src/commands/bundle/prune.rs
@@ -11,7 +11,7 @@ use crate::git::{git_output, is_git_worktree};
 use crate::model::{ChangeGroup, KnitConfig, RepoEntry};
 use crate::output as out;
 use crate::providers::{self, Forge, PrTarget, PullRequest};
-use crate::store::{bundle_exists, load_config, read_json, write_json};
+use crate::store::{bundle_exists, read_json, write_json};
 use anyhow::{bail, Context, Result};
 use std::collections::{BTreeSet, HashMap};
 use std::ffi::OsString;
@@ -225,7 +225,7 @@ pub fn prune_merged_bundles(
 
     let root = current_root()?;
     let config = if remote_bundles {
-        Some(load_config(&root)?)
+        Some(crate::store::load_effective_config(&root)?)
     } else {
         None
     };

--- a/src/commands/config.rs
+++ b/src/commands/config.rs
@@ -1,74 +1,196 @@
+use crate::commands::remote::configured_sync_remote_names;
 use crate::ids::slugify;
 use crate::model::KnitConfig;
 use crate::output as out;
-use crate::store::{find_knit_root, load_config, save_config};
+use crate::store::{
+    find_knit_root, global_config_path, load_config, load_effective_config, load_global_config,
+    merge_effective_config, save_config, save_global_config,
+};
 use anyhow::{bail, Context, Result};
 
-pub fn set_config_value(key: &str, value: &str) -> Result<()> {
+pub fn set_config_value(key: &str, value: &str, global: bool) -> Result<()> {
+    if global {
+        let mut config = load_global_config()?;
+        apply_config_value(&mut config, key, value)?;
+        ensure_sync_remotes_in_config(&config)?;
+        save_global_config(&config)?;
+        print_config_value(key, &config, "global")?;
+        return Ok(());
+    }
+
     let cwd = std::env::current_dir().context("failed to read current directory")?;
     let root = find_knit_root(&cwd).context("No Knit workspace found.")?;
     let mut config = load_config(&root)?;
+    apply_config_value(&mut config, key, value)?;
+    ensure_sync_remotes_exist(&root, &config)?;
+    save_config(&root, &config)?;
+    print_config_value(key, &config, "workspace")?;
+    Ok(())
+}
+
+pub fn show_config(global: bool) -> Result<()> {
+    if global {
+        let path = global_config_path()?;
+        let config = load_global_config()?;
+        print_config_section("Global config", &path, &config);
+        return Ok(());
+    }
+
+    let cwd = std::env::current_dir().context("failed to read current directory")?;
+    let global_path = global_config_path()?;
+    let global_config = load_global_config()?;
+
+    let Some(root) = find_knit_root(&cwd) else {
+        print_config_section("Global config", &global_path, &global_config);
+        return Ok(());
+    };
+
+    let workspace_path = root.join(".knit/config.json");
+    let workspace_config = load_config(&root)?;
+    let effective = load_effective_config(&root)?;
+
+    print_config_section("Global config", &global_path, &global_config);
+    println!();
+    print_config_section("Workspace config", &workspace_path, &workspace_config);
+    println!();
+    print_config_section("Effective config", &workspace_path, &effective);
+    Ok(())
+}
+
+fn apply_config_value(config: &mut KnitConfig, key: &str, value: &str) -> Result<()> {
     match key {
         "advice" => {
             config.advice = parse_bool(value)?;
-            save_config(&root, &config)?;
-            println!(
-                "{} advice={}",
-                out::heading("Config:"),
-                if config.advice { "true" } else { "false" }
-            );
             Ok(())
         }
         "push-sync" | "push_sync" => {
             config.push_sync = parse_bool(value)?;
-            save_config(&root, &config)?;
-            println!(
-                "{} push-sync={}",
-                out::heading("Config:"),
-                if config.push_sync { "true" } else { "false" }
-            );
             Ok(())
         }
         "sync-remote" | "sync_remote" => {
             if is_clear_value(value) {
                 config.sync_remote = None;
                 config.sync_remotes.clear();
-                save_config(&root, &config)?;
-                println!("{} sync-remote={}", out::heading("Config:"), out::muted("none"));
                 return Ok(());
             }
             let remote_name = parse_remote_name(value)?;
-            ensure_remote_exists(&config, &remote_name)?;
             config.sync_remote = Some(remote_name.clone());
-            config.sync_remotes = vec![remote_name.clone()];
-            save_config(&root, &config)?;
-            println!("{} sync-remote={remote_name}", out::heading("Config:"));
+            config.sync_remotes = vec![remote_name];
             Ok(())
         }
         "sync-remotes" | "sync_remotes" => {
             if is_clear_value(value) {
                 config.sync_remote = None;
                 config.sync_remotes.clear();
-                save_config(&root, &config)?;
-                println!("{} sync-remotes={}", out::heading("Config:"), out::muted("none"));
                 return Ok(());
             }
             let remote_names = parse_remote_names(value)?;
-            for remote_name in &remote_names {
-                ensure_remote_exists(&config, remote_name)?;
-            }
             config.sync_remote = remote_names.first().cloned();
-            config.sync_remotes = remote_names.clone();
-            save_config(&root, &config)?;
-            println!(
-                "{} sync-remotes={}",
-                out::heading("Config:"),
-                remote_names.join(",")
-            );
+            config.sync_remotes = remote_names;
             Ok(())
         }
-        _ => bail!("Unknown config key `{key}`. Currently supported: advice, push-sync, sync-remote, sync-remotes."),
+        _ => bail!("Unknown config key `{key}`. Supported: advice, push-sync, sync-remote, sync-remotes."),
     }
+}
+
+fn print_config_value(key: &str, config: &KnitConfig, scope: &str) -> Result<()> {
+    match key {
+        "advice" | "push-sync" | "push_sync" => {
+            let label = if key == "advice" { "advice" } else { "push-sync" };
+            let value = if key == "advice" {
+                config.advice
+            } else {
+                config.push_sync
+            };
+            println!(
+                "{} {scope} {label}={}",
+                out::heading("Config:"),
+                if value { "true" } else { "false" }
+            );
+        }
+        "sync-remote" | "sync_remote" => {
+            let remote = config
+                .sync_remote
+                .as_deref()
+                .map(str::to_string)
+                .unwrap_or_else(|| "none".to_string());
+            println!(
+                "{} {scope} sync-remote={remote}",
+                out::heading("Config:")
+            );
+        }
+        "sync-remotes" | "sync_remotes" => {
+            let remotes = if config.sync_remotes.is_empty() {
+                "none".to_string()
+            } else {
+                config.sync_remotes.join(",")
+            };
+            println!(
+                "{} {scope} sync-remotes={remotes}",
+                out::heading("Config:")
+            );
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+fn print_config_section(title: &str, path: &std::path::Path, config: &KnitConfig) {
+    println!("{} {}", out::heading(title), out::muted(path.display()));
+    if let Some(project) = config.active_project.as_deref() {
+        println!("{} {}", out::heading("Project:"), out::repo(project));
+    }
+    if let Some(bundle) = config.active_bundle.as_deref() {
+        println!("{} {}", out::heading("Bundle:"), out::repo(bundle));
+    }
+    println!(
+        "{} {}",
+        out::heading("Push sync:"),
+        if config.push_sync { "true" } else { "false" }
+    );
+    let sync_remotes = configured_sync_remote_names(config);
+    println!(
+        "{} {}",
+        out::heading("Sync remotes:"),
+        if sync_remotes.is_empty() {
+            out::muted("none").to_string()
+        } else {
+            sync_remotes.join(",")
+        }
+    );
+    if config.remotes.is_empty() {
+        println!("{} {}", out::heading("Remotes:"), out::muted("none"));
+        return;
+    }
+    println!("{}", out::heading("Remotes:"));
+    for (name, remote) in &config.remotes {
+        println!(
+            "  {} {} {}",
+            out::repo(name),
+            remote.url,
+            out::muted(if remote.token.is_some() {
+                "stored token"
+            } else {
+                "no stored token"
+            })
+        );
+    }
+}
+
+fn ensure_sync_remotes_exist(root: &std::path::Path, config: &KnitConfig) -> Result<()> {
+    let effective = merge_effective_config(load_global_config()?, config.clone());
+    ensure_sync_remotes_in_config(&effective)?;
+    let _ = root;
+    Ok(())
+}
+
+fn ensure_sync_remotes_in_config(config: &KnitConfig) -> Result<()> {
+    for remote_name in configured_sync_remote_names(config) {
+        if !config.remotes.contains_key(&remote_name) {
+            bail!("No KnitHub remote named `{remote_name}`. Run `knit remote add {remote_name} <url>` or `knit remote add --global {remote_name} <url>` first.");
+        }
+    }
+    Ok(())
 }
 
 fn parse_bool(value: &str) -> Result<bool> {
@@ -102,14 +224,6 @@ fn parse_remote_names(value: &str) -> Result<Vec<String>> {
         bail!("Expected at least one remote name, for example `local,knithub`.");
     }
     Ok(names)
-}
-
-fn ensure_remote_exists(config: &KnitConfig, remote_name: &str) -> Result<()> {
-    if config.remotes.contains_key(remote_name) {
-        Ok(())
-    } else {
-        bail!("No KnitHub remote named `{remote_name}`. Run `knit remote add {remote_name} <url>` first.")
-    }
 }
 
 fn is_clear_value(value: &str) -> bool {

--- a/src/commands/doctor.rs
+++ b/src/commands/doctor.rs
@@ -4,7 +4,7 @@ use crate::model::{
     BUNDLE_STATE_OPEN,
 };
 use crate::output as out;
-use crate::store::{find_knit_root, read_json, write_json};
+use crate::store::{find_knit_root, global_config_path, load_effective_config, read_json, write_json};
 use crate::tracking::ledger_recorded_head_sha;
 use anyhow::{bail, Context, Result};
 use serde_json::Value;
@@ -18,6 +18,16 @@ pub fn doctor_workspace() -> Result<()> {
     match read_json::<KnitConfig>(&config_path) {
         Ok(config) => inspect_config(&root, &config, &mut issues),
         Err(error) => issues.push(format!("config: {error:#}")),
+    }
+    if let Ok(global_path) = global_config_path() {
+        if global_path.exists() {
+            if let Err(error) = read_json::<KnitConfig>(&global_path) {
+                issues.push(format!("global config: {error:#}"));
+            }
+        }
+    }
+    if let Ok(effective) = load_effective_config(&root) {
+        inspect_effective_remotes(&effective, &mut issues);
     }
     inspect_json_dir::<ChangeGroup>(&root.join(".knit/bundles"), "bundle", &mut issues);
     inspect_json_dir::<KnitProject>(&root.join(".knit/projects"), "project", &mut issues);
@@ -96,6 +106,17 @@ fn inspect_config(root: &Path, config: &KnitConfig, issues: &mut Vec<String>) {
             .join(format!("{project_id}.project.json"));
         if !path.exists() {
             issues.push(format!("active project `{project_id}` does not exist"));
+        }
+    }
+}
+
+fn inspect_effective_remotes(config: &KnitConfig, issues: &mut Vec<String>) {
+    use crate::commands::remote::configured_sync_remote_names;
+    for remote_name in configured_sync_remote_names(config) {
+        if !config.remotes.contains_key(&remote_name) {
+            issues.push(format!(
+                "sync remote `{remote_name}` is configured but no matching remote entry exists"
+            ));
         }
     }
 }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -44,7 +44,7 @@ pub use cherrypick::{cherrypick_from_bundle, split_bundle};
 pub use clean::clean_generated;
 pub use close::close_bundle;
 pub use commit::commit_staged;
-pub use config::set_config_value;
+pub use config::{set_config_value, show_config};
 pub use diff::show_diff;
 pub use doctor::{doctor_workspace, migrate_workspace};
 pub use fetch::fetch_repos;

--- a/src/commands/remote/client.rs
+++ b/src/commands/remote/client.rs
@@ -7,7 +7,7 @@ use crate::checkout::is_in_place;
 use crate::git::{branch_exists, current_branch, git_output, is_ancestor, ref_exists, rev_parse};
 use crate::ids::slugify;
 use crate::model::{ChangeGroup, KnitConfig, KnitProject, KnitRemote, RepoEntry};
-use crate::store::{find_knit_root, load_config, project_path, read_json, ActiveBundle};
+use crate::store::{find_knit_root, load_config, load_effective_config, project_path, read_json, ActiveBundle};
 use crate::time::now_iso;
 use anyhow::{bail, Context, Result};
 use serde::de::DeserializeOwned;
@@ -28,6 +28,13 @@ pub(super) fn workspace_config() -> Result<(PathBuf, KnitConfig)> {
     let cwd = std::env::current_dir().context("failed to read current directory")?;
     let root = find_knit_root(&cwd).context("No Knit workspace found.")?;
     let config = load_config(&root)?;
+    Ok((root, config))
+}
+
+pub(super) fn effective_workspace_config() -> Result<(PathBuf, KnitConfig)> {
+    let cwd = std::env::current_dir().context("failed to read current directory")?;
+    let root = find_knit_root(&cwd).context("No Knit workspace found.")?;
+    let config = load_effective_config(&root)?;
     Ok((root, config))
 }
 
@@ -80,7 +87,7 @@ pub(super) fn token_from_env(name: &str) -> Option<String> {
 
 /// Return configured KnitHub sync remotes in priority order. `syncRemotes` is the
 /// multi-target form; `syncRemote` remains the legacy single-target form.
-pub(super) fn configured_sync_remote_names(config: &KnitConfig) -> Vec<String> {
+pub fn configured_sync_remote_names(config: &KnitConfig) -> Vec<String> {
     let mut names = Vec::new();
     if !config.sync_remotes.is_empty() {
         for name in &config.sync_remotes {

--- a/src/commands/remote/clone.rs
+++ b/src/commands/remote/clone.rs
@@ -19,7 +19,7 @@ use crate::model::{
     SCHEMA_VERSION,
 };
 use crate::output as out;
-use crate::store::{bundle_path, find_knit_root, load_config, project_path, read_json, write_json, ActiveBundle};
+use crate::store::{bundle_path, find_knit_root, project_path, read_json, write_json, ActiveBundle};
 use crate::time::now_iso;
 use anyhow::{bail, Context, Result};
 use serde_json::Value;
@@ -128,7 +128,7 @@ fn resolve_remote_for_clone(
 ) -> Result<(KnitRemote, Option<String>, String)> {
     let cwd = std::env::current_dir().context("failed to read current directory")?;
     let configured = find_knit_root(&cwd)
-        .and_then(|root| load_config(&root).ok())
+        .and_then(|root| crate::store::load_effective_config(&root).ok())
         .and_then(|config| config.remotes.get(remote_name).cloned());
     let remote_url = url
         .map(ToString::to_string)

--- a/src/commands/remote/mod.rs
+++ b/src/commands/remote/mod.rs
@@ -22,6 +22,7 @@ pub use push::{
     push_project_to_remote, push_views_to_remote, remove_remote, set_remote_token, show_remote,
     sync_bundle_to_remote, sync_bundle_to_remote_if_enabled,
 };
+pub use client::configured_sync_remote_names;
 
 use crate::model::{KnitProject, ProjectView};
 use serde::Deserialize;

--- a/src/commands/remote/pull.rs
+++ b/src/commands/remote/pull.rs
@@ -5,7 +5,7 @@ use super::client::{
     configured_sync_remote_names, decode_bundle_payload, ensure_remote_bundle_fast_forward,
     fast_forward_feature_checkouts, fetch_project_export, localize_bundle, load_project_if_present,
     prepare_feature_branches, request_json, resolve_project_id, resolve_remote,
-    resolve_sync_remote_name, resolve_token, workspace_config,
+    resolve_sync_remote_name, resolve_token, effective_workspace_config,
 };
 use super::clone::{
     clone_export_repositories, export_repo_local_id, project_repo_entry_from_export,
@@ -27,7 +27,7 @@ use std::path::Path;
 /// Pull the current user's saved views for a project from the KnitHub remote,
 /// replacing the local views artifact.
 pub fn pull_views_from_remote(name: Option<&str>, remote_name: &str) -> Result<()> {
-    let (root, config) = workspace_config()?;
+    let (root, config) = effective_workspace_config()?;
     let project_id = resolve_project_id(&root, &config, name)?;
     let remote = resolve_remote(&config, remote_name)?;
     let token = resolve_token(remote_name, remote)?;
@@ -100,7 +100,7 @@ pub fn prepare_remote_pull(
     if skip_remote {
         return Ok(None);
     }
-    let (root, config) = workspace_config()?;
+    let (root, config) = effective_workspace_config()?;
     let Some(remote_name) = remote_override
         .map(crate::ids::slugify)
         .or_else(|| configured_sync_remote_names(&config).into_iter().next())

--- a/src/commands/remote/push.rs
+++ b/src/commands/remote/push.rs
@@ -3,21 +3,30 @@
 //! sync-on-push.
 
 use super::client::{
-    configured_sync_remote_names, decode_response, load_project_if_present, normalize_base_url,
-    request, request_json, resolve_project_id, resolve_remote, resolve_sync_remote_names,
-    resolve_token, token_from_env, workspace_config,
+    configured_sync_remote_names, decode_response, effective_workspace_config,
+    load_project_if_present, normalize_base_url, request, request_json, resolve_project_id,
+    resolve_remote, resolve_sync_remote_names, resolve_token, token_from_env, workspace_config,
 };
 use super::{RemoteArtifact, RemoteBundle, RemoteProject};
 use crate::ids::slugify;
 use crate::model::{ChangeGroup, KnitConfig, KnitProject, KnitRemote, ProjectRepoEntry};
 use crate::output as out;
-use crate::store::{load_active_bundle, load_config, save_config};
+use crate::store::{
+    find_knit_root, load_active_bundle, load_config, load_effective_config, load_global_config,
+    save_config, save_global_config,
+};
 use anyhow::{bail, Context, Result};
 use serde_json::{json, Value};
+use std::collections::BTreeMap;
 use std::path::Path;
 
-pub fn add_remote(name: &str, url: &str, token: Option<&str>) -> Result<()> {
-    let (root, mut config) = workspace_config()?;
+pub fn add_remote(name: &str, url: &str, token: Option<&str>, global: bool) -> Result<()> {
+    let (root, mut config) = if global {
+        (None, load_global_config()?)
+    } else {
+        let (root, config) = workspace_config()?;
+        (Some(root), config)
+    };
     let remote_name = slugify(name);
     config.remotes.insert(
         remote_name.clone(),
@@ -26,13 +35,23 @@ pub fn add_remote(name: &str, url: &str, token: Option<&str>) -> Result<()> {
             token: token.map(ToString::to_string),
         },
     );
-    save_config(&root, &config)?;
-    println!("{} {}", out::movement("configured"), out::repo(remote_name));
+    if let Some(root) = root {
+        save_config(&root, &config)?;
+    } else {
+        save_global_config(&config)?;
+    }
+    let scope = if global { "global " } else { "" };
+    println!(
+        "{} {}{}",
+        out::movement("configured"),
+        scope,
+        out::repo(remote_name)
+    );
     Ok(())
 }
 
-pub fn list_remotes() -> Result<()> {
-    let (_root, config) = workspace_config()?;
+pub fn list_remotes(global: bool) -> Result<()> {
+    let (config, sources) = remote_listing(global)?;
     if config.remotes.is_empty() {
         println!("{}", out::muted("No KnitHub remotes configured."));
         return Ok(());
@@ -40,6 +59,10 @@ pub fn list_remotes() -> Result<()> {
 
     let sync_remotes = configured_sync_remote_names(&config);
     for (name, remote) in config.remotes {
+        let source = sources
+            .get(&name)
+            .map(String::as_str)
+            .unwrap_or("workspace");
         let token_label = if token_from_env(&name).is_some() {
             "token from env"
         } else if remote.token.is_some() {
@@ -52,9 +75,10 @@ pub fn list_remotes() -> Result<()> {
             .then_some("sync")
             .unwrap_or("not sync");
         println!(
-            "{} {} {} {}",
+            "{} {} {} {} {}",
             out::repo(name),
             remote.url,
+            out::muted(source),
             out::muted(token_label),
             out::muted(sync_label)
         );
@@ -62,15 +86,33 @@ pub fn list_remotes() -> Result<()> {
     Ok(())
 }
 
-pub fn show_remote(name: &str) -> Result<()> {
-    let (_root, config) = workspace_config()?;
+pub fn show_remote(name: &str, global: bool) -> Result<()> {
+    let (config, sources) = remote_listing(global)?;
     let remote_name = slugify(name);
     let remote = config
         .remotes
         .get(&remote_name)
         .with_context(|| format!("No KnitHub remote named `{remote_name}`."))?;
+    let sync_remotes = configured_sync_remote_names(&config);
     println!("{} {}", out::heading("Remote:"), out::repo(&remote_name));
     println!("{} {}", out::heading("URL:"), remote.url);
+    println!(
+        "{} {}",
+        out::heading("Scope:"),
+        sources
+            .get(&remote_name)
+            .map(String::as_str)
+            .unwrap_or("workspace")
+    );
+    println!(
+        "{} {}",
+        out::heading("Sync:"),
+        if sync_remotes.contains(&remote_name) {
+            "enabled"
+        } else {
+            "disabled"
+        }
+    );
     println!(
         "{} {}",
         out::heading("Token:"),
@@ -85,15 +127,20 @@ pub fn show_remote(name: &str) -> Result<()> {
     Ok(())
 }
 
-pub fn remove_remote(name: &str) -> Result<()> {
-    let (root, mut config) = workspace_config()?;
+pub fn remove_remote(name: &str, global: bool) -> Result<()> {
+    let (root, mut config) = if global {
+        (None, load_global_config()?)
+    } else {
+        let (root, config) = workspace_config()?;
+        (Some(root), config)
+    };
     let remote_name = slugify(name);
     if config.remotes.remove(&remote_name).is_none() {
         bail!("No KnitHub remote named `{remote_name}`.");
     }
     config
         .sync_remotes
-        .retain(|name| slugify(name) != remote_name);
+        .retain(|entry| slugify(entry) != remote_name);
     let removed_sync_remote = config
         .sync_remote
         .as_deref()
@@ -103,13 +150,28 @@ pub fn remove_remote(name: &str) -> Result<()> {
     if removed_sync_remote {
         config.sync_remote = config.sync_remotes.first().cloned();
     }
-    save_config(&root, &config)?;
-    println!("{} {}", out::movement("removed"), out::repo(remote_name));
+    if let Some(root) = root {
+        save_config(&root, &config)?;
+    } else {
+        save_global_config(&config)?;
+    }
+    let scope = if global { "global " } else { "" };
+    println!(
+        "{} {}{}",
+        out::movement("removed"),
+        scope,
+        out::repo(remote_name)
+    );
     Ok(())
 }
 
-pub fn set_remote_token(name: &str, token: Option<&str>, clear: bool) -> Result<()> {
-    let (root, mut config) = workspace_config()?;
+pub fn set_remote_token(name: &str, token: Option<&str>, clear: bool, global: bool) -> Result<()> {
+    let (root, mut config) = if global {
+        (None, load_global_config()?)
+    } else {
+        let (root, config) = workspace_config()?;
+        (Some(root), config)
+    };
     let remote_name = slugify(name);
     let remote = config
         .remotes
@@ -125,12 +187,16 @@ pub fn set_remote_token(name: &str, token: Option<&str>, clear: bool) -> Result<
         println!("{} {}", out::movement("stored"), out::repo(remote_name));
     }
 
-    save_config(&root, &config)?;
+    if let Some(root) = root {
+        save_config(&root, &config)?;
+    } else {
+        save_global_config(&config)?;
+    }
     Ok(())
 }
 
 pub fn push_project_to_remote(name: Option<&str>, remote_name: &str) -> Result<()> {
-    let (root, config) = workspace_config()?;
+    let (root, config) = effective_workspace_config()?;
     let project_id = resolve_project_id(&root, &config, name)?;
     let remote = resolve_remote(&config, remote_name)?;
     let token = resolve_token(remote_name, remote)?;
@@ -179,7 +245,7 @@ fn upload_views(remote: &KnitRemote, token: &str, root: &Path, project_slug: &st
 
 /// Push the current user's saved views for a project to the KnitHub remote.
 pub fn push_views_to_remote(name: Option<&str>, remote_name: &str) -> Result<()> {
-    let (root, config) = workspace_config()?;
+    let (root, config) = effective_workspace_config()?;
     let project_id = resolve_project_id(&root, &config, name)?;
     let remote = resolve_remote(&config, remote_name)?;
     let token = resolve_token(remote_name, remote)?;
@@ -206,7 +272,7 @@ pub fn push_views_to_remote(name: Option<&str>, remote_name: &str) -> Result<()>
 
 pub fn push_bundle_to_remote(remote_name: &str, project: Option<&str>) -> Result<()> {
     let active = load_active_bundle()?;
-    let config = load_config(&active.root)?;
+    let config = load_effective_config(&active.root)?;
     let project_id = project
         .map(slugify)
         .or_else(|| active.bundle.project_id.clone())
@@ -251,7 +317,7 @@ pub fn maybe_sync_bundle_to_remote(remote_overrides: &[String], no_remote: bool)
     if no_remote {
         return Ok(());
     }
-    let Ok((_, config)) = workspace_config() else {
+    let Ok((_, config)) = effective_workspace_config() else {
         return Ok(());
     };
     if !config.push_sync && remote_overrides.is_empty() {
@@ -302,7 +368,7 @@ pub fn sync_bundle_to_remote_if_enabled(
     if no_remote {
         return Ok(());
     }
-    let Ok((_, config)) = workspace_config() else {
+    let Ok((_, config)) = effective_workspace_config() else {
         return Ok(());
     };
     if !config.push_sync && remote_overrides.is_empty() {
@@ -319,11 +385,11 @@ pub fn sync_bundle_to_remote_if_enabled(
 /// Push the resolved bundle artifact to KnitHub, failing if no remote is
 /// configured or if the sync cannot complete.
 pub fn sync_bundle_to_remote(remote_overrides: &[String]) -> Result<()> {
-    let (_, config) = workspace_config()?;
+    let (_, config) = effective_workspace_config()?;
     let remote_names = resolve_sync_remote_names(&config, remote_overrides);
     if remote_names.is_empty() {
         bail!(
-            "No KnitHub remote configured. Run `knit remote add knithub <url>` or `knit config set sync-remotes <name>[,<name>...]` first."
+            "No KnitHub remote configured. Run `knit remote add --global knithub <url>`, `knit remote add knithub <url>`, or `knit config set sync-remotes <name>[,<name>...]` first."
         );
     }
     sync_bundle_to_remote_names(&config, &remote_names)
@@ -527,4 +593,41 @@ fn fallback_repo_identity(repo_id: &str) -> RepoIdentity {
         name: repo_id.to_string(),
         full_name: repo_id.to_string(),
     }
+}
+
+fn remote_listing(global: bool) -> Result<(KnitConfig, BTreeMap<String, String>)> {
+    if global {
+        let config = load_global_config()?;
+        let sources = config
+            .remotes
+            .keys()
+            .map(|name| (name.clone(), "global".to_string()))
+            .collect();
+        return Ok((config, sources));
+    }
+
+    let cwd = std::env::current_dir().context("failed to read current directory")?;
+    let Some(root) = find_knit_root(&cwd) else {
+        let config = load_global_config()?;
+        let sources = config
+            .remotes
+            .keys()
+            .map(|name| (name.clone(), "global".to_string()))
+            .collect();
+        return Ok((config, sources));
+    };
+
+    let global_config = load_global_config()?;
+    let workspace_config = load_config(&root)?;
+    let mut sources = BTreeMap::new();
+    for name in global_config.remotes.keys() {
+        sources.insert(name.clone(), "global".to_string());
+    }
+    for name in workspace_config.remotes.keys() {
+        sources.insert(name.clone(), "workspace".to_string());
+    }
+
+    let effective = crate::store::merge_effective_config(global_config, workspace_config);
+
+    Ok((effective, sources))
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -189,15 +189,21 @@ pub fn run(cli: Cli) -> Result<()> {
             }
         },
         Commands::Remote { command } => match command {
-            RemoteCommand::Add { name, url, token } => {
-                commands::add_remote(&name, &url, token.as_deref())
-            }
-            RemoteCommand::List => commands::list_remotes(),
-            RemoteCommand::Show { name } => commands::show_remote(&name),
-            RemoteCommand::Remove { name } => commands::remove_remote(&name),
-            RemoteCommand::Token { name, token, clear } => {
-                commands::set_remote_token(&name, token.as_deref(), clear)
-            }
+            RemoteCommand::Add {
+                name,
+                url,
+                token,
+                global,
+            } => commands::add_remote(&name, &url, token.as_deref(), global),
+            RemoteCommand::List { global } => commands::list_remotes(global),
+            RemoteCommand::Show { name, global } => commands::show_remote(&name, global),
+            RemoteCommand::Remove { name, global } => commands::remove_remote(&name, global),
+            RemoteCommand::Token {
+                name,
+                token,
+                clear,
+                global,
+            } => commands::set_remote_token(&name, token.as_deref(), clear, global),
         },
         Commands::Clone {
             project,
@@ -666,7 +672,10 @@ pub fn run(cli: Cli) -> Result<()> {
         Commands::Git { repos, all, args } => commands::run_git(&args, &repos, all),
         Commands::Show { target } => commands::show_target(&target),
         Commands::Config { command } => match command {
-            ConfigCommand::Set { key, value } => commands::set_config_value(&key, &value),
+            ConfigCommand::Show { global } => commands::show_config(global),
+            ConfigCommand::Set { key, value, global } => {
+                commands::set_config_value(&key, &value, global)
+            }
         },
         Commands::Schema { command } => match command {
             SchemaCommand::Print { name } => commands::print_schema(&name),

--- a/src/model/config.rs
+++ b/src/model/config.rs
@@ -1,10 +1,10 @@
-//! Workspace-level config: `.knit/config.json` and the folder→bundle context map.
+//! Knit config: user-global (`~/.config/knit/config.json`) and workspace (`.knit/config.json`).
 
 use super::SCHEMA_VERSION;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct KnitConfig {
     pub schema_version: String,
@@ -27,6 +27,19 @@ pub struct KnitConfig {
 }
 
 impl KnitConfig {
+    pub fn empty() -> Self {
+        Self {
+            schema_version: SCHEMA_VERSION.to_string(),
+            active_bundle: None,
+            active_project: None,
+            sync_remote: None,
+            sync_remotes: Vec::new(),
+            advice: true,
+            push_sync: true,
+            remotes: BTreeMap::new(),
+        }
+    }
+
     pub fn new(active_bundle: String) -> Self {
         Self {
             schema_version: SCHEMA_VERSION.to_string(),

--- a/src/store.rs
+++ b/src/store.rs
@@ -4,6 +4,7 @@ use crate::model::{
 };
 use anyhow::{bail, Context, Result};
 use serde::{de::DeserializeOwned, Serialize};
+use std::env;
 use std::fs::{self, OpenOptions};
 use std::path::{Component, Path, PathBuf};
 use std::sync::Mutex;
@@ -114,6 +115,73 @@ pub fn load_config(root: &Path) -> Result<KnitConfig> {
 
 pub fn save_config(root: &Path, config: &KnitConfig) -> Result<()> {
     write_json(&root.join(".knit/config.json"), config)
+}
+
+pub fn global_config_path() -> Result<PathBuf> {
+    if let Some(home) = env::var_os("KNIT_HOME") {
+        return Ok(PathBuf::from(home).join("config.json"));
+    }
+    if let Some(config_home) = env::var_os("XDG_CONFIG_HOME") {
+        return Ok(PathBuf::from(config_home).join("knit/config.json"));
+    }
+    let home = env::var_os("HOME").context(
+        "No home directory found. Set KNIT_HOME or HOME before using global Knit config.",
+    )?;
+    Ok(PathBuf::from(home).join(".config/knit/config.json"))
+}
+
+pub fn load_global_config() -> Result<KnitConfig> {
+    let path = global_config_path()?;
+    if path.exists() {
+        read_json(&path)
+    } else {
+        Ok(KnitConfig::empty())
+    }
+}
+
+pub fn save_global_config(config: &KnitConfig) -> Result<()> {
+    let path = global_config_path()?;
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create {}", parent.display()))?;
+    }
+    write_json(&path, config)
+}
+
+/// Merge user-global config with workspace config. Workspace remotes override global
+/// remotes of the same name; workspace sync targets override global sync targets when set.
+pub fn merge_effective_config(global: KnitConfig, workspace: KnitConfig) -> KnitConfig {
+    let mut effective = global;
+
+    effective.active_bundle = workspace.active_bundle;
+    effective.active_project = workspace.active_project;
+
+    if !workspace.sync_remotes.is_empty() {
+        effective.sync_remotes = workspace.sync_remotes;
+        effective.sync_remote = workspace
+            .sync_remote
+            .or_else(|| effective.sync_remotes.first().cloned());
+    } else if workspace.sync_remote.is_some() {
+        effective.sync_remote = workspace.sync_remote.clone();
+        effective.sync_remotes = effective
+            .sync_remote
+            .iter()
+            .cloned()
+            .collect();
+    }
+
+    effective.advice = workspace.advice;
+    effective.push_sync = workspace.push_sync;
+    effective.remotes.extend(workspace.remotes);
+
+    effective
+}
+
+pub fn load_effective_config(root: &Path) -> Result<KnitConfig> {
+    Ok(merge_effective_config(
+        load_global_config()?,
+        load_config(root)?,
+    ))
 }
 
 pub fn bundle_path(root: &Path, bundle_id: &str) -> PathBuf {

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -1409,6 +1409,61 @@ fn bundle_lifecycle_clean_schema_migrate_doctor_and_advice_work() {
 }
 
 #[test]
+fn remote_config_supports_global_fallback_and_workspace_override() {
+    let root = unique_temp_dir();
+    let workspace = root.join("workspace");
+    let knit_home = root.join("knit-home");
+    fs::create_dir_all(&workspace).unwrap();
+    let env = [("KNIT_HOME", knit_home.to_str().unwrap())];
+
+    knit_with_env(
+        &workspace,
+        [
+            "remote",
+            "add",
+            "--global",
+            "knithub",
+            "https://api.knithub.dev",
+            "--token",
+            "global-token",
+        ],
+        &env,
+    );
+    let global_config: Value =
+        serde_json::from_str(&fs::read_to_string(knit_home.join("config.json")).unwrap()).unwrap();
+    assert_eq!(
+        global_config["remotes"]["knithub"]["url"].as_str(),
+        Some("https://api.knithub.dev")
+    );
+
+    knit_with_env(&workspace, ["project", "init", "arbient"], &env);
+    let inherited = knit_with_env(&workspace, ["remote", "show", "knithub"], &env);
+    assert!(inherited.contains("https://api.knithub.dev"));
+    assert!(inherited.contains("Scope: global"));
+    assert!(inherited.contains("Token: stored"));
+
+    knit_with_env(
+        &workspace,
+        ["remote", "add", "knithub", "http://localhost:4000"],
+        &env,
+    );
+    let overridden = knit_with_env(&workspace, ["remote", "show", "knithub"], &env);
+    assert!(overridden.contains("http://localhost:4000"));
+    assert!(overridden.contains("Scope: workspace"));
+
+    let global_only = knit_with_env(&workspace, ["remote", "show", "--global", "knithub"], &env);
+    assert!(global_only.contains("https://api.knithub.dev"));
+    assert!(global_only.contains("Scope: global"));
+
+    let show = knit_with_env(&workspace, ["config", "show"], &env);
+    assert!(show.contains("Global config"));
+    assert!(show.contains("Effective config"));
+    assert!(show.contains("https://api.knithub.dev"));
+
+    fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
 fn config_can_target_multiple_knithub_sync_remotes() {
     let root = unique_temp_dir();
     let workspace = root.join("workspace");


### PR DESCRIPTION
Store shared KnitHub remotes and sync defaults under KNIT_HOME or XDG config, let workspaces override by name, and add --global flags plus knit config show.