### PR TITLE
Add version flag and bundle artifact fast-forward refresh (knit)

### DIFF
--- a/README.md
+++ b/README.md
@@ -450,6 +450,8 @@ Target flags drive the aggregate, best-effort report directly and may be combine
 
 Aggregate pulls run in parallel — git work on the same source repo is serialized, distinct repos run concurrently — and never abort on the first problem: a dirty tree or non-fast-forward is reported (`skipped`/`failed`) while the rest proceed.
 
+A bundle's local artifact is refreshed from its KnitHub copy only when the remote ledger is a strict fast-forward of the local one (the local node-id sequence is a prefix of the remote's). Identical or locally-ahead ledgers are left untouched (`skipped`), and a diverged ledger keeps the local artifact and reports a per-bundle warning rather than overwriting your work. This applies to both `knit pull --bundles` and `knit fetch --bundles`; `knit clone` is unaffected because it writes into a fresh workspace with no local artifacts.
+
 ```sh
 knit pull                 # at the base: project main repos + every open bundle, reported
 knit pull --main          # update all project repos' current branch (fast-forward only)

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -4,6 +4,7 @@ use std::path::PathBuf;
 
 #[derive(Parser)]
 #[command(name = "knit")]
+#[command(version)]
 #[command(about = "Git for cross-repo feature work")]
 pub struct Cli {
     /// Resolve commands against this bundle instead of cwd or workspace context.

--- a/src/commands/remote/pull.rs
+++ b/src/commands/remote/pull.rs
@@ -12,7 +12,10 @@ use super::clone::{
 };
 use super::{RemoteBundle, RemoteExportRepository, RemoteProjectExport, RemoteViews};
 use crate::commands::worktree::materialize_repos;
-use crate::model::{ChangeGroup, KnitConfig, KnitProject, KnitProjectViews, KnitRemote};
+use crate::model::{
+    ledger_relation, ChangeGroup, KnitConfig, KnitProject, KnitProjectViews, KnitRemote,
+    LedgerRelation,
+};
 use crate::output as out;
 use crate::store::{
     bundle_path, load_active_bundle, project_path, read_json, save_active_bundle, write_json,
@@ -253,6 +256,20 @@ pub fn pull_bundle_remote_state(
         return Ok(RemoteBundleOutcome::Skipped("no remote artifact".to_string()));
     };
     let remote_payload = decode_bundle_payload(&artifact.payload, &remote_bundle.slug)?;
+    match ledger_relation(&local.node_id_sequence(), &remote_payload.node_id_sequence()) {
+        LedgerRelation::Equal => return Ok(RemoteBundleOutcome::Skipped("up to date".to_string())),
+        LedgerRelation::LocalAhead => {
+            return Ok(RemoteBundleOutcome::Skipped(
+                "local is ahead of remote".to_string(),
+            ))
+        }
+        LedgerRelation::Diverged => {
+            return Ok(RemoteBundleOutcome::Skipped(format!(
+                "bundle {bundle_id}: local and remote artifacts have diverged; keeping local"
+            )))
+        }
+        LedgerRelation::RemoteAhead => {}
+    }
     let localized = localize_bundle(remote_payload, &context.project)?;
     prepare_feature_branches(&localized)?;
     ensure_remote_bundle_fast_forward(&local, &localized)?;
@@ -402,10 +419,31 @@ pub fn fetch_bundles_from_remote(
 
         let mut bundle = decode_bundle_payload(&artifact.payload, &remote_bundle.slug)
             .with_context(|| format!("failed to decode bundle `{}`", remote_bundle.slug))?;
+
+        let bundle_path = bundles_dir.join(format!("{}.bundle.json", bundle.id));
+        // An existing local artifact is only refreshed when the remote ledger is
+        // strictly ahead (a fast-forward). Equal/local-ahead artifacts are left
+        // untouched; diverged ledgers keep local and warn.
+        if bundle_path.exists() {
+            let local: ChangeGroup = read_json(&bundle_path)
+                .with_context(|| format!("failed to read local bundle `{}`", bundle.id))?;
+            match ledger_relation(&local.node_id_sequence(), &bundle.node_id_sequence()) {
+                LedgerRelation::Equal | LedgerRelation::LocalAhead => continue,
+                LedgerRelation::Diverged => {
+                    println!(
+                        "{} bundle {}: local and remote artifacts have diverged; keeping local",
+                        out::warn("warning:"),
+                        out::node(&bundle.id)
+                    );
+                    continue;
+                }
+                LedgerRelation::RemoteAhead => {}
+            }
+        }
+
         bundle = localize_bundle(bundle, &local_project)
             .with_context(|| format!("failed to localize bundle `{}`", remote_bundle.slug))?;
 
-        let bundle_path = bundles_dir.join(format!("{}.bundle.json", bundle.id));
         crate::store::write_json(&bundle_path, &bundle)
             .with_context(|| format!("failed to write bundle `{}`", remote_bundle.slug))?;
         fetched_count += 1;

--- a/src/model/bundle.rs
+++ b/src/model/bundle.rs
@@ -67,6 +67,48 @@ impl ChangeGroup {
     }
 }
 
+/// How a local bundle artifact's append-only ledger relates to a remote copy of
+/// the same bundle, decided purely from their node-id sequences. The ledger is
+/// append-only, so a fast-forward is exactly the case where one sequence is a
+/// (non-strict) prefix of the other.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LedgerRelation {
+    /// Both ledgers record the same node-id sequence; nothing to refresh.
+    Equal,
+    /// The local ledger is a strict prefix of the remote: the remote is strictly
+    /// ahead and the local artifact can be fast-forwarded to it.
+    RemoteAhead,
+    /// The remote ledger is a strict prefix of the local: local has work the
+    /// remote has not seen. Keep local; a later push reconciles the remote.
+    LocalAhead,
+    /// Neither sequence is a prefix of the other: the ledgers have diverged.
+    Diverged,
+}
+
+/// Decide how a local bundle ledger relates to a remote one, comparing their
+/// append-only node-id sequences position by position. Pure and total: it makes
+/// no I/O and treats two empty ledgers as `Equal`.
+pub fn ledger_relation(local_node_ids: &[String], remote_node_ids: &[String]) -> LedgerRelation {
+    let common = local_node_ids.len().min(remote_node_ids.len());
+    if local_node_ids[..common] != remote_node_ids[..common] {
+        return LedgerRelation::Diverged;
+    }
+    use std::cmp::Ordering;
+    match local_node_ids.len().cmp(&remote_node_ids.len()) {
+        Ordering::Equal => LedgerRelation::Equal,
+        Ordering::Less => LedgerRelation::RemoteAhead,
+        Ordering::Greater => LedgerRelation::LocalAhead,
+    }
+}
+
+impl ChangeGroup {
+    /// The ordered node-id sequence of this bundle's append-only ledger, used to
+    /// compare local and remote copies for fast-forward refresh.
+    pub fn node_id_sequence(&self) -> Vec<String> {
+        self.nodes.iter().map(|node| node.id.clone()).collect()
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct PublicationEntry {

--- a/tests/model.rs
+++ b/tests/model.rs
@@ -1,4 +1,63 @@
-use knit::model::ChangeGroup;
+use knit::model::{ledger_relation, ChangeGroup, LedgerRelation};
+
+fn seq(ids: &[&str]) -> Vec<String> {
+    ids.iter().map(|id| id.to_string()).collect()
+}
+
+#[test]
+fn ledger_relation_equal_sequences() {
+    assert_eq!(
+        ledger_relation(&seq(&["a", "b"]), &seq(&["a", "b"])),
+        LedgerRelation::Equal
+    );
+    // Two empty ledgers are trivially equal.
+    assert_eq!(ledger_relation(&[], &[]), LedgerRelation::Equal);
+}
+
+#[test]
+fn ledger_relation_remote_strict_prefix_is_remote_ahead() {
+    assert_eq!(
+        ledger_relation(&seq(&["a"]), &seq(&["a", "b"])),
+        LedgerRelation::RemoteAhead
+    );
+    // Empty local with non-empty remote is also remote-ahead.
+    assert_eq!(
+        ledger_relation(&[], &seq(&["a"])),
+        LedgerRelation::RemoteAhead
+    );
+}
+
+#[test]
+fn ledger_relation_local_strict_prefix_is_local_ahead() {
+    assert_eq!(
+        ledger_relation(&seq(&["a", "b", "c"]), &seq(&["a", "b"])),
+        LedgerRelation::LocalAhead
+    );
+}
+
+#[test]
+fn ledger_relation_mismatched_node_diverges() {
+    // Same length, differing at a position.
+    assert_eq!(
+        ledger_relation(&seq(&["a", "x"]), &seq(&["a", "y"])),
+        LedgerRelation::Diverged
+    );
+    // Different lengths but neither is a prefix of the other.
+    assert_eq!(
+        ledger_relation(&seq(&["a", "x"]), &seq(&["a", "y", "z"])),
+        LedgerRelation::Diverged
+    );
+}
+
+#[test]
+fn node_id_sequence_follows_ledger_order() {
+    let bundle = ChangeGroup::new(
+        "venue-capacity".to_string(),
+        "venue capacity".to_string(),
+        "2026-05-05T00:00:00.000Z".to_string(),
+    );
+    assert_eq!(bundle.node_id_sequence(), seq(&["venue-capacity"]));
+}
 
 #[test]
 fn new_change_group_starts_node_chain() {


### PR DESCRIPTION
## Summary

Adds a `knit --version` flag and ledger-based fast-forward refresh for bundle artifacts pulled from KnitHub remotes.

### `knit --version`

`#[command(version)]` on the `Cli` struct makes clap emit the crate version (`knit 0.1.0`).

