### PR TITLE
Run commit, pull, fetch, and add git work across repos in parallel.

### DIFF
--- a/src/commands/commit.rs
+++ b/src/commands/commit.rs
@@ -1,7 +1,7 @@
 use crate::checkout::{checkout_dir, ensure_expected_branch, ensure_mutable_checkouts};
 use crate::git::{git_output, rev_parse};
 use crate::ids::{commit_group_id, short_sha};
-use crate::model::{BundleNode, CommitGroup, CommitRef, RepoChange};
+use crate::model::{BundleNode, CommitGroup, CommitRef, RepoChange, RepoEntry};
 use crate::output as out;
 use crate::status::has_staged_changes;
 use crate::store::{load_active_bundle_for_update, save_active_bundle, ActiveBundle};
@@ -9,7 +9,7 @@ use crate::time::now_iso;
 use crate::tracking::{sync_note, sync_observed_changes};
 use anyhow::{bail, Context, Result};
 use std::ffi::OsString;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 pub fn commit_staged(message: &str, stage_first: bool) -> Result<()> {
     let mut active = load_active_bundle_for_update()?;
@@ -44,38 +44,56 @@ pub fn commit_staged(message: &str, stage_first: bool) -> Result<()> {
     let mut commits = Vec::new();
     let mut repo_changes = Vec::new();
 
-    for target in repos_to_commit {
-        git_output(
-            &target.worktree_abs,
-            [
-                OsString::from("commit"),
-                OsString::from("-m"),
-                OsString::from(&commit_message),
-            ],
-        )
-        .with_context(|| format!("{}: git commit failed", target.repo_id))?;
-        let sha = rev_parse(&target.worktree_abs, "HEAD")
-            .with_context(|| format!("{}: failed to read commit sha", target.repo_id))?;
-        let short = short_sha(&sha);
-        println!(
-            "{}: {} {}",
-            out::repo(&target.repo_id),
-            out::movement("committed"),
-            out::sha(short)
-        );
-        commits.push(CommitRef {
-            repo_id: target.repo_id.clone(),
-            sha: sha.clone(),
-        });
-        repo_changes.push(RepoChange {
-            repo_id: target.repo_id,
-            movement: "advanced".to_string(),
-            before_sha: Some(target.before_sha),
-            after_sha: sha.clone(),
-            commits: vec![sha.clone()],
-            dropped_commits: Vec::new(),
-        });
-        active.bundle.repos[target.repo_index].head_sha = Some(sha);
+    let results: Vec<(String, Result<CommitOutcome>)> = std::thread::scope(|scope| {
+        let handles: Vec<_> = repos_to_commit
+            .iter()
+            .map(|target| {
+                let target = target.clone();
+                let repo_id = target.repo_id.clone();
+                let message = commit_message.clone();
+                scope.spawn(move || (repo_id, run_commit(&target, &message)))
+            })
+            .collect();
+
+        handles
+            .into_iter()
+            .map(|handle| handle.join().expect("commit worker thread panicked"))
+            .collect()
+    });
+
+    let mut failures = Vec::new();
+    for (repo_id, result) in results {
+        match result {
+            Ok(outcome) => {
+                println!(
+                    "{}: {} {}",
+                    out::repo(&repo_id),
+                    out::movement("committed"),
+                    out::sha(short_sha(&outcome.sha))
+                );
+                commits.push(CommitRef {
+                    repo_id: repo_id.clone(),
+                    sha: outcome.sha.clone(),
+                });
+                repo_changes.push(RepoChange {
+                    repo_id,
+                    movement: "advanced".to_string(),
+                    before_sha: Some(outcome.before_sha),
+                    after_sha: outcome.sha.clone(),
+                    commits: vec![outcome.sha.clone()],
+                    dropped_commits: Vec::new(),
+                });
+                active.bundle.repos[outcome.repo_index].head_sha = Some(outcome.sha);
+            }
+            Err(error) => {
+                println!("{}: {}", out::repo(&repo_id), out::danger("commit failed"));
+                failures.push(format!("{repo_id}: {error:#}"));
+            }
+        }
+    }
+
+    if !failures.is_empty() {
+        bail!("commit failed:\n{}", failures.join("\n"));
     }
 
     active.bundle.commit_groups.push(CommitGroup {
@@ -103,19 +121,65 @@ pub fn commit_staged(message: &str, stage_first: bool) -> Result<()> {
     Ok(())
 }
 
+struct CommitOutcome {
+    repo_index: usize,
+    before_sha: String,
+    sha: String,
+}
+
+fn run_commit(target: &CommitTarget, commit_message: &str) -> Result<CommitOutcome> {
+    git_output(
+        &target.worktree_abs,
+        [
+            OsString::from("commit"),
+            OsString::from("-m"),
+            OsString::from(commit_message),
+        ],
+    )
+    .with_context(|| format!("{}: git commit failed", target.repo_id))?;
+    let sha = rev_parse(&target.worktree_abs, "HEAD")
+        .with_context(|| format!("{}: failed to read commit sha", target.repo_id))?;
+    Ok(CommitOutcome {
+        repo_index: target.repo_index,
+        before_sha: target.before_sha.clone(),
+        sha,
+    })
+}
+
 pub(crate) fn stage_all_tracked(active: &ActiveBundle) -> Result<()> {
-    for repo in &active.bundle.repos {
-        let Some(worktree_abs) = checkout_dir(active, repo) else {
-            continue;
-        };
-        ensure_expected_branch(repo, &worktree_abs)?;
-        git_output(&worktree_abs, ["add", "-A"])
-            .with_context(|| format!("{}: failed to stage changes", repo.id))?;
+    let targets = worktree_targets(active)?;
+    if targets.is_empty() {
+        return Ok(());
+    }
+
+    let failures: Vec<String> = std::thread::scope(|scope| {
+        let handles: Vec<_> = targets
+            .iter()
+            .map(|target| {
+                let repo_id = target.repo_id.clone();
+                let worktree_abs = target.worktree_abs.clone();
+                scope.spawn(move || {
+                    git_output(&worktree_abs, ["add", "-A"])
+                        .with_context(|| format!("{repo_id}: failed to stage changes"))
+                        .map_err(|error| format!("{error:#}"))
+                })
+            })
+            .collect();
+
+        handles
+            .into_iter()
+            .filter_map(|handle| handle.join().expect("stage worker thread panicked").err())
+            .collect()
+    });
+
+    if !failures.is_empty() {
+        bail!("stage failed:\n{}", failures.join("\n"));
     }
 
     Ok(())
 }
 
+#[derive(Clone)]
 struct CommitTarget {
     repo_index: usize,
     repo_id: String,
@@ -123,26 +187,87 @@ struct CommitTarget {
     before_sha: String,
 }
 
-fn repos_with_staged_changes(active: &ActiveBundle) -> Result<Vec<CommitTarget>> {
-    let mut repos_to_commit = Vec::new();
+struct WorktreeTarget {
+    repo_id: String,
+    worktree_abs: PathBuf,
+}
 
-    for (repo_index, repo) in active.bundle.repos.iter().enumerate() {
+fn worktree_targets(active: &ActiveBundle) -> Result<Vec<WorktreeTarget>> {
+    let mut targets = Vec::new();
+    for repo in &active.bundle.repos {
         let Some(worktree_abs) = checkout_dir(active, repo) else {
             continue;
         };
         ensure_expected_branch(repo, &worktree_abs)?;
-        let short_status = git_output(&worktree_abs, ["status", "--short"])?;
-        if has_staged_changes(&short_status) {
-            let before_sha = rev_parse(&worktree_abs, "HEAD")
-                .with_context(|| format!("{}: failed to read current HEAD", repo.id))?;
-            repos_to_commit.push(CommitTarget {
-                repo_index,
-                repo_id: repo.id.clone(),
-                worktree_abs,
-                before_sha,
-            });
-        }
+        targets.push(WorktreeTarget {
+            repo_id: repo.id.clone(),
+            worktree_abs,
+        });
+    }
+    Ok(targets)
+}
+
+fn repos_with_staged_changes(active: &ActiveBundle) -> Result<Vec<CommitTarget>> {
+    let candidates: Vec<(usize, PathBuf)> = active
+        .bundle
+        .repos
+        .iter()
+        .enumerate()
+        .filter_map(|(repo_index, repo)| {
+            checkout_dir(active, repo).map(|worktree_abs| (repo_index, worktree_abs))
+        })
+        .collect();
+
+    if candidates.is_empty() {
+        return Ok(Vec::new());
     }
 
+    let results: Vec<Result<Option<CommitTarget>>> = std::thread::scope(|scope| {
+        let active = active;
+        let handles: Vec<_> = candidates
+            .iter()
+            .map(|(repo_index, worktree_abs)| {
+                let repo_index = *repo_index;
+                let worktree_abs = worktree_abs.clone();
+                scope.spawn(move || {
+                    let repo = &active.bundle.repos[repo_index];
+                    scan_staged_changes(repo_index, repo, &worktree_abs)
+                })
+            })
+            .collect();
+
+        handles
+            .into_iter()
+            .map(|handle| handle.join().expect("scan worker thread panicked"))
+            .collect()
+    });
+
+    let mut repos_to_commit = Vec::new();
+    for result in results {
+        if let Some(target) = result? {
+            repos_to_commit.push(target);
+        }
+    }
+    repos_to_commit.sort_by_key(|target| target.repo_index);
     Ok(repos_to_commit)
+}
+
+fn scan_staged_changes(
+    repo_index: usize,
+    repo: &RepoEntry,
+    worktree_abs: &Path,
+) -> Result<Option<CommitTarget>> {
+    ensure_expected_branch(repo, worktree_abs)?;
+    let short_status = git_output(worktree_abs, ["status", "--short"])?;
+    if !has_staged_changes(&short_status) {
+        return Ok(None);
+    }
+    let before_sha = rev_parse(worktree_abs, "HEAD")
+        .with_context(|| format!("{}: failed to read current HEAD", repo.id))?;
+    Ok(Some(CommitTarget {
+        repo_index,
+        repo_id: repo.id.clone(),
+        worktree_abs: worktree_abs.to_path_buf(),
+        before_sha,
+    }))
 }

--- a/src/commands/fetch.rs
+++ b/src/commands/fetch.rs
@@ -1,6 +1,7 @@
 use crate::cli::FetchMode;
 use crate::git::{git_output, git_output_optional};
 use crate::ids::short_sha;
+use crate::model::RepoEntry;
 use crate::output as out;
 use crate::repo_selectors::resolve_repo_indexes;
 use crate::store::load_active_bundle;
@@ -26,15 +27,44 @@ pub fn fetch_repos(
         }
 
         let indexes = resolve_repo_indexes(&active, selectors, false)?;
-        for index in indexes {
-            let repo = &active.bundle.repos[index];
-            if let Err(error) = fetch_repo(repo) {
-                println!(
-                    "{}: {}",
-                    out::repo(&repo.id),
-                    out::danger("fetch failed")
-                );
-                git_failures.push(format!("{}: {error:#}", repo.id));
+        let repos: Vec<&RepoEntry> = indexes
+            .iter()
+            .map(|index| &active.bundle.repos[*index])
+            .collect();
+
+        let results: Vec<(String, Result<FetchOutcome>)> = std::thread::scope(|scope| {
+            let handles: Vec<_> = repos
+                .iter()
+                .map(|repo| {
+                    let repo_id = repo.id.clone();
+                    scope.spawn(move || (repo_id, fetch_repo(repo)))
+                })
+                .collect();
+
+            handles
+                .into_iter()
+                .map(|handle| handle.join().expect("fetch worker thread panicked"))
+                .collect()
+        });
+
+        for (repo_id, result) in results {
+            match result {
+                Ok(outcome) => {
+                    print_fetch_summary(
+                        &outcome.repo_id,
+                        &outcome.remote_ref,
+                        outcome.before.as_deref(),
+                        outcome.after.as_deref(),
+                    );
+                }
+                Err(error) => {
+                    println!(
+                        "{}: {}",
+                        out::repo(&repo_id),
+                        out::danger("fetch failed")
+                    );
+                    git_failures.push(format!("{repo_id}: {error:#}"));
+                }
             }
         }
     }
@@ -65,25 +95,35 @@ pub fn fetch_repos(
     Ok(())
 }
 
-fn fetch_repo(repo: &crate::model::RepoEntry) -> Result<()> {
+struct FetchOutcome {
+    repo_id: String,
+    remote_ref: String,
+    before: Option<String>,
+    after: Option<String>,
+}
+
+fn fetch_repo(repo: &RepoEntry) -> Result<FetchOutcome> {
     let cwd = PathBuf::from(&repo.path);
     if !cwd.exists() {
         bail!("original repo path does not exist: {}", cwd.display());
     }
 
     let remote = "origin";
-    git_output_optional(&cwd, ["remote", "get-url", remote])?
-        .with_context(|| {
-            format!("no `{remote}` remote configured in {}", cwd.display())
-        })?;
+    git_output_optional(&cwd, ["remote", "get-url", remote])?.with_context(|| {
+        format!("no `{remote}` remote configured in {}", cwd.display())
+    })?;
 
     let remote_ref = format!("{remote}/{}", repo.base_branch);
     let before = ref_sha(&cwd, &remote_ref)?;
     git_output(&cwd, ["fetch", remote])?;
     let after = ref_sha(&cwd, &remote_ref)?;
 
-    print_fetch_summary(&repo.id, &remote_ref, before.as_deref(), after.as_deref());
-    Ok(())
+    Ok(FetchOutcome {
+        repo_id: repo.id.clone(),
+        remote_ref,
+        before,
+        after,
+    })
 }
 
 fn ref_sha(cwd: &Path, reference: &str) -> Result<Option<String>> {

--- a/src/commands/pull.rs
+++ b/src/commands/pull.rs
@@ -51,24 +51,44 @@ pub fn pull_repos(
 
     preflight_clean(&targets, force)?;
 
+    let results: Vec<(String, Result<PullOutcome>)> = std::thread::scope(|scope| {
+        let handles: Vec<_> = targets
+            .iter()
+            .map(|target| {
+                let repo_id = target.repo_id.clone();
+                scope.spawn(move || (repo_id, run_pull_target(target, rebase)))
+            })
+            .collect();
+
+        handles
+            .into_iter()
+            .map(|handle| handle.join().expect("pull worker thread panicked"))
+            .collect()
+    });
+
     let mut bundle_changed = false;
-    for target in &targets {
-        let before = rev_parse(&target.cwd, "HEAD")
-            .with_context(|| format!("{}: failed to read HEAD before pull", target.repo_id))?;
-        run_pull(&target.cwd, rebase)
-            .with_context(|| format!("{}: git pull failed", target.repo_id))?;
-        let after = rev_parse(&target.cwd, "HEAD")
-            .with_context(|| format!("{}: failed to read HEAD after pull", target.repo_id))?;
-
-        print_pull_summary(target, &before, &after);
-
-        if !feature {
-            let repo = &mut active.bundle.repos[target.repo_index];
-            if repo.base_sha.as_deref() != Some(after.as_str()) {
-                repo.base_sha = Some(after);
-                bundle_changed = true;
+    let mut failures = Vec::new();
+    for (repo_id, result) in results {
+        match result {
+            Ok(outcome) => {
+                print_pull_summary(&repo_id, &outcome.before, &outcome.after);
+                if !feature {
+                    let repo = &mut active.bundle.repos[outcome.repo_index];
+                    if repo.base_sha.as_deref() != Some(outcome.after.as_str()) {
+                        repo.base_sha = Some(outcome.after);
+                        bundle_changed = true;
+                    }
+                }
+            }
+            Err(error) => {
+                println!("{}: {}", out::repo(&repo_id), out::danger("pull failed"));
+                failures.push(format!("{repo_id}: {error:#}"));
             }
         }
+    }
+
+    if !failures.is_empty() {
+        bail!("pull failed:\n{}", failures.join("\n"));
     }
 
     if feature {
@@ -95,6 +115,26 @@ struct PullTarget {
     repo_index: usize,
     repo_id: String,
     cwd: PathBuf,
+}
+
+struct PullOutcome {
+    repo_index: usize,
+    before: String,
+    after: String,
+}
+
+fn run_pull_target(target: &PullTarget, rebase: bool) -> Result<PullOutcome> {
+    let before = rev_parse(&target.cwd, "HEAD")
+        .with_context(|| format!("{}: failed to read HEAD before pull", target.repo_id))?;
+    run_pull(&target.cwd, rebase)
+        .with_context(|| format!("{}: git pull failed", target.repo_id))?;
+    let after = rev_parse(&target.cwd, "HEAD")
+        .with_context(|| format!("{}: failed to read HEAD after pull", target.repo_id))?;
+    Ok(PullOutcome {
+        repo_index: target.repo_index,
+        before,
+        after,
+    })
 }
 
 fn pull_cwd(active: &ActiveBundle, repo: &RepoEntry, feature: bool) -> Result<PathBuf> {
@@ -199,18 +239,18 @@ fn run_pull(cwd: &Path, rebase: bool) -> Result<()> {
     Ok(())
 }
 
-fn print_pull_summary(target: &PullTarget, before: &str, after: &str) {
+fn print_pull_summary(repo_id: &str, before: &str, after: &str) {
     if before == after {
         println!(
             "{}: {} {}",
-            out::repo(&target.repo_id),
+            out::repo(repo_id),
             out::muted("unchanged"),
             out::sha(short_sha(after))
         );
     } else {
         println!(
             "{}: {} {} -> {}",
-            out::repo(&target.repo_id),
+            out::repo(repo_id),
             out::movement("advanced"),
             out::sha(short_sha(before)),
             out::sha(short_sha(after))

--- a/src/commands/stage.rs
+++ b/src/commands/stage.rs
@@ -25,22 +25,86 @@ pub fn stage_paths(
         bail!("--intent-to-add requires at least one pathspec.");
     }
 
+    let mut no_checkouts = Vec::new();
+    let mut targets = Vec::new();
     for repo in repos {
         let Some(worktree_abs) = checkout_dir(&active, repo) else {
-            println!("{}: {}", out::repo(&repo.id), out::muted("no checkout"));
+            no_checkouts.push(repo.id.clone());
             continue;
         };
         ensure_expected_branch(repo, &worktree_abs)?;
-        run_git_add(&worktree_abs, &pathspecs, intent_to_add, update)?;
-        let short_status = git_output(&worktree_abs, ["status", "--short"])?;
-        println!(
-            "{}: {}",
-            out::repo(&repo.id),
-            out::status(status_label(&short_status))
-        );
+        targets.push(StageTarget {
+            repo_id: repo.id.clone(),
+            worktree_abs,
+            pathspecs: pathspecs.clone(),
+            intent_to_add,
+            update,
+        });
+    }
+
+    for repo_id in &no_checkouts {
+        println!("{}: {}", out::repo(repo_id), out::muted("no checkout"));
+    }
+
+    if targets.is_empty() {
+        return Ok(());
+    }
+
+    let results: Vec<(String, Result<String>)> = std::thread::scope(|scope| {
+        let handles: Vec<_> = targets
+            .iter()
+            .map(|target| {
+                let target = target.clone();
+                let repo_id = target.repo_id.clone();
+                scope.spawn(move || {
+                    let result = (|| {
+                        run_git_add(
+                            &target.worktree_abs,
+                            &target.pathspecs,
+                            target.intent_to_add,
+                            target.update,
+                        )?;
+                        let short_status = git_output(&target.worktree_abs, ["status", "--short"])?;
+                        Ok(status_label(&short_status).to_string())
+                    })();
+                    (repo_id, result)
+                })
+            })
+            .collect();
+
+        handles
+            .into_iter()
+            .map(|handle| handle.join().expect("stage worker thread panicked"))
+            .collect()
+    });
+
+    let mut failures = Vec::new();
+    for (repo_id, result) in results {
+        match result {
+            Ok(status) => {
+                println!("{}: {}", out::repo(&repo_id), out::status(&status));
+            }
+            Err(error) => {
+                println!("{}: {}", out::repo(&repo_id), out::danger("add failed"));
+                failures.push(format!("{repo_id}: {error:#}"));
+            }
+        }
+    }
+
+    if !failures.is_empty() {
+        bail!("add failed:\n{}", failures.join("\n"));
     }
 
     Ok(())
+}
+
+#[derive(Clone)]
+struct StageTarget {
+    repo_id: String,
+    worktree_abs: PathBuf,
+    pathspecs: Vec<String>,
+    intent_to_add: bool,
+    update: bool,
 }
 
 fn run_git_add(

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -2188,6 +2188,45 @@ fn push_sends_selected_feature_branches_in_parallel() {
 }
 
 #[test]
+#[cfg(unix)]
+fn commit_stages_and_commits_repos_in_parallel() {
+    let root = unique_temp_dir();
+    let (_backend_remote, backend, _backend_collaborator) = init_remote_repo(&root, "backend");
+    let (_frontend_remote, frontend, _frontend_collaborator) = init_remote_repo(&root, "frontend");
+    let workspace = root.join("workspace");
+    fs::create_dir_all(&workspace).unwrap();
+
+    knit(&workspace, ["init", "venue capacity"]);
+    knit(
+        &workspace,
+        [
+            "track",
+            backend.to_str().unwrap(),
+            frontend.to_str().unwrap(),
+        ],
+    );
+    let backend_feature = workspace.join(".knit/worktrees/venue-capacity/backend");
+    let frontend_feature = workspace.join(".knit/worktrees/venue-capacity/frontend");
+
+    append_line(&backend_feature.join("app.txt"), "parallel backend commit");
+    append_line(&frontend_feature.join("app.txt"), "parallel frontend commit");
+
+    let gate = root.join("commit-gate");
+    install_parallel_gate_hook(&backend_feature, "pre-commit", &gate, "backend", "frontend");
+    install_parallel_gate_hook(&frontend_feature, "pre-commit", &gate, "frontend", "backend");
+
+    let commit = knit(
+        &workspace,
+        ["commit", "--stage", "-m", "Parallel commit"],
+    );
+    assert!(commit.contains("backend"));
+    assert!(commit.contains("frontend"));
+    assert!(commit.contains("Recorded commit group"));
+
+    fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
 fn pr_create_pushes_creates_records_and_syncs_cross_links() {
     let root = unique_temp_dir();
     let (backend_remote, backend, _backend_collaborator) = init_remote_repo(&root, "backend");
@@ -4162,10 +4201,15 @@ fn append_line(path: &Path, line: &str) {
 
 #[cfg(unix)]
 fn install_parallel_push_hook(repo: &Path, gate: &Path, id: &str, peer: &str) {
+    install_parallel_gate_hook(repo, "pre-push", gate, id, peer);
+}
+
+#[cfg(unix)]
+fn install_parallel_gate_hook(repo: &Path, hook: &str, gate: &Path, id: &str, peer: &str) {
     use std::os::unix::fs::PermissionsExt;
 
     fs::create_dir_all(gate).unwrap();
-    let hook_path = git(repo, ["rev-parse", "--git-path", "hooks/pre-push"]);
+    let hook_path = git(repo, ["rev-parse", "--git-path", &format!("hooks/{hook}")]);
     let hook_path = PathBuf::from(hook_path.trim());
     let hook_path = if hook_path.is_absolute() {
         hook_path


### PR DESCRIPTION
Each command now uses thread-scoped workers like push, with serial bundle ledger updates afterward.