### PR TITLE
scope project clone with owner slug namespace (knit)

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -60,7 +60,9 @@ pub enum Commands {
     },
     /// Clone a KnitHub project export into a local Knit workspace.
     Clone {
-        /// Project id or slug on the KnitHub remote.
+        /// Project to clone: `owner/slug`, a bare slug, or a project id. Use the
+        /// `owner/slug` form (owner is a username or org slug) when a slug is not
+        /// unique across owners.
         project: String,
         /// Directory to create. Defaults to the project slug.
         target: Option<PathBuf>,

--- a/src/commands/remote/client.rs
+++ b/src/commands/remote/client.rs
@@ -153,13 +153,25 @@ pub(super) fn fetch_project_export(
     token: &str,
     project_identifier: &str,
 ) -> Result<RemoteProjectExport> {
-    request_json(
-        remote,
-        token,
-        "GET",
-        &format!("/projects/{}/export", slugify(project_identifier)),
-        None,
-    )
+    let (owner, slug) = split_project_identifier(project_identifier);
+    let path = match owner {
+        Some(owner) => format!("/projects/{slug}/export?owner={owner}"),
+        None => format!("/projects/{slug}/export"),
+    };
+    request_json(remote, token, "GET", &path, None)
+}
+
+/// Split an `owner/slug` clone reference into its parts. A bare identifier (no
+/// `/`) resolves by slug alone, preserving the historical behavior used by
+/// local project ids. Each segment is slugified so it is URL-safe and matches
+/// how KnitHub stores usernames, org slugs, and project slugs.
+pub(super) fn split_project_identifier(identifier: &str) -> (Option<String>, String) {
+    match identifier.split_once('/') {
+        Some((owner, slug)) if !owner.trim().is_empty() && !slug.trim().is_empty() => {
+            (Some(slugify(owner)), slugify(slug))
+        }
+        _ => (None, slugify(identifier)),
+    }
 }
 
 pub(super) fn decode_bundle_payload(payload: &Value, bundle_slug: &str) -> Result<ChangeGroup> {
@@ -464,5 +476,48 @@ fn api_base_url(url: &str) -> String {
         url
     } else {
         format!("{url}/api/v1")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::split_project_identifier;
+
+    #[test]
+    fn splits_owner_and_slug() {
+        assert_eq!(
+            split_project_identifier("marc/knit-tools"),
+            (Some("marc".to_string()), "knit-tools".to_string())
+        );
+    }
+
+    #[test]
+    fn bare_slug_has_no_owner() {
+        assert_eq!(
+            split_project_identifier("knit-tools"),
+            (None, "knit-tools".to_string())
+        );
+    }
+
+    #[test]
+    fn slugifies_each_segment() {
+        assert_eq!(
+            split_project_identifier("Marc Merino/Knit Tools"),
+            (Some("marc-merino".to_string()), "knit-tools".to_string())
+        );
+    }
+
+    #[test]
+    fn empty_side_falls_back_to_bare_slug() {
+        // A leading or trailing slash is not a valid owner/slug pair; treat the
+        // whole thing as a bare identifier and slugify it.
+        assert_eq!(
+            split_project_identifier("/knit-tools"),
+            (None, "knit-tools".to_string())
+        );
+        assert_eq!(
+            split_project_identifier("marc/"),
+            (None, "marc".to_string())
+        );
     }
 }

--- a/src/commands/remote/clone.rs
+++ b/src/commands/remote/clone.rs
@@ -162,9 +162,11 @@ fn resolve_remote_for_clone(
 
 fn resolve_clone_target(target: Option<&Path>, project_identifier: &str) -> Result<PathBuf> {
     let cwd = std::env::current_dir().context("failed to read current directory")?;
+    // Default the directory to the project slug, dropping any `owner/` prefix.
+    let (_owner, slug) = super::client::split_project_identifier(project_identifier);
     let target = target
         .map(PathBuf::from)
-        .unwrap_or_else(|| PathBuf::from(slugify(project_identifier)));
+        .unwrap_or_else(|| PathBuf::from(slug));
     if target.is_absolute() {
         Ok(target)
     } else {


### PR DESCRIPTION
Generated by Knit. Cross-links will be refreshed after all review objects are created.

<!-- BEGIN KNIT BUNDLE -->
## Knit Bundle

This PR is part of Knit bundle `scope-project-clone-with-owner-slug-namespace`.

See the other review objects in this bundle:
- `knit`: https://github.com/marc-merino/knit/pull/56 (this PR)
- `knithub`: https://github.com/marc-merino/knithub/pull/40

Bundle id: `scope-project-clone-with-owner-slug-namespace`
Bundle title: scope project clone with owner slug namespace
<!-- END KNIT BUNDLE -->