### Ledger-based fast-forward refresh

Previously, `knit pull --bundles` / `knit fetch --bundles` only localized a remote bundle artifact when no local file existed; an existing local artifact was never refreshed. This change refreshes an existing local artifact from its KnitHub copy, but only when it is safe to do so.

The decision is made by a pure, total `ledger_relation(local, remote)` function that compares the two append-only node-id sequences position by position. Because the ledger is append-only, a fast-forward is exactly the case where one sequence is a prefix of the other:

- **Equal** — identical node-id sequences. Skip; nothing to refresh.
- **RemoteAhead** — local is a strict prefix of remote. Fast-forward: refresh local from remote via `localize_bundle`.
- **LocalAhead** — remote is a strict prefix of local. Local has work the remote has not seen; keep local silently (a later push reconciles the remote).
- **Diverged** — neither sequence is a prefix of the other. Keep local and emit a clear per-bundle warning rather than overwriting work.

Applied consistently in both the single-bundle pull path (`pull_bundle_remote_state`, used by `knit pull --bundles`) and the aggregate fetch path (`fetch_bundles_from_remote`, used by `knit fetch --bundles`). `knit clone` is unaffected since it writes into a fresh workspace with no local artifacts.

### Tests

`ledger_relation` is unit-tested for all four relations (including empty-ledger edge cases) in `tests/model.rs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)