### PR TITLE
Parallelize tier 2 commands and knit prune

### DIFF
--- a/src/commands/bundle/prune.rs
+++ b/src/commands/bundle/prune.rs
@@ -117,6 +117,7 @@ impl PruneAssessment {
     }
 }
 
+#[derive(Clone)]
 struct PruneCache {
     pr_by_url: Arc<Mutex<HashMap<String, PullRequest>>>,
     pr_by_branch: Arc<Mutex<HashMap<BranchKey, Option<PullRequest>>>>,
@@ -454,29 +455,19 @@ fn assess_bundles(
         }
     }
 
-    let results: Vec<(String, Result<PruneAssessment>)> = if refresh {
-        std::thread::scope(|scope| {
-            let mut handles = Vec::new();
-            for (path, mut bundle) in bundles {
-                handles.push(scope.spawn(move || {
-                    let id = bundle.id.clone();
-                    (id, assess_bundle(root, &path, &mut bundle, true, cache))
-                }));
-            }
-            handles
-                .into_iter()
-                .map(|handle| handle.join().unwrap())
-                .collect()
-        })
-    } else {
-        bundles
-            .into_iter()
-            .map(|(path, mut bundle)| {
+    let results: Vec<(String, Result<PruneAssessment>)> = std::thread::scope(|scope| {
+        let mut handles = Vec::new();
+        for (path, mut bundle) in bundles {
+            handles.push(scope.spawn(move || {
                 let id = bundle.id.clone();
-                (id, assess_bundle(root, &path, &mut bundle, false, cache))
-            })
+                (id, assess_bundle(root, &path, &mut bundle, refresh, cache))
+            }));
+        }
+        handles
+            .into_iter()
+            .map(|handle| handle.join().unwrap())
             .collect()
-    };
+    });
 
     let mut assessments = Vec::new();
     for (id, result) in results {
@@ -497,82 +488,71 @@ fn assess_bundle(
     refresh: bool,
     cache: &PruneCache,
 ) -> Result<PruneAssessment> {
-    let repos = bundle.repos.clone();
+    let bundle_id = bundle.id.clone();
+    let jobs: Vec<(usize, RepoEntry, Option<crate::model::PublicationEntry>)> = bundle
+        .repos
+        .iter()
+        .enumerate()
+        .map(|(index, repo)| {
+            (
+                index,
+                repo.clone(),
+                providers::publication_for_repo(bundle, &repo.id).cloned(),
+            )
+        })
+        .collect();
+
+    let repo_results: Vec<(usize, Result<RepoPruneSignals>)> = std::thread::scope(|scope| {
+        let handles: Vec<_> = jobs
+            .iter()
+            .map(|(index, repo, recorded)| {
+                let index = *index;
+                let repo = repo.clone();
+                let recorded = recorded.clone();
+                let bundle_id = bundle_id.clone();
+                scope.spawn(move || {
+                    (
+                        index,
+                        assess_repo_signals(
+                            root,
+                            &bundle_id,
+                            &repo,
+                            recorded.as_ref(),
+                            refresh,
+                            cache,
+                        ),
+                    )
+                })
+            })
+            .collect();
+
+        handles
+            .into_iter()
+            .map(|handle| handle.join().expect("prune repo worker thread panicked"))
+            .collect()
+    });
+
     let mut saw_publication = false;
     let mut saw_merged_publication = false;
     let mut saw_open_publication = false;
     let mut pending = Pending::default();
-    for repo in repos {
-        let branch = repo.feature_branch.as_deref();
-        let mut publication = providers::publication_for_repo(bundle, &repo.id).cloned();
 
-        // Skip review-state refresh for repos whose host is not recognized;
-        // prune still proceeds on the remaining signals.
-        // A failed lookup or checkout probe must not abort the whole prune: warn
-        // and fall back to the last recorded state, keeping the bundle when the
-        // checkout is unverifiable.
-        if refresh {
+    for (index, result) in repo_results {
+        let repo_id = bundle.repos[index].id.clone();
+        let signals = result.with_context(|| format!("{bundle_id}/{repo_id}"))?;
+        if let Some(pr) = signals.publication_update {
+            let repo = bundle.repos[index].clone();
             if let Ok(forge) = providers::for_repo(&repo) {
-                if let Some(existing) = publication.as_ref() {
-                    match cache.view_pr(forge.as_ref(), Path::new(&repo.path), &existing.url) {
-                        Ok(pr) => {
-                            providers::upsert_publication(bundle, &repo, forge.as_ref(), &pr);
-                            publication = providers::publication_for_repo(bundle, &repo.id).cloned();
-                        }
-                        Err(err) => cache.note_refresh_failure(
-                            &bundle.id,
-                            &repo.id,
-                            &format!("could not refresh {}", existing.url),
-                            &err,
-                        ),
-                    }
-                } else if let Some(branch) = branch {
-                    match cache.find_existing_pr(
-                        forge.as_ref(),
-                        Path::new(&repo.path),
-                        branch,
-                        &repo.base_branch,
-                    ) {
-                        Ok(Some(pr)) => {
-                            providers::upsert_publication(bundle, &repo, forge.as_ref(), &pr);
-                            publication = providers::publication_for_repo(bundle, &repo.id).cloned();
-                        }
-                        Ok(None) => {}
-                        Err(err) => cache.note_refresh_failure(
-                            &bundle.id,
-                            &repo.id,
-                            &format!("could not check for an open review object on {branch}"),
-                            &err,
-                        ),
-                    }
-                }
+                providers::upsert_publication(bundle, &repo, forge.as_ref(), &pr);
             }
         }
-
-        match cache.checkout_has_pending_changes(root, &repo) {
-            Ok(found) => pending.merge(found),
-            Err(err) => {
-                print_prune_warning(format!(
-                    "{}/{}: could not inspect checkout for pending changes ({err:#}); keeping the bundle to be safe",
-                    bundle.id, repo.id
-                ));
-                pending.tracked = true;
-            }
+        pending.merge(signals.pending);
+        if signals.pending_check_failed {
+            pending.tracked = true;
         }
-
-        let Some(publication) = publication else {
-            continue;
-        };
-        saw_publication = true;
-        if Some(publication.head_branch.as_str()) != branch {
-            saw_open_publication = true;
-            continue;
-        }
-        if publication_state_is_merged(&publication.state) {
-            saw_merged_publication = true;
-        } else if !publication_state_is_closed(&publication.state) {
-            saw_open_publication = true;
-        }
+        saw_publication |= signals.saw_publication;
+        saw_open_publication |= signals.saw_open_publication;
+        saw_merged_publication |= signals.saw_merged_publication;
     }
 
     if refresh {
@@ -587,6 +567,116 @@ fn assess_bundle(
         saw_merged_publication,
         pending,
     })
+}
+
+struct RepoPruneSignals {
+    publication_update: Option<PullRequest>,
+    pending: Pending,
+    pending_check_failed: bool,
+    saw_publication: bool,
+    saw_open_publication: bool,
+    saw_merged_publication: bool,
+}
+
+fn assess_repo_signals(
+    root: &Path,
+    bundle_id: &str,
+    repo: &RepoEntry,
+    recorded: Option<&crate::model::PublicationEntry>,
+    refresh: bool,
+    cache: &PruneCache,
+) -> Result<RepoPruneSignals> {
+    let branch = repo.feature_branch.as_deref();
+    let mut publication_update = None;
+
+    if refresh {
+        if let Ok(forge) = providers::for_repo(repo) {
+            if let Some(existing) = recorded {
+                match cache.view_pr(forge.as_ref(), Path::new(&repo.path), &existing.url) {
+                    Ok(pr) => publication_update = Some(pr),
+                    Err(err) => cache.note_refresh_failure(
+                        bundle_id,
+                        &repo.id,
+                        &format!("could not refresh {}", existing.url),
+                        &err,
+                    ),
+                }
+            } else if let Some(branch) = branch {
+                match cache.find_existing_pr(
+                    forge.as_ref(),
+                    Path::new(&repo.path),
+                    branch,
+                    &repo.base_branch,
+                ) {
+                    Ok(Some(pr)) => publication_update = Some(pr),
+                    Ok(None) => {}
+                    Err(err) => cache.note_refresh_failure(
+                        bundle_id,
+                        &repo.id,
+                        &format!("could not check for an open review object on {branch}"),
+                        &err,
+                    ),
+                }
+            }
+        }
+    }
+
+    let (saw_publication, saw_open_publication, saw_merged_publication) =
+        if let Some(pr) = publication_update.as_ref() {
+            publication_flags_from_pr(
+                branch,
+                pr.head_ref_name.as_deref().unwrap_or(""),
+                pr.state.as_deref().unwrap_or("UNKNOWN"),
+            )
+        } else if let Some(existing) = recorded {
+            publication_flags_from_publication(branch, existing)
+        } else {
+            (false, false, false)
+        };
+
+    let (pending, pending_check_failed) = match cache.checkout_has_pending_changes(root, repo) {
+        Ok(found) => (found, false),
+        Err(err) => {
+            print_prune_warning(format!(
+                "{bundle_id}/{}: could not inspect checkout for pending changes ({err:#}); keeping the bundle to be safe",
+                repo.id
+            ));
+            (Pending::default(), true)
+        }
+    };
+
+    Ok(RepoPruneSignals {
+        publication_update,
+        pending,
+        pending_check_failed,
+        saw_publication,
+        saw_open_publication,
+        saw_merged_publication,
+    })
+}
+
+fn publication_flags_from_publication(
+    branch: Option<&str>,
+    publication: &crate::model::PublicationEntry,
+) -> (bool, bool, bool) {
+    publication_flags_from_pr(branch, &publication.head_branch, &publication.state)
+}
+
+fn publication_flags_from_pr(
+    branch: Option<&str>,
+    head_branch: &str,
+    state: &str,
+) -> (bool, bool, bool) {
+    if Some(head_branch) != branch {
+        return (true, true, false);
+    }
+    if publication_state_is_merged(state) {
+        (true, false, true)
+    } else if publication_state_is_closed(state) {
+        (true, false, false)
+    } else {
+        (true, true, false)
+    }
 }
 
 /// Find KnitHub remote bundle records that have no local artifact and whose recorded
@@ -617,22 +707,64 @@ fn remote_orphan_candidates(
         }
     };
     let mut orphans = Vec::new();
-    for record in records {
-        if record.lifecycle_state == "deleted" || local_ids.contains(&record.slug) {
-            continue;
-        }
-        let Some(payload) = record.payload.as_ref() else {
-            continue;
-        };
-        if let Some(reason) = remote_payload_dead_reason(root, payload, refresh) {
-            orphans.push(RemoteOrphan {
+    let cache = PruneCache::new();
+    let jobs: Vec<RemoteOrphanJob> = records
+        .into_iter()
+        .filter_map(|record| {
+            if record.lifecycle_state == "deleted" || local_ids.contains(&record.slug) {
+                return None;
+            }
+            let payload = record.payload?;
+            Some(RemoteOrphanJob {
                 remote_id: record.remote_id,
                 slug: record.slug,
-                reason,
-            });
+                payload,
+            })
+        })
+        .collect();
+
+    let results: Vec<(String, Option<RemoteOrphan>)> = std::thread::scope(|scope| {
+        let handles: Vec<_> = jobs
+            .iter()
+            .map(|job| {
+                let slug = job.slug.clone();
+                let remote_id = job.remote_id.clone();
+                let payload = job.payload.clone();
+                let cache = cache.clone();
+                scope.spawn(move || {
+                    (
+                        slug.clone(),
+                        remote_payload_dead_reason(root, &payload, refresh, &cache)
+                            .map(|reason| RemoteOrphan {
+                                remote_id,
+                                slug,
+                                reason,
+                            }),
+                    )
+                })
+            })
+            .collect();
+
+        handles
+            .into_iter()
+            .map(|handle| handle.join().expect("remote orphan worker thread panicked"))
+            .collect()
+    });
+
+    for (slug, orphan) in results {
+        if let Some(orphan) = orphan {
+            orphans.push(orphan);
+        } else {
+            let _ = slug;
         }
     }
     orphans
+}
+
+struct RemoteOrphanJob {
+    remote_id: String,
+    slug: String,
+    payload: ChangeGroup,
 }
 
 /// Classify an orphaned remote bundle's pull requests. The remote's stored artifact can be
@@ -644,36 +776,69 @@ fn remote_payload_dead_reason(
     root: &Path,
     payload: &ChangeGroup,
     refresh: bool,
+    cache: &PruneCache,
 ) -> Option<&'static str> {
-    let mut saw_publication = false;
-    let mut saw_merged = false;
-    for publication in &payload.publications {
-        saw_publication = true;
-        let state = if refresh {
-            match providers::by_id(&publication.provider) {
-                Some(forge) => match forge.view(&PrTarget::checkout(root), &publication.url) {
-                    Ok(pr) => pr.state.unwrap_or_else(|| publication.state.clone()),
-                    Err(err) => {
-                        print_prune_warning(format!(
-                            "{}: could not refresh remote review object {} ({err:#}); using last synced state",
-                            payload.id, publication.url
-                        ));
-                        publication.state.clone()
-                    }
-                },
-                None => publication.state.clone(),
+    if payload.publications.is_empty() {
+        return None;
+    }
+
+    let states: Vec<String> = if refresh {
+        std::thread::scope(|scope| {
+            let handles: Vec<_> = payload
+                .publications
+                .iter()
+                .map(|publication| {
+                    let publication = publication.clone();
+                    scope.spawn(move || {
+                        refresh_remote_publication_state(root, &publication, cache)
+                    })
+                })
+                .collect();
+
+            handles
+                .into_iter()
+                .map(|handle| handle.join().expect("remote publication worker thread panicked"))
+                .collect()
+        })
+    } else {
+        payload
+            .publications
+            .iter()
+            .map(|publication| publication.state.clone())
+            .collect()
+    };
+
+    classify_remote_publication_states(&states)
+}
+
+fn refresh_remote_publication_state(
+    root: &Path,
+    publication: &crate::model::PublicationEntry,
+    cache: &PruneCache,
+) -> String {
+    match providers::by_id(&publication.provider) {
+        Some(forge) => match cache.view_pr(forge.as_ref(), root, &publication.url) {
+            Ok(pr) => pr.state.unwrap_or_else(|| publication.state.clone()),
+            Err(err) => {
+                print_prune_warning(format!(
+                    "could not refresh remote review object {} ({err:#}); using last synced state",
+                    publication.url
+                ));
+                publication.state.clone()
             }
-        } else {
-            publication.state.clone()
-        };
-        if publication_state_is_merged(&state) {
+        },
+        None => publication.state.clone(),
+    }
+}
+
+fn classify_remote_publication_states(states: &[String]) -> Option<&'static str> {
+    let mut saw_merged = false;
+    for state in states {
+        if publication_state_is_merged(state) {
             saw_merged = true;
-        } else if !publication_state_is_closed(&state) {
+        } else if !publication_state_is_closed(state) {
             return None;
         }
-    }
-    if !saw_publication {
-        return None;
     }
     if saw_merged {
         Some("remote PRs are merged")
@@ -947,10 +1112,12 @@ mod prune_tests {
     // refresh=false keeps these pure (no host lookups), exercising the classification of
     // an orphan remote bundle from its recorded publication states.
     fn dead_reason(states: &[&str]) -> Option<&'static str> {
+        let cache = PruneCache::new();
         remote_payload_dead_reason(
             Path::new("/nonexistent"),
             &bundle_with_publication_states(states),
             false,
+            &cache,
         )
     }
 

--- a/src/commands/publish/mod.rs
+++ b/src/commands/publish/mod.rs
@@ -35,24 +35,69 @@ pub fn create_publications(
     let indexes = resolve_publish_repo_indexes(&active, selectors, all)?;
     let base_overrides = BaseOverrides::parse(bases)?;
     base_overrides.validate_tracked_repos(&active.bundle)?;
+    let bundle_snapshot = active.bundle.clone();
     let mut failures = Vec::new();
+    let mut bundle_changed = false;
 
-    for index in indexes.iter().copied() {
-        let repo = active.bundle.repos[index].clone();
-        let base_branch =
-            base_overrides.branch_for(&repo, publication_for_repo(&active.bundle, &repo.id));
-        match create_or_reuse_pr(&mut active, &repo, &base_branch, draft, set_upstream) {
-            Ok(()) => save_active_bundle(&active)?,
+    let jobs: Vec<PublishJob> = indexes
+        .iter()
+        .map(|&index| {
+            let repo = active.bundle.repos[index].clone();
+            let base_branch = base_overrides.branch_for(
+                &repo,
+                publication_for_repo(&active.bundle, &repo.id),
+            );
+            PublishJob {
+                repo_index: index,
+                repo,
+                base_branch,
+            }
+        })
+        .collect();
+
+    let results: Vec<(String, Result<PublishRemoteResult>)> = std::thread::scope(|scope| {
+        let active = &active;
+        let bundle = &bundle_snapshot;
+        let handles: Vec<_> = jobs
+            .iter()
+            .map(|job| {
+                let job = job.clone();
+                let repo_id = job.repo.id.clone();
+                scope.spawn(move || {
+                    (
+                        repo_id,
+                        publish_repo_remote(active, bundle, &job, draft, set_upstream),
+                    )
+                })
+            })
+            .collect();
+
+        handles
+            .into_iter()
+            .map(|handle| handle.join().expect("publish worker thread panicked"))
+            .collect()
+    });
+
+    for (repo_id, result) in results {
+        match result {
+            Ok(outcome) => {
+                if apply_publish_remote_result(&mut active, &outcome)? {
+                    bundle_changed = true;
+                }
+            }
             Err(error) => {
                 println!(
                     "{}: {}",
-                    out::repo(&repo.id),
+                    out::repo(&repo_id),
                     out::danger("PR create failed")
                 );
-                failures.push(format!("{}: {error:#}", repo.id));
-                save_active_bundle(&active)?;
+                failures.push(format!("{repo_id}: {error:#}"));
             }
         }
+    }
+
+    if bundle_changed {
+        save_active_bundle(&active)?;
     }
 
     if failures.is_empty() && sync {
@@ -103,20 +148,56 @@ pub fn create_publications_from_artifact(
     let indexes = resolve_publish_repo_indexes_for_bundle(&bundle, selectors, all)?;
     let base_overrides = BaseOverrides::parse(bases)?;
     base_overrides.validate_tracked_repos(&bundle)?;
+    let bundle_snapshot = bundle.clone();
     let mut failures = Vec::new();
 
-    for index in indexes.iter().copied() {
-        let repo = bundle.repos[index].clone();
-        let base_branch = base_overrides.branch_for(&repo, publication_for_repo(&bundle, &repo.id));
-        match create_or_reuse_pr_from_artifact(&cwd, &mut bundle, &repo, &base_branch, draft) {
-            Ok(()) => {}
+    let jobs: Vec<PublishJob> = indexes
+        .iter()
+        .map(|&index| {
+            let repo = bundle.repos[index].clone();
+            let base_branch =
+                base_overrides.branch_for(&repo, publication_for_repo(&bundle, &repo.id));
+            PublishJob {
+                repo_index: index,
+                repo,
+                base_branch,
+            }
+        })
+        .collect();
+
+    let results: Vec<(String, Result<ArtifactPublishResult>)> = std::thread::scope(|scope| {
+        let cwd = cwd.as_ref();
+        let bundle = &bundle_snapshot;
+        let handles: Vec<_> = jobs
+            .iter()
+            .map(|job| {
+                let job = job.clone();
+                let repo_id = job.repo.id.clone();
+                scope.spawn(move || {
+                    (
+                        repo_id,
+                        publish_repo_remote_from_artifact(cwd, bundle, &job, draft),
+                    )
+                })
+            })
+            .collect();
+
+        handles
+            .into_iter()
+            .map(|handle| handle.join().expect("artifact publish worker thread panicked"))
+            .collect()
+    });
+
+    for (repo_id, result) in results {
+        match result {
+            Ok(outcome) => apply_artifact_publish_result(&mut bundle, &outcome),
             Err(error) => {
                 println!(
                     "{}: {}",
-                    out::repo(&repo.id),
+                    out::repo(&repo_id),
                     out::danger("PR create failed")
                 );
-                failures.push(format!("{}: {error:#}", repo.id));
+                failures.push(format!("{repo_id}: {error:#}"));
             }
         }
     }
@@ -385,13 +466,59 @@ fn resolve_publish_repo_indexes_for_bundle(
     Ok(indexes)
 }
 
-fn create_or_reuse_pr(
-    active: &mut ActiveBundle,
-    repo: &RepoEntry,
-    base_branch: &str,
+#[derive(Clone)]
+struct PublishJob {
+    repo_index: usize,
+    repo: RepoEntry,
+    base_branch: String,
+}
+
+struct PushedInfo {
+    sha: String,
+    branch: String,
+}
+
+enum PublishStatus {
+    ExistsRecorded(String),
+    FoundExisting(PullRequest),
+    Created(PullRequest),
+}
+
+struct PublishRemoteResult {
+    repo_index: usize,
+    repo_id: String,
+    pushed: PushedInfo,
+    status: PublishStatus,
+}
+
+struct ArtifactPublishResult {
+    repo_index: usize,
+    repo_id: String,
+    status: PublishStatus,
+}
+
+enum SyncFetchResult {
+    NoReviewObject,
+    Summary {
+        repo_index: usize,
+        summary: PullRequest,
+    },
+}
+
+enum SyncBodyResult {
+    Synced(String),
+    AlreadySynced,
+}
+
+fn publish_repo_remote(
+    active: &ActiveBundle,
+    bundle: &ChangeGroup,
+    job: &PublishJob,
     draft: bool,
     set_upstream: bool,
-) -> Result<()> {
+) -> Result<PublishRemoteResult> {
+    let repo = &job.repo;
+    let base_branch = &job.base_branch;
     let branch = repo.feature_branch.as_deref().with_context(|| {
         format!(
             "{}: no feature branch recorded. Run `knit worktree`.",
@@ -410,124 +537,34 @@ fn create_or_reuse_pr(
         .with_context(|| format!("{}: failed to read feature branch HEAD", repo.id))?;
     run_push(&cwd, branch, set_upstream)
         .with_context(|| format!("{}: failed to push {branch}", repo.id))?;
-    println!(
-        "{}: {} {} {}",
-        out::repo(&repo.id),
-        out::movement("pushed"),
-        out::branch(format!("origin/{branch}")),
-        out::sha(short_sha(&sha))
-    );
-
-    if let Some(existing) = publication_for_repo(&active.bundle, &repo.id) {
-        if existing.base_branch != base_branch {
-            bail!(
-                "{}: review object already recorded against {}. Knit records one review object per repo in a bundle; create a new bundle or publish before changing the base.",
-                repo.id,
-                out::branch(&existing.base_branch)
-            );
-        }
-        println!(
-            "{}: {} {}",
-            out::repo(&repo.id),
-            out::movement("exists"),
-            existing.url
-        );
-        return Ok(());
-    }
-
-    if let Some(existing) = forge.find_existing(&target, branch, base_branch)? {
-        providers::upsert_publication(&mut active.bundle, repo, forge.as_ref(), &existing);
-        let pr =
-            publication_for_repo(&active.bundle, &repo.id).expect("publication was just inserted");
-        println!(
-            "{}: {} {}",
-            out::repo(&repo.id),
-            out::movement("exists"),
-            pr.url
-        );
-        return Ok(());
-    }
-
-    let title = format!("{} ({})", active.bundle.title, repo.id);
-    let initial_body = initial_pr_body(&active.bundle, &repo.id);
-    let url = forge.create(&target, base_branch, branch, &title, &initial_body, draft)?;
-    let summary = forge.view(&target, &url).unwrap_or_else(|_| PullRequest {
-        number: pr_number_from_url(&url).unwrap_or(0),
-        url: url.clone(),
-        state: Some("OPEN".to_string()),
-        title: Some(title),
-        base_ref_name: Some(base_branch.to_string()),
-        head_ref_name: Some(branch.to_string()),
-        body: None,
-        is_draft: None,
-        head_ref_oid: None,
-        mergeable: None,
-        merge_state_status: None,
-        review_decision: None,
-    });
-    providers::upsert_publication(&mut active.bundle, repo, forge.as_ref(), &summary);
-
-    let pr = publication_for_repo(&active.bundle, &repo.id).expect("publication was just inserted");
-    println!(
-        "{}: {} #{} {}",
-        out::repo(&repo.id),
-        out::movement("created"),
-        pr.number,
-        pr.url
-    );
-    Ok(())
-}
-
-fn create_or_reuse_pr_from_artifact(
-    cwd: &Path,
-    bundle: &mut ChangeGroup,
-    repo: &RepoEntry,
-    base_branch: &str,
-    draft: bool,
-) -> Result<()> {
-    let branch = repo.feature_branch.as_deref().with_context(|| {
-        format!(
-            "{}: no feature branch recorded in the bundle artifact.",
-            repo.id
-        )
-    })?;
-    let remote = repo
-        .remote
-        .as_deref()
-        .with_context(|| format!("{}: no git remote recorded in the bundle artifact.", repo.id))?;
-    let forge = providers::for_repo(repo)?;
-    let repo_full_name = forge
-        .repo_full_name(remote)
-        .with_context(|| format!("{}: invalid {} remote {remote}", repo.id, forge.id()))?;
-    let target = PrTarget::explicit(cwd, repo_full_name);
+    let pushed = PushedInfo {
+        sha,
+        branch: format!("origin/{branch}"),
+    };
 
     if let Some(existing) = publication_for_repo(bundle, &repo.id) {
-        if existing.base_branch != base_branch {
+        if existing.base_branch != *base_branch {
             bail!(
                 "{}: review object already recorded against {}. Knit records one review object per repo in a bundle; create a new bundle or publish before changing the base.",
                 repo.id,
                 out::branch(&existing.base_branch)
             );
         }
-        println!(
-            "{}: {} {}",
-            out::repo(&repo.id),
-            out::movement("exists"),
-            existing.url
-        );
-        return Ok(());
+        return Ok(PublishRemoteResult {
+            repo_index: job.repo_index,
+            repo_id: repo.id.clone(),
+            pushed,
+            status: PublishStatus::ExistsRecorded(existing.url.clone()),
+        });
     }
 
     if let Some(existing) = forge.find_existing(&target, branch, base_branch)? {
-        providers::upsert_publication(bundle, repo, forge.as_ref(), &existing);
-        let pr = publication_for_repo(bundle, &repo.id).expect("publication was just inserted");
-        println!(
-            "{}: {} {}",
-            out::repo(&repo.id),
-            out::movement("exists"),
-            pr.url
-        );
-        return Ok(());
+        return Ok(PublishRemoteResult {
+            repo_index: job.repo_index,
+            repo_id: repo.id.clone(),
+            pushed,
+            status: PublishStatus::FoundExisting(existing),
+        });
     }
 
     let title = format!("{} ({})", bundle.title, repo.id);
@@ -547,17 +584,291 @@ fn create_or_reuse_pr_from_artifact(
         merge_state_status: None,
         review_decision: None,
     });
-    providers::upsert_publication(bundle, repo, forge.as_ref(), &summary);
+    Ok(PublishRemoteResult {
+        repo_index: job.repo_index,
+        repo_id: repo.id.clone(),
+        pushed,
+        status: PublishStatus::Created(summary),
+    })
+}
 
-    let pr = publication_for_repo(bundle, &repo.id).expect("publication was just inserted");
+fn publish_repo_remote_from_artifact(
+    cwd: &Path,
+    bundle: &ChangeGroup,
+    job: &PublishJob,
+    draft: bool,
+) -> Result<ArtifactPublishResult> {
+    let repo = &job.repo;
+    let base_branch = &job.base_branch;
+    let branch = repo.feature_branch.as_deref().with_context(|| {
+        format!(
+            "{}: no feature branch recorded in the bundle artifact.",
+            repo.id
+        )
+    })?;
+    let remote = repo
+        .remote
+        .as_deref()
+        .with_context(|| format!("{}: no git remote recorded in the bundle artifact.", repo.id))?;
+    let forge = providers::for_repo(repo)?;
+    let repo_full_name = forge
+        .repo_full_name(remote)
+        .with_context(|| format!("{}: invalid {} remote {remote}", repo.id, forge.id()))?;
+    let target = PrTarget::explicit(cwd, repo_full_name);
+
+    if let Some(existing) = publication_for_repo(bundle, &repo.id) {
+        if existing.base_branch != *base_branch {
+            bail!(
+                "{}: review object already recorded against {}. Knit records one review object per repo in a bundle; create a new bundle or publish before changing the base.",
+                repo.id,
+                out::branch(&existing.base_branch)
+            );
+        }
+        return Ok(ArtifactPublishResult {
+            repo_index: job.repo_index,
+            repo_id: repo.id.clone(),
+            status: PublishStatus::ExistsRecorded(existing.url.clone()),
+        });
+    }
+
+    if let Some(existing) = forge.find_existing(&target, branch, base_branch)? {
+        return Ok(ArtifactPublishResult {
+            repo_index: job.repo_index,
+            repo_id: repo.id.clone(),
+            status: PublishStatus::FoundExisting(existing),
+        });
+    }
+
+    let title = format!("{} ({})", bundle.title, repo.id);
+    let initial_body = initial_pr_body(bundle, &repo.id);
+    let url = forge.create(&target, base_branch, branch, &title, &initial_body, draft)?;
+    let summary = forge.view(&target, &url).unwrap_or_else(|_| PullRequest {
+        number: pr_number_from_url(&url).unwrap_or(0),
+        url: url.clone(),
+        state: Some("OPEN".to_string()),
+        title: Some(title),
+        base_ref_name: Some(base_branch.to_string()),
+        head_ref_name: Some(branch.to_string()),
+        body: None,
+        is_draft: None,
+        head_ref_oid: None,
+        mergeable: None,
+        merge_state_status: None,
+        review_decision: None,
+    });
+    Ok(ArtifactPublishResult {
+        repo_index: job.repo_index,
+        repo_id: repo.id.clone(),
+        status: PublishStatus::Created(summary),
+    })
+}
+
+fn apply_publish_remote_result(
+    active: &mut ActiveBundle,
+    outcome: &PublishRemoteResult,
+) -> Result<bool> {
     println!(
-        "{}: {} #{} {}",
-        out::repo(&repo.id),
-        out::movement("created"),
-        pr.number,
-        pr.url
+        "{}: {} {} {}",
+        out::repo(&outcome.repo_id),
+        out::movement("pushed"),
+        out::branch(&outcome.pushed.branch),
+        out::sha(short_sha(&outcome.pushed.sha))
     );
-    Ok(())
+
+    let repo = active.bundle.repos[outcome.repo_index].clone();
+    let mut changed = false;
+    match &outcome.status {
+        PublishStatus::ExistsRecorded(url) => {
+            println!(
+                "{}: {} {}",
+                out::repo(&outcome.repo_id),
+                out::movement("exists"),
+                url
+            );
+        }
+        PublishStatus::FoundExisting(summary) | PublishStatus::Created(summary) => {
+            let forge = providers::for_repo(&repo)?;
+            providers::upsert_publication(&mut active.bundle, &repo, forge.as_ref(), summary);
+            let pr = publication_for_repo(&active.bundle, &outcome.repo_id)
+                .expect("publication was just inserted");
+            match &outcome.status {
+                PublishStatus::FoundExisting(_) => println!(
+                    "{}: {} {}",
+                    out::repo(&outcome.repo_id),
+                    out::movement("exists"),
+                    pr.url
+                ),
+                PublishStatus::Created(_) => println!(
+                    "{}: {} #{} {}",
+                    out::repo(&outcome.repo_id),
+                    out::movement("created"),
+                    pr.number,
+                    pr.url
+                ),
+                PublishStatus::ExistsRecorded(_) => unreachable!(),
+            }
+            changed = true;
+        }
+    }
+    Ok(changed)
+}
+
+fn apply_artifact_publish_result(bundle: &mut ChangeGroup, outcome: &ArtifactPublishResult) {
+    let repo = bundle.repos[outcome.repo_index].clone();
+    match &outcome.status {
+        PublishStatus::ExistsRecorded(url) => {
+            println!(
+                "{}: {} {}",
+                out::repo(&outcome.repo_id),
+                out::movement("exists"),
+                url
+            );
+        }
+        PublishStatus::FoundExisting(summary) | PublishStatus::Created(summary) => {
+            let forge = providers::for_repo(&repo).expect("forge resolves for published repo");
+            providers::upsert_publication(bundle, &repo, forge.as_ref(), summary);
+            let pr = publication_for_repo(bundle, &outcome.repo_id)
+                .expect("publication was just inserted");
+            match &outcome.status {
+                PublishStatus::FoundExisting(_) => println!(
+                    "{}: {} {}",
+                    out::repo(&outcome.repo_id),
+                    out::movement("exists"),
+                    pr.url
+                ),
+                PublishStatus::Created(_) => println!(
+                    "{}: {} #{} {}",
+                    out::repo(&outcome.repo_id),
+                    out::movement("created"),
+                    pr.number,
+                    pr.url
+                ),
+                PublishStatus::ExistsRecorded(_) => unreachable!(),
+            }
+        }
+    }
+}
+
+fn fetch_pr_summary_for_sync(
+    active: &ActiveBundle,
+    repo_index: usize,
+    repo: &RepoEntry,
+) -> Result<SyncFetchResult> {
+    let branch = repo.feature_branch.as_deref().with_context(|| {
+        format!(
+            "{}: no feature branch recorded. Run `knit worktree`.",
+            repo.id
+        )
+    })?;
+    let Some(cwd) = checkout_dir(active, repo) else {
+        bail!("{}: no feature checkout is recorded.", repo.id);
+    };
+    let forge = providers::for_repo(repo)?;
+    let target = PrTarget::checkout(&cwd);
+
+    let summary = if let Some(pr) = publication_for_repo(&active.bundle, &repo.id) {
+        forge.view(&target, &pr.url)?
+    } else if let Some(existing) = forge.find_existing(&target, branch, &repo.base_branch)? {
+        existing
+    } else {
+        return Ok(SyncFetchResult::NoReviewObject);
+    };
+
+    Ok(SyncFetchResult::Summary {
+        repo_index,
+        summary,
+    })
+}
+
+fn fetch_pr_summary_for_sync_from_artifact(
+    cwd: &Path,
+    bundle: &ChangeGroup,
+    repo_index: usize,
+    repo: &RepoEntry,
+) -> Result<SyncFetchResult> {
+    let branch = repo.feature_branch.as_deref().with_context(|| {
+        format!(
+            "{}: no feature branch recorded in the bundle artifact.",
+            repo.id
+        )
+    })?;
+    let remote = repo
+        .remote
+        .as_deref()
+        .with_context(|| format!("{}: no git remote recorded in the bundle artifact.", repo.id))?;
+    let forge = providers::for_repo(repo)?;
+    let repo_full_name = forge
+        .repo_full_name(remote)
+        .with_context(|| format!("{}: invalid {} remote {remote}", repo.id, forge.id()))?;
+    let target = PrTarget::explicit(cwd, repo_full_name);
+
+    let summary = if let Some(pr) = publication_for_repo(bundle, &repo.id) {
+        forge.view(&target, &pr.url)?
+    } else if let Some(existing) = forge.find_existing(&target, branch, &repo.base_branch)? {
+        existing
+    } else {
+        return Ok(SyncFetchResult::NoReviewObject);
+    };
+
+    Ok(SyncFetchResult::Summary {
+        repo_index,
+        summary,
+    })
+}
+
+fn sync_pr_body_remote(
+    active: &ActiveBundle,
+    _repo_index: usize,
+    repo: &RepoEntry,
+) -> Result<SyncBodyResult> {
+    let Some(cwd) = checkout_dir(active, repo) else {
+        bail!("{}: no feature checkout is recorded.", repo.id);
+    };
+    let forge = providers::for_repo(repo)?;
+    let target = PrTarget::checkout(&cwd);
+    let pr = publication_for_repo(&active.bundle, &repo.id)
+        .with_context(|| format!("{}: no publication recorded after sync fetch", repo.id))?;
+    let current_body = forge
+        .view(&target, &pr.url)?
+        .body
+        .unwrap_or_default();
+    let block = render_knit_pr_block(&active.bundle, Some(&repo.id));
+    let next_body = upsert_knit_pr_block(&current_body, &block);
+    if next_body == current_body {
+        return Ok(SyncBodyResult::AlreadySynced);
+    }
+    forge.edit_body(&target, &pr.url, &next_body)?;
+    Ok(SyncBodyResult::Synced(pr.url.clone()))
+}
+
+fn sync_pr_body_remote_from_artifact(
+    cwd: &Path,
+    bundle: &ChangeGroup,
+    _repo_index: usize,
+    repo: &RepoEntry,
+) -> Result<SyncBodyResult> {
+    let remote = repo
+        .remote
+        .as_deref()
+        .with_context(|| format!("{}: no git remote recorded in the bundle artifact.", repo.id))?;
+    let forge = providers::for_repo(repo)?;
+    let repo_full_name = forge
+        .repo_full_name(remote)
+        .with_context(|| format!("{}: invalid {} remote {remote}", repo.id, forge.id()))?;
+    let target = PrTarget::explicit(cwd, repo_full_name);
+    let pr = publication_for_repo(bundle, &repo.id)
+        .with_context(|| format!("{}: no publication recorded after sync fetch", repo.id))?;
+    let current_body = forge
+        .view(&target, &pr.url)?
+        .body
+        .unwrap_or_default();
+    let block = render_knit_pr_block(bundle, Some(&repo.id));
+    let next_body = upsert_knit_pr_block(&current_body, &block);
+    if next_body == current_body {
+        return Ok(SyncBodyResult::AlreadySynced);
+    }
+    forge.edit_body(&target, &pr.url, &next_body)?;
+    Ok(SyncBodyResult::Synced(pr.url.clone()))
 }
 
 #[derive(Debug, Default)]
@@ -617,16 +928,106 @@ fn sync_publications_for_indexes(
     active: &mut ActiveBundle,
     indexes: &[usize],
 ) -> Result<Vec<String>> {
-    let mut failures = Vec::new();
+    let jobs: Vec<(usize, RepoEntry)> = indexes
+        .iter()
+        .map(|&index| (index, active.bundle.repos[index].clone()))
+        .collect();
 
-    for index in indexes.iter().copied() {
-        let repo = active.bundle.repos[index].clone();
-        match sync_one_pr(active, &repo) {
-            Ok(()) => save_active_bundle(active)?,
+    let active_read = &*active;
+    let fetched: Vec<(String, Result<SyncFetchResult>)> = std::thread::scope(|scope| {
+        let active_read = active_read;
+        let handles: Vec<_> = jobs
+            .iter()
+            .map(|(repo_index, repo)| {
+                let repo_index = *repo_index;
+                let repo = repo.clone();
+                let repo_id = repo.id.clone();
+                scope.spawn(move || {
+                    (
+                        repo_id,
+                        fetch_pr_summary_for_sync(active_read, repo_index, &repo),
+                    )
+                })
+            })
+            .collect();
+
+        handles
+            .into_iter()
+            .map(|handle| handle.join().expect("publish sync fetch thread panicked"))
+            .collect()
+    });
+
+    let mut failures = Vec::new();
+    let mut synced_repo_indexes = Vec::new();
+    for (repo_id, result) in fetched {
+        match result {
+            Ok(SyncFetchResult::NoReviewObject) => {
+                println!(
+                    "{}: {}",
+                    out::repo(&repo_id),
+                    out::muted("no review object recorded")
+                );
+            }
+            Ok(SyncFetchResult::Summary {
+                repo_index,
+                summary,
+            }) => {
+                let repo = active.bundle.repos[repo_index].clone();
+                let forge = providers::for_repo(&repo)?;
+                providers::upsert_publication(&mut active.bundle, &repo, forge.as_ref(), &summary);
+                synced_repo_indexes.push(repo_index);
+            }
             Err(error) => {
-                println!("{}: {}", out::repo(&repo.id), out::danger("PR sync failed"));
-                failures.push(format!("{}: {error:#}", repo.id));
-                save_active_bundle(active)?;
+                println!("{}: {}", out::repo(&repo_id), out::danger("PR sync failed"));
+                failures.push(format!("{repo_id}: {error:#}"));
+            }
+        }
+    }
+
+    if !synced_repo_indexes.is_empty() {
+        save_active_bundle(active)?;
+    }
+
+    let active_read = &*active;
+    let body_results: Vec<(String, Result<SyncBodyResult>)> = std::thread::scope(|scope| {
+        let active_read = active_read;
+        let handles: Vec<_> = synced_repo_indexes
+            .iter()
+            .map(|&repo_index| {
+                let repo = active_read.bundle.repos[repo_index].clone();
+                let repo_id = repo.id.clone();
+                scope.spawn(move || {
+                    (repo_id, sync_pr_body_remote(active_read, repo_index, &repo))
+                })
+            })
+            .collect();
+
+        handles
+            .into_iter()
+            .map(|handle| handle.join().expect("publish sync body thread panicked"))
+            .collect()
+    });
+
+    for (repo_id, result) in body_results {
+        match result {
+            Ok(SyncBodyResult::Synced(url)) => {
+                println!(
+                    "{}: {} {}",
+                    out::repo(&repo_id),
+                    out::movement("synced"),
+                    url
+                );
+            }
+            Ok(SyncBodyResult::AlreadySynced) => {
+                println!(
+                    "{}: {}",
+                    out::repo(&repo_id),
+                    out::muted("PR body already synced")
+                );
+            }
+            Err(error) => {
+                println!("{}: {}", out::repo(&repo_id), out::danger("PR sync failed"));
+                failures.push(format!("{repo_id}: {error:#}"));
             }
         }
     }
@@ -639,123 +1040,109 @@ fn sync_publications_for_indexes_from_artifact(
     bundle: &mut ChangeGroup,
     indexes: &[usize],
 ) -> Result<Vec<String>> {
+    let jobs: Vec<(usize, RepoEntry)> = indexes
+        .iter()
+        .map(|&index| (index, bundle.repos[index].clone()))
+        .collect();
+    let bundle_snapshot = bundle.clone();
+
+    let fetched: Vec<(String, Result<SyncFetchResult>)> = std::thread::scope(|scope| {
+        let bundle = &bundle_snapshot;
+        let handles: Vec<_> = jobs
+            .iter()
+            .map(|(repo_index, repo)| {
+                let repo_index = *repo_index;
+                let repo = repo.clone();
+                let repo_id = repo.id.clone();
+                scope.spawn(move || {
+                    (
+                        repo_id,
+                        fetch_pr_summary_for_sync_from_artifact(cwd, bundle, repo_index, &repo),
+                    )
+                })
+            })
+            .collect();
+
+        handles
+            .into_iter()
+            .map(|handle| handle.join().expect("artifact publish sync fetch thread panicked"))
+            .collect()
+    });
+
     let mut failures = Vec::new();
-    for index in indexes.iter().copied() {
-        let repo = bundle.repos[index].clone();
-        match sync_one_pr_from_artifact(cwd, bundle, &repo) {
-            Ok(()) => {}
+    let mut synced_repo_indexes = Vec::new();
+    for (repo_id, result) in fetched {
+        match result {
+            Ok(SyncFetchResult::NoReviewObject) => {
+                println!(
+                    "{}: {}",
+                    out::repo(&repo_id),
+                    out::muted("no review object recorded")
+                );
+            }
+            Ok(SyncFetchResult::Summary {
+                repo_index,
+                summary,
+            }) => {
+                let repo = bundle.repos[repo_index].clone();
+                let forge = providers::for_repo(&repo)?;
+                providers::upsert_publication(bundle, &repo, forge.as_ref(), &summary);
+                synced_repo_indexes.push(repo_index);
+            }
             Err(error) => {
-                println!("{}: {}", out::repo(&repo.id), out::danger("PR sync failed"));
-                failures.push(format!("{}: {error:#}", repo.id));
+                println!("{}: {}", out::repo(&repo_id), out::danger("PR sync failed"));
+                failures.push(format!("{repo_id}: {error:#}"));
             }
         }
     }
+
+    let body_results: Vec<(String, Result<SyncBodyResult>)> = std::thread::scope(|scope| {
+        let bundle_read = &*bundle;
+        let handles: Vec<_> = synced_repo_indexes
+            .iter()
+            .map(|&repo_index| {
+                let repo = bundle_read.repos[repo_index].clone();
+                let repo_id = repo.id.clone();
+                scope.spawn(move || {
+                    (
+                        repo_id,
+                        sync_pr_body_remote_from_artifact(cwd, bundle_read, repo_index, &repo),
+                    )
+                })
+            })
+            .collect();
+
+        handles
+            .into_iter()
+            .map(|handle| handle.join().expect("artifact publish sync body thread panicked"))
+            .collect()
+    });
+
+    for (repo_id, result) in body_results {
+        match result {
+            Ok(SyncBodyResult::Synced(url)) => {
+                println!(
+                    "{}: {} {}",
+                    out::repo(&repo_id),
+                    out::movement("synced"),
+                    url
+                );
+            }
+            Ok(SyncBodyResult::AlreadySynced) => {
+                println!(
+                    "{}: {}",
+                    out::repo(&repo_id),
+                    out::muted("PR body already synced")
+                );
+            }
+            Err(error) => {
+                println!("{}: {}", out::repo(&repo_id), out::danger("PR sync failed"));
+                failures.push(format!("{repo_id}: {error:#}"));
+            }
+        }
+    }
+
     Ok(failures)
-}
-
-fn sync_one_pr(active: &mut ActiveBundle, repo: &RepoEntry) -> Result<()> {
-    let branch = repo.feature_branch.as_deref().with_context(|| {
-        format!(
-            "{}: no feature branch recorded. Run `knit worktree`.",
-            repo.id
-        )
-    })?;
-    let Some(cwd) = checkout_dir(active, repo) else {
-        bail!("{}: no feature checkout is recorded.", repo.id);
-    };
-    let forge = providers::for_repo(repo)?;
-    let target = PrTarget::checkout(&cwd);
-
-    let summary = if let Some(pr) = publication_for_repo(&active.bundle, &repo.id) {
-        forge.view(&target, &pr.url)?
-    } else if let Some(existing) = forge.find_existing(&target, branch, &repo.base_branch)? {
-        existing
-    } else {
-        println!(
-            "{}: {}",
-            out::repo(&repo.id),
-            out::muted("no review object recorded")
-        );
-        return Ok(());
-    };
-
-    providers::upsert_publication(&mut active.bundle, repo, forge.as_ref(), &summary);
-    let current_body = summary.body.unwrap_or_default();
-    let block = render_knit_pr_block(&active.bundle, Some(&repo.id));
-    let next_body = upsert_knit_pr_block(&current_body, &block);
-    if next_body != current_body {
-        let pr =
-            publication_for_repo(&active.bundle, &repo.id).expect("publication was just inserted");
-        forge.edit_body(&target, &pr.url, &next_body)?;
-        println!(
-            "{}: {} {}",
-            out::repo(&repo.id),
-            out::movement("synced"),
-            pr.url
-        );
-    } else {
-        println!(
-            "{}: {}",
-            out::repo(&repo.id),
-            out::muted("PR body already synced")
-        );
-    }
-
-    Ok(())
-}
-
-fn sync_one_pr_from_artifact(cwd: &Path, bundle: &mut ChangeGroup, repo: &RepoEntry) -> Result<()> {
-    let branch = repo.feature_branch.as_deref().with_context(|| {
-        format!(
-            "{}: no feature branch recorded in the bundle artifact.",
-            repo.id
-        )
-    })?;
-    let remote = repo
-        .remote
-        .as_deref()
-        .with_context(|| format!("{}: no git remote recorded in the bundle artifact.", repo.id))?;
-    let forge = providers::for_repo(repo)?;
-    let repo_full_name = forge
-        .repo_full_name(remote)
-        .with_context(|| format!("{}: invalid {} remote {remote}", repo.id, forge.id()))?;
-    let target = PrTarget::explicit(cwd, repo_full_name);
-
-    let summary = if let Some(pr) = publication_for_repo(bundle, &repo.id) {
-        forge.view(&target, &pr.url)?
-    } else if let Some(existing) = forge.find_existing(&target, branch, &repo.base_branch)? {
-        existing
-    } else {
-        println!(
-            "{}: {}",
-            out::repo(&repo.id),
-            out::muted("no review object recorded")
-        );
-        return Ok(());
-    };
-
-    providers::upsert_publication(bundle, repo, forge.as_ref(), &summary);
-    let current_body = summary.body.unwrap_or_default();
-    let block = render_knit_pr_block(bundle, Some(&repo.id));
-    let next_body = upsert_knit_pr_block(&current_body, &block);
-    if next_body != current_body {
-        let pr = publication_for_repo(bundle, &repo.id).expect("publication was just inserted");
-        forge.edit_body(&target, &pr.url, &next_body)?;
-        println!(
-            "{}: {} {}",
-            out::repo(&repo.id),
-            out::movement("synced"),
-            pr.url
-        );
-    } else {
-        println!(
-            "{}: {}",
-            out::repo(&repo.id),
-            out::muted("PR body already synced")
-        );
-    }
-
-    Ok(())
 }
 
 fn ensure_feature_branch(repo: &RepoEntry, expected: &str, cwd: &Path) -> Result<()> {

--- a/src/commands/remote/client.rs
+++ b/src/commands/remote/client.rs
@@ -270,33 +270,84 @@ pub(super) fn ensure_remote_bundle_fast_forward(
 
 pub(super) fn fast_forward_feature_checkouts(active: &mut ActiveBundle) -> Result<()> {
     let root = active.root.clone();
-    for repo in &mut active.bundle.repos {
-        let Some(branch) = repo.feature_branch.as_deref() else {
-            continue;
-        };
-        let Some(checkout) = remote_checkout_dir(&root, repo) else {
-            continue;
-        };
-        let actual = current_branch(&checkout)?.unwrap_or_else(|| "(detached HEAD)".to_string());
-        if actual != branch {
-            bail!(
-                "{}: expected feature checkout branch `{branch}`, found `{actual}` in {}.",
-                repo.id,
-                checkout.display()
-            );
-        }
-        let remote_ref = format!("origin/{branch}");
-        if ref_exists(&checkout, &remote_ref) {
-            git_output(&checkout, ["merge", "--ff-only", &remote_ref])
-                .with_context(|| format!("{}: failed to fast-forward {branch}", repo.id))?;
-        }
-        repo.head_sha = Some(
-            rev_parse(&checkout, "HEAD")
-                .with_context(|| format!("{}: failed to read feature checkout HEAD", repo.id))?,
-        );
+    let jobs: Vec<(usize, String, PathBuf, String)> = active
+        .bundle
+        .repos
+        .iter()
+        .enumerate()
+        .filter_map(|(repo_index, repo)| {
+            let branch = repo.feature_branch.as_deref()?;
+            let checkout = remote_checkout_dir(&root, repo)?;
+            Some((repo_index, repo.id.clone(), checkout, branch.to_string()))
+        })
+        .collect();
+
+    if jobs.is_empty() {
+        return Ok(());
     }
+
+    let results: Vec<(String, Result<(usize, String)>)> = std::thread::scope(|scope| {
+        let handles: Vec<_> = jobs
+            .iter()
+            .map(|(repo_index, repo_id, checkout, branch)| {
+                let repo_index = *repo_index;
+                let repo_id = repo_id.clone();
+                let checkout = checkout.clone();
+                let branch = branch.clone();
+                scope.spawn(move || {
+                    (
+                        repo_id.clone(),
+                        fast_forward_one_checkout(repo_index, &repo_id, &checkout, &branch),
+                    )
+                })
+            })
+            .collect();
+
+        handles
+            .into_iter()
+            .map(|handle| handle.join().expect("fast-forward worker thread panicked"))
+            .collect()
+    });
+
+    let mut failures = Vec::new();
+    for (repo_id, result) in results {
+        match result {
+            Ok((repo_index, head_sha)) => {
+                active.bundle.repos[repo_index].head_sha = Some(head_sha);
+            }
+            Err(error) => failures.push(format!("{repo_id}: {error:#}")),
+        }
+    }
+
+    if !failures.is_empty() {
+        bail!("fast-forward failed:\n{}", failures.join("\n"));
+    }
+
     active.bundle.updated_at = now_iso();
     Ok(())
+}
+
+fn fast_forward_one_checkout(
+    repo_index: usize,
+    repo_id: &str,
+    checkout: &Path,
+    branch: &str,
+) -> Result<(usize, String)> {
+    let actual = current_branch(checkout)?.unwrap_or_else(|| "(detached HEAD)".to_string());
+    if actual != branch {
+        bail!(
+            "{repo_id}: expected feature checkout branch `{branch}`, found `{actual}` in {}.",
+            checkout.display()
+        );
+    }
+    let remote_ref = format!("origin/{branch}");
+    if ref_exists(checkout, &remote_ref) {
+        git_output(checkout, ["merge", "--ff-only", &remote_ref])
+            .with_context(|| format!("{repo_id}: failed to fast-forward {branch}"))?;
+    }
+    let head_sha = rev_parse(checkout, "HEAD")
+        .with_context(|| format!("{repo_id}: failed to read feature checkout HEAD"))?;
+    Ok((repo_index, head_sha))
 }
 
 fn remote_checkout_dir(root: &Path, repo: &RepoEntry) -> Option<PathBuf> {

--- a/src/commands/worktree.rs
+++ b/src/commands/worktree.rs
@@ -7,14 +7,14 @@ use crate::git::{
     branch_exists, current_branch, git_output, is_git_worktree, resolve_base_ref, rev_parse,
 };
 use crate::ids::node_id;
-use crate::model::BundleNode;
+use crate::model::{BundleNode, RepoEntry};
 use crate::output as out;
 use crate::store::{load_active_bundle_for_update, save_active_bundle, ActiveBundle};
 use crate::time::now_iso;
 use anyhow::{bail, Context, Result};
 use std::ffi::OsString;
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 pub fn create_worktrees() -> Result<()> {
     let mut active = load_active_bundle_for_update()?;
@@ -46,131 +46,253 @@ pub fn materialize_repos(
     let bundle_id = active.bundle.id.clone();
     fs::create_dir_all(active.root.join(".knit/worktrees").join(&bundle_id))
         .context("failed to create bundle worktree directory")?;
+
+    let jobs: Vec<(usize, RepoEntry)> = active
+        .bundle
+        .repos
+        .iter()
+        .enumerate()
+        .filter(|(_, repo)| {
+            only_repo_ids.is_none_or(|repo_ids| repo_ids.iter().any(|repo_id| repo_id == &repo.id))
+        })
+        .map(|(index, repo)| (index, repo.clone()))
+        .collect();
+
+    if jobs.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let root = active.root.clone();
+    let results: Vec<(String, Result<MaterializeResult>)> = std::thread::scope(|scope| {
+        let handles: Vec<_> = jobs
+            .iter()
+            .map(|(repo_index, repo)| {
+                let repo_index = *repo_index;
+                let repo = repo.clone();
+                let root = root.clone();
+                let bundle_id = bundle_id.clone();
+                let repo_id = repo.id.clone();
+                scope.spawn(move || {
+                    (
+                        repo_id,
+                        materialize_one_repo(&root, &bundle_id, repo_index, &repo),
+                    )
+                })
+            })
+            .collect();
+
+        handles
+            .into_iter()
+            .map(|handle| handle.join().expect("worktree worker thread panicked"))
+            .collect()
+    });
+
     let mut materialized_repo_ids = Vec::new();
-
-    for repo in &mut active.bundle.repos {
-        if let Some(repo_ids) = only_repo_ids {
-            if !repo_ids.iter().any(|repo_id| repo_id == &repo.id) {
-                continue;
+    let mut failures = Vec::new();
+    for (repo_id, result) in results {
+        match result {
+            Ok(update) => {
+                apply_materialize_result(&mut active.bundle.repos[update.repo_index], &update);
+                print_materialize_result(&update);
+                materialized_repo_ids.push(repo_id);
             }
-        }
-
-        let repo_root = PathBuf::from(&repo.path);
-        let feature_branch = format!("knit/{bundle_id}");
-        if is_in_place(repo) {
-            materialize_in_place(repo, &repo_root, &feature_branch)?;
-            materialized_repo_ids.push(repo.id.clone());
-            continue;
-        }
-
-        let worktree_path = format!(".knit/worktrees/{}/{}", bundle_id, repo.id);
-        let worktree_abs = active.root.join(&worktree_path);
-        let base_ref = resolve_base_ref(&repo_root, &repo.base_branch);
-        let base_sha = rev_parse(&repo_root, &base_ref)
-            .with_context(|| format!("{}: failed to resolve base ref {base_ref}", repo.id))?;
-
-        if repo.base_sha.is_none() {
-            repo.base_sha = Some(base_sha.clone());
-        }
-        repo.feature_branch = Some(feature_branch.clone());
-        repo.worktree_path = Some(worktree_path.clone());
-
-        if worktree_abs.exists() {
-            if is_git_worktree(&worktree_abs) {
-                if repo.head_sha.is_none() {
-                    repo.head_sha =
-                        Some(rev_parse(&worktree_abs, "HEAD").with_context(|| {
-                            format!("{}: failed to read worktree HEAD", repo.id)
-                        })?);
-                }
-                println!(
-                    "{}: worktree already present at {}",
-                    out::repo(&repo.id),
-                    out::path(&worktree_path)
-                );
-                materialized_repo_ids.push(repo.id.clone());
-                continue;
+            Err(error) => {
+                println!("{}: {}", out::repo(&repo_id), out::danger("worktree failed"));
+                failures.push(format!("{repo_id}: {error:#}"));
             }
-            bail!(
-                "{}: {} exists but is not a git worktree",
-                repo.id,
-                worktree_abs.display()
-            );
-        }
-
-        if let Some(parent) = worktree_abs.parent() {
-            fs::create_dir_all(parent).with_context(|| {
-                format!("failed to create worktree parent {}", parent.display())
-            })?;
-        }
-
-        if branch_exists(&repo_root, &feature_branch) {
-            git_output(
-                &repo_root,
-                [
-                    OsString::from("worktree"),
-                    OsString::from("add"),
-                    worktree_abs.as_os_str().to_os_string(),
-                    OsString::from(&feature_branch),
-                ],
-            )
-            .with_context(|| format!("failed to add worktree for {}", repo.id))?;
-            if repo.head_sha.is_none() {
-                repo.head_sha = Some(
-                    rev_parse(&worktree_abs, "HEAD")
-                        .with_context(|| format!("{}: failed to read worktree HEAD", repo.id))?,
-                );
-            }
-            println!(
-                "{}: {} worktree from existing branch",
-                out::repo(&repo.id),
-                out::movement("created")
-            );
-            materialized_repo_ids.push(repo.id.clone());
-        } else {
-            git_output(
-                &repo_root,
-                [
-                    OsString::from("worktree"),
-                    OsString::from("add"),
-                    OsString::from("-b"),
-                    OsString::from(&feature_branch),
-                    worktree_abs.as_os_str().to_os_string(),
-                    OsString::from(base_ref),
-                ],
-            )
-            .with_context(|| format!("failed to create branch/worktree for {}", repo.id))?;
-            repo.head_sha = Some(
-                rev_parse(&worktree_abs, "HEAD")
-                    .with_context(|| format!("{}: failed to read worktree HEAD", repo.id))?,
-            );
-            println!(
-                "{}: {} {}",
-                out::repo(&repo.id),
-                out::movement("created"),
-                out::branch(feature_branch)
-            );
-            materialized_repo_ids.push(repo.id.clone());
         }
     }
+
+    if !failures.is_empty() {
+        bail!("worktree failed:\n{}", failures.join("\n"));
+    }
+
+    materialized_repo_ids.sort_by(|left, right| {
+        active
+            .bundle
+            .repos
+            .iter()
+            .position(|repo| &repo.id == left)
+            .cmp(&active.bundle.repos.iter().position(|repo| &repo.id == right))
+    });
 
     Ok(materialized_repo_ids)
 }
 
+struct MaterializeResult {
+    repo_index: usize,
+    repo_id: String,
+    base_sha: Option<String>,
+    feature_branch: Option<String>,
+    worktree_path: Option<String>,
+    head_sha: Option<String>,
+    log: MaterializeLog,
+}
+
+enum MaterializeLog {
+    InPlace,
+    WorktreeExists(String),
+    WorktreeFromBranch,
+    WorktreeCreated(String),
+}
+
+fn apply_materialize_result(repo: &mut RepoEntry, update: &MaterializeResult) {
+    if let Some(base_sha) = &update.base_sha {
+        if repo.base_sha.is_none() {
+            repo.base_sha = Some(base_sha.clone());
+        }
+    }
+    if let Some(feature_branch) = &update.feature_branch {
+        repo.feature_branch = Some(feature_branch.clone());
+    }
+    if let Some(worktree_path) = &update.worktree_path {
+        repo.worktree_path = Some(worktree_path.clone());
+    }
+    if let Some(head_sha) = &update.head_sha {
+        match &update.log {
+            MaterializeLog::WorktreeExists(_) if repo.head_sha.is_some() => {}
+            _ => repo.head_sha = Some(head_sha.clone()),
+        }
+    }
+}
+
+fn print_materialize_result(update: &MaterializeResult) {
+    match &update.log {
+        MaterializeLog::InPlace => println!(
+            "{}: using in-place checkout at {}",
+            out::repo(&update.repo_id),
+            out::path(
+                update
+                    .worktree_path
+                    .as_deref()
+                    .unwrap_or(update.repo_id.as_str())
+            )
+        ),
+        MaterializeLog::WorktreeExists(worktree_path) => println!(
+            "{}: worktree already present at {}",
+            out::repo(&update.repo_id),
+            out::path(worktree_path)
+        ),
+        MaterializeLog::WorktreeFromBranch => println!(
+            "{}: {} worktree from existing branch",
+            out::repo(&update.repo_id),
+            out::movement("created")
+        ),
+        MaterializeLog::WorktreeCreated(feature_branch) => println!(
+            "{}: {} {}",
+            out::repo(&update.repo_id),
+            out::movement("created"),
+            out::branch(feature_branch)
+        ),
+    }
+}
+
+fn materialize_one_repo(
+    root: &Path,
+    bundle_id: &str,
+    repo_index: usize,
+    repo: &RepoEntry,
+) -> Result<MaterializeResult> {
+    let feature_branch = format!("knit/{bundle_id}");
+    let repo_root = PathBuf::from(&repo.path);
+
+    if is_in_place(repo) {
+        let update = materialize_in_place(repo_index, repo, &repo_root, &feature_branch)?;
+        return Ok(update);
+    }
+
+    let worktree_path = format!(".knit/worktrees/{bundle_id}/{}", repo.id);
+    let worktree_abs = root.join(&worktree_path);
+    let base_ref = resolve_base_ref(&repo_root, &repo.base_branch);
+    let base_sha = rev_parse(&repo_root, &base_ref)
+        .with_context(|| format!("{}: failed to resolve base ref {base_ref}", repo.id))?;
+
+    let mut update = MaterializeResult {
+        repo_index,
+        repo_id: repo.id.clone(),
+        base_sha: if repo.base_sha.is_none() {
+            Some(base_sha)
+        } else {
+            None
+        },
+        feature_branch: Some(feature_branch.clone()),
+        worktree_path: Some(worktree_path.clone()),
+        head_sha: None,
+        log: MaterializeLog::WorktreeCreated(feature_branch.clone()),
+    };
+
+    if worktree_abs.exists() {
+        if is_git_worktree(&worktree_abs) {
+            update.head_sha = Some(
+                rev_parse(&worktree_abs, "HEAD")
+                    .with_context(|| format!("{}: failed to read worktree HEAD", repo.id))?,
+            );
+            update.log = MaterializeLog::WorktreeExists(worktree_path);
+            return Ok(update);
+        }
+        bail!(
+            "{}: {} exists but is not a git worktree",
+            repo.id,
+            worktree_abs.display()
+        );
+    }
+
+    if let Some(parent) = worktree_abs.parent() {
+        fs::create_dir_all(parent).with_context(|| {
+            format!("failed to create worktree parent {}", parent.display())
+        })?;
+    }
+
+    if branch_exists(&repo_root, &feature_branch) {
+        git_output(
+            &repo_root,
+            [
+                OsString::from("worktree"),
+                OsString::from("add"),
+                worktree_abs.as_os_str().to_os_string(),
+                OsString::from(&feature_branch),
+            ],
+        )
+        .with_context(|| format!("failed to add worktree for {}", repo.id))?;
+        update.head_sha = Some(
+            rev_parse(&worktree_abs, "HEAD")
+                .with_context(|| format!("{}: failed to read worktree HEAD", repo.id))?,
+        );
+        update.log = MaterializeLog::WorktreeFromBranch;
+        return Ok(update);
+    }
+
+    git_output(
+        &repo_root,
+        [
+            OsString::from("worktree"),
+            OsString::from("add"),
+            OsString::from("-b"),
+            OsString::from(&feature_branch),
+            worktree_abs.as_os_str().to_os_string(),
+            OsString::from(base_ref),
+        ],
+    )
+    .with_context(|| format!("failed to create branch/worktree for {}", repo.id))?;
+    update.head_sha = Some(
+        rev_parse(&worktree_abs, "HEAD")
+            .with_context(|| format!("{}: failed to read worktree HEAD", repo.id))?,
+    );
+    Ok(update)
+}
+
 fn materialize_in_place(
-    repo: &mut crate::model::RepoEntry,
-    repo_root: &PathBuf,
+    repo_index: usize,
+    repo: &RepoEntry,
+    repo_root: &Path,
     feature_branch: &str,
-) -> Result<()> {
+) -> Result<MaterializeResult> {
     let base_ref = resolve_base_ref(repo_root, &repo.base_branch);
     let base_sha = rev_parse(repo_root, &base_ref)
         .with_context(|| format!("{}: failed to resolve base ref {base_ref}", repo.id))?;
-    if repo.base_sha.is_none() {
-        repo.base_sha = Some(base_sha);
-    }
 
-    let current_branch = current_branch(repo_root)?;
-    if current_branch.as_deref() != Some(feature_branch) {
+    let current = current_branch(repo_root)?;
+    if current.as_deref() != Some(feature_branch) {
         let short_status = git_output(repo_root, ["status", "--short"])?;
         if !short_status.trim().is_empty() {
             bail!(
@@ -196,17 +318,20 @@ fn materialize_in_place(
         }
     }
 
-    repo.feature_branch = Some(feature_branch.to_string());
-    repo.worktree_path = Some(repo.path.clone());
-    repo.head_sha = Some(
-        rev_parse(repo_root, "HEAD")
-            .with_context(|| format!("{}: failed to read in-place HEAD", repo.id))?,
-    );
-    println!(
-        "{}: using in-place checkout at {}",
-        out::repo(&repo.id),
-        out::path(&repo.path)
-    );
-
-    Ok(())
+    Ok(MaterializeResult {
+        repo_index,
+        repo_id: repo.id.clone(),
+        base_sha: if repo.base_sha.is_none() {
+            Some(base_sha)
+        } else {
+            None
+        },
+        feature_branch: Some(feature_branch.to_string()),
+        worktree_path: Some(repo.path.clone()),
+        head_sha: Some(
+            rev_parse(repo_root, "HEAD")
+                .with_context(|| format!("{}: failed to read in-place HEAD", repo.id))?,
+        ),
+        log: MaterializeLog::InPlace,
+    })
 }


### PR DESCRIPTION
## Summary
- Parallelize publish create/sync, worktree materialization, and bundle-pull fast-forward across repos.
- Parallelize knit prune assessment: per-bundle and per-repo GitHub refresh, checkout pending scans, and KnitHub remote orphan publication refresh (with shared `PruneCache` dedup).
- Keep bundle ledger writes, publication upserts, and bundle JSON persistence serial after worker threads finish.

## Test plan
- [x] `cargo test prune` (unit + smoke)
- [x] Release build on branch
- [x] Arbient smoke: default/`--no-refresh`/`--report`/`--worktrees`/`--remote-bundles`/`--all` dry-run paths
- [x] Tier 1 parallel smoke tests still pass on main


Made with [Cursor](https://cursor.com)