### PR TITLE
land rollback on failure v2 (knit)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -418,7 +418,7 @@ dependencies = [
 
 [[package]]
 name = "knit-cli"
-version = "0.1.0"
+version = "0.1.0-alpha.1"
 dependencies = [
  "anyhow",
  "chrono",

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ knit land               # creates/shows the landing plan (does not merge)
 knit land apply         # merges each PR into its base, then runs any deploy steps
 ```
 
-`knit land` is safe on its own: it only creates or shows the plan. Nothing merges until `knit land apply`.
+`knit land` is safe on its own: it only creates or shows the plan. Nothing merges until `knit land apply`. If a landing fails halfway, `knit land resume` continues it, and `knit land rollback --apply` opens revert PRs for the steps that already merged (or set `onFailure: "rollback"` in the landing template to do that automatically).
 
 **Local-only, no code host** — integrate the bundle's feature branches into a target branch directly:
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -97,6 +97,7 @@ knit land check
 knit land update [--push] [--continue-merge] [repo-id-or-path...]
 knit land apply [--plan <path>] [--remote <remote>]... [--no-remote]
 knit land resume [--run <path>] [--remote <remote>]... [--no-remote]
+knit land rollback [--run <path>] [--apply]
 knit land status [--run <path>]
 knit merge <source-bundle-or-ref> --into <target-branch-or-bundle> [--fetch] [--push] [--set-upstream] [--manual]
 knit merge status [--run <id-or-path>]
@@ -220,6 +221,7 @@ Projects can define a default landing template. `knit land plan` expands it into
 {
   "landing": {
     "provider": "github",
+    "onFailure": "rollback",
     "merge": {
       "repoOrder": ["schema-store", "scrapers", "backend", "engine", "frontend"],
       "method": "merge",
@@ -517,6 +519,7 @@ knit land update --push
 knit land apply
 knit land status
 knit land resume
+knit land rollback
 ```
 
 `knit land check` is a read-only preflight: it fetches each recorded PR once and prints a readiness table (state, mergeable, checks, review decision, and a verdict) so you can see whether `knit land apply` will succeed and why not. A `conflict` verdict points you at `knit land update`; an already-merged PR shows `already landed`. `knit publish status --live` shows the same live columns alongside the recorded review objects. Both are non-mutating.
@@ -527,7 +530,9 @@ Bare `knit land` is safe: it creates or shows the default plan and stops. It nev
 
 `knit land update` prepares published PR branches for landing by fetching each PR's base branch, merging that base into the feature checkout, and recording the movement as a first-class `land.update` bundle node. This is the preferred way to resolve routine "base moved" landing conflicts because the integration merge is attributed to landing prep instead of appearing later as an incidental `git.observed` movement. Pass `--push` to push the updated feature branches after recording the node. If a merge conflicts, resolve and commit it in the feature checkout, then run `knit land update --continue-merge` to record the already-resolved movement as `land.update`.
 
-`knit land apply` preflights referenced PRs, refuses draft/closed/missing PRs, writes a durable run file under `.knit/land-runs/`, then executes the plan step by step. Already-merged PRs are treated as satisfied and skipped (whether or not a prior run exists), and an open PR that conflicts with its base is rejected with guidance to run `knit land update` first. `deploy` steps support `deploymentMode: "command"` for real deployment commands and `deploymentMode: "push"` for deployments that are triggered by the PR merge itself. A command deployment can specify a `checkout` branch; Knit creates or refreshes a managed detached checkout under `.knit/land-worktrees/` before running the command. If a step fails, the run stops and records the exact step status, stdout/stderr for `run` and command `deploy` steps, and failure detail. `knit land resume` continues that run from pending or failed steps only; succeeded steps are not repeated. A fully successful run appends a `feature.landed` node to the bundle with the plan id, run id, provider, repo ids, and publication URLs, then syncs the updated bundle artifact to configured KnitHub remotes when push-sync is enabled. Use repeated `--remote <name>` to force remotes, `--no-remote` to skip this sync, or `knit sync push --bundles` to push the landed artifact later.
+`knit land apply` preflights referenced PRs, refuses draft/closed/missing PRs, writes a durable run file under `.knit/land-runs/`, then executes the plan step by step. Already-merged PRs are treated as satisfied and skipped (whether or not a prior run exists), and an open PR that conflicts with its base is rejected with guidance to run `knit land update` first. `deploy` steps support `deploymentMode: "command"` for real deployment commands and `deploymentMode: "push"` for deployments that are triggered by the PR merge itself. A command deployment can specify a `checkout` branch; Knit creates or refreshes a managed detached checkout under `.knit/land-worktrees/` before running the command. If a step fails, the run stops and records the exact step status, stdout/stderr for `run` and command `deploy` steps, and failure detail. `knit land resume` continues that run from pending or failed steps only; succeeded steps are not repeated.
+
+A failed run can leave some PRs merged and others not — merged PRs cannot be un-merged, so Knit offers compensation instead of reset. `knit land rollback` previews the merge steps the failed run completed (verifying each PR is live-MERGED), and `knit land rollback --apply` opens a provider-side revert PR for each of them, records a `pr.revert` node targeting the run, and marks the run rolled back so `knit land resume` refuses to continue it. Setting `onFailure: "rollback"` in the land plan (or in the project landing template, which `knit land plan` copies into generated plans) makes `knit land apply` perform this rollback automatically when a step fails; the default `onFailure: "resume"` keeps today's stop-and-resume behavior. A fully successful run appends a `feature.landed` node to the bundle with the plan id, run id, provider, repo ids, and publication URLs, then syncs the updated bundle artifact to configured KnitHub remotes when push-sync is enabled. Use repeated `--remote <name>` to force remotes, `--no-remote` to skip this sync, or `knit sync push --bundles` to push the landed artifact later.
 
 `knit merge` is for local branch integration that is not a PR landing. It can merge a bundle or git ref into a target branch, or into another bundle's feature branches:
 
@@ -649,7 +654,7 @@ Sparse advice is enabled by default for new workspaces. It prints a `Next:` line
 - `knit push` pushes feature branches to `origin` and, when KnitHub sync remotes are configured and `push-sync` is enabled, the bundle artifact to those remotes; use `knit publish create` to publish review objects.
 - `knit publish` detects the host from each repo's remote: GitLab uses `glab`, Codeberg/Forgejo uses `tea`, and every other remote defaults to GitHub's `gh`. The matching CLI must be installed and authenticated. Bitbucket and other hosts would need new adapters. The GitLab and Forgejo adapters target current `glab`/`tea` JSON; their field mapping may need tuning across CLI versions, and `tea` does not surface commit-status checks, so landing treats Forgejo PRs as having no required checks.
 - `knit publish create` is not perfectly transactional. Branch pushes, review creation, and body updates happen sequentially. If phase two fails after review objects are created, run `knit publish sync`.
-- `knit land` resolves the host adapter per repo from its remote. A merge lands into the recorded base branch. Remote merges cannot be automatically unmerged by Knit, so failed land runs are recorded in `.knit/land-runs/`; fix the failed step and use `knit land resume`.
+- `knit land` resolves the host adapter per repo from its remote. A merge lands into the recorded base branch. Remote merges cannot be automatically unmerged by Knit, so failed land runs are recorded in `.knit/land-runs/`; fix the failed step and use `knit land resume`, or use `knit land rollback` to open revert PRs for the steps that already merged.
 - `knit land plan` never executes local commands. `run` steps execute only during `apply` or `resume`.
 - `knit clean --worktrees` removes generated worktree directories only. It leaves source repos and feature branches in place. `knit bundle delete --worktrees --branches --force-branches` is the explicit local discard path for a bundle's generated worktrees and local feature branches.
 - `knit commit` only looks for staged changes inside tracked checkouts.

--- a/schemas/land-plan.schema.json
+++ b/schemas/land-plan.schema.json
@@ -10,6 +10,7 @@
     "bundleId": { "type": "string" },
     "sourceProjectId": { "type": "string" },
     "createdAt": { "type": "string" },
+    "onFailure": { "enum": ["resume", "rollback"], "default": "resume" },
     "steps": {
       "type": "array",
       "minItems": 1,

--- a/schemas/land-run.schema.json
+++ b/schemas/land-run.schema.json
@@ -7,6 +7,7 @@
     "schemaVersion": { "const": "0.1" },
     "kind": { "const": "KnitLandRun" },
     "status": { "type": "string" },
+    "rolledBackAt": { "type": "string" },
     "steps": { "type": "array" }
   }
 }

--- a/schemas/project.schema.json
+++ b/schemas/project.schema.json
@@ -79,6 +79,7 @@
       "type": "object",
       "properties": {
         "provider": { "enum": ["github"] },
+        "onFailure": { "enum": ["resume", "rollback"], "default": "resume" },
         "merge": {
           "type": "object",
           "properties": {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1011,6 +1011,15 @@ pub enum LandCommand {
         #[arg(long, conflicts_with = "remote")]
         no_remote: bool,
     },
+    /// Create revert PRs for the merge steps a failed landing run completed.
+    Rollback {
+        /// Run file to roll back. Defaults to the latest run.
+        #[arg(long)]
+        run: Option<PathBuf>,
+        /// Create the revert PRs. Without this flag the rollback is only previewed.
+        #[arg(long)]
+        apply: bool,
+    },
     /// Resume a failed or incomplete landing run.
     Resume {
         /// Run file to resume. Defaults to the latest run.

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -601,6 +601,7 @@ knit cherrypick --from feature-a --repo backend abc123
 - `knit merge <bundle> --into <branch-or-bundle> --manual` leaves conflicts for manual resolution, followed by `knit merge --continue` or `knit merge --abort`.
 - `knit land` creates or shows the landing plan; `knit land apply` executes it.
 - `knit land check` previews each recorded PR's live landing readiness (state, mergeable, checks, review, verdict) without mutating anything; `knit publish status --live` shows the same columns.
+- `knit land resume` continues a failed run; `knit land rollback [--apply]` previews/creates revert PRs for the merge steps a failed run already completed. A landing template or plan can set `onFailure: "rollback"` to do this automatically.
 - `knit doctor` checks workspace JSON, stale locks, and missing paths.
 - `knit migrate --check` reports additive JSON migrations; `knit migrate` applies them.
 - `knit config set advice false` disables sparse `Next:` advice.

--- a/src/commands/land/execute.rs
+++ b/src/commands/land/execute.rs
@@ -193,12 +193,29 @@ pub(super) fn execute_run(
             } else {
                 "steps"
             };
-            bail!(
-                "Land run {} stopped at {} {}. Fix the issue and run `knit land resume`.",
+            let stopped = format!(
+                "Land run {} stopped at {} {}.",
                 run.id,
                 label,
                 failed_ids.join(", ")
             );
+
+            if plan.on_failure == Some(crate::model::LandOnFailure::Rollback) {
+                println!(
+                    "{} creating revert PRs for already-merged steps (onFailure: rollback)",
+                    out::movement("rolling back")
+                );
+                match super::rollback::rollback_merged_steps(active, run, run_path) {
+                    Ok(Some(group_id)) => bail!(
+                        "{stopped} Rolled back: revert group {group_id} opened revert PRs for the merged steps."
+                    ),
+                    Ok(None) => bail!("{stopped} No PRs had merged yet; nothing to roll back."),
+                    Err(error) => bail!(
+                        "{stopped} Automatic rollback failed: {error:#}. Run `knit land rollback` to retry it."
+                    ),
+                };
+            }
+            bail!("{stopped} Fix the issue and run `knit land resume`, or run `knit land rollback` to revert the steps that already merged.");
         }
     }
 
@@ -679,6 +696,7 @@ pub(super) fn new_run(active: &ActiveBundle, plan: &LandPlan, plan_path: &Path) 
         status: LandStatus::Running,
         created_at: now.clone(),
         updated_at: now,
+        rolled_back_at: None,
         steps: plan
             .steps
             .iter()

--- a/src/commands/land/mod.rs
+++ b/src/commands/land/mod.rs
@@ -8,6 +8,7 @@
 //! - [`check`] live landing-readiness preflight (`knit land check`)
 //! - [`validate`] validates a plan and preflights its PRs
 //! - [`execute`] schedules and runs the plan, recording progress
+//! - [`rollback`] creates revert PRs for a failed run's merged steps
 //! - [`update`] implements `knit land update` (merge base into feature branches)
 //! - [`display`] renders plans, run status, and PR/check state
 
@@ -16,6 +17,7 @@ mod check;
 mod display;
 mod execute;
 mod plan;
+mod rollback;
 mod types;
 mod update;
 mod validate;
@@ -23,6 +25,7 @@ mod validate;
 pub use artifact::apply_land_from_artifact;
 pub use check::check_landing;
 pub(crate) use check::{assess_landing_readiness, print_readiness_row};
+pub use rollback::rollback_land_run;
 
 use crate::advice;
 use crate::checkout::{checkout_dir, ensure_expected_branch};
@@ -77,9 +80,16 @@ pub fn land_default() -> Result<()> {
         if run.status == LandStatus::Succeeded {
             return Ok(());
         }
+        if run.rolled_back_at.is_some() {
+            advice::print(
+                &active.root,
+                "this run was rolled back; its merged PRs have open revert PRs. Land those reverts or start over with `knit land apply` once the bundle is ready again.",
+            );
+            return Ok(());
+        }
         advice::print(
             &active.root,
-            "fix the failed or incomplete step, then run `knit land resume` when you are ready to continue execution.",
+            "fix the failed or incomplete step, then run `knit land resume` when you are ready to continue execution. Use `knit land rollback` to revert the steps that already merged instead.",
         );
         return Ok(());
     }
@@ -138,6 +148,12 @@ pub fn resume_land_run(run_path: Option<&Path>, remote: &[String], no_remote: bo
             out::node(&run.id)
         );
         return Ok(());
+    }
+    if let Some(rolled_back_at) = &run.rolled_back_at {
+        bail!(
+            "Land run {} was rolled back at {rolled_back_at}; its merged PRs have revert PRs. Run `knit land apply` to start a new landing instead.",
+            run.id
+        );
     }
     let plan_path = resolve_stored_path(&active.root, &run.plan_path);
     let plan: LandPlan = read_json(&plan_path)?;
@@ -455,6 +471,7 @@ mod tests {
             status: LandStatus::Running,
             created_at: now_iso(),
             updated_at: now_iso(),
+            rolled_back_at: None,
             steps: vec![LandRunStep {
                 id: "a".to_string(),
                 step_type: LandStepKind::Run,
@@ -594,6 +611,7 @@ mod tests {
             status: LandStatus::Succeeded,
             created_at: now_iso(),
             updated_at: now_iso(),
+            rolled_back_at: None,
             steps: Vec::new(),
         };
         let text = serde_json::to_string_pretty(&run).unwrap();

--- a/src/commands/land/plan.rs
+++ b/src/commands/land/plan.rs
@@ -84,8 +84,9 @@ pub(super) fn build_default_plan(
         id: format!("land-{}", active.bundle.id),
         provider,
         bundle_id: active.bundle.id.clone(),
-        source_project_id: project.map(|project| project.id),
+        source_project_id: project.as_ref().map(|project| project.id.clone()),
         created_at: now_iso(),
+        on_failure: landing.and_then(|landing| landing.on_failure),
         steps,
     })
 }

--- a/src/commands/land/rollback.rs
+++ b/src/commands/land/rollback.rs
@@ -1,0 +1,168 @@
+//! `knit land rollback` — compensate a failed landing run.
+//!
+//! A land run that fails halfway can leave an arbitrary subset of PRs merged
+//! into their base branches. Merged PRs cannot be un-merged, so rollback is
+//! compensation, not reset: for every merge step the failed run completed,
+//! create a provider-side revert PR (reusing the `knit revert` machinery) and
+//! record a `pr.revert` ledger node targeting the run. The run is then marked
+//! rolled back so `knit land resume` refuses to continue it.
+
+use super::{resolve_land_run_path, LandRun, LandStatus, LandStepKind};
+use crate::commands::revert::{create_provider_revert_prs, provider_revert_context};
+use crate::output as out;
+use crate::store::{
+    load_active_bundle, load_active_bundle_for_update, read_json, write_json, ActiveBundle,
+};
+use crate::time::now_iso;
+use anyhow::{bail, Context, Result};
+use std::path::Path;
+
+pub fn rollback_land_run(run_path: Option<&Path>, apply: bool) -> Result<()> {
+    let mut active = if apply {
+        load_active_bundle_for_update()?
+    } else {
+        load_active_bundle()?
+    };
+    let path = resolve_land_run_path(&active, run_path)?
+        .with_context(|| "No land run found. Run `knit land apply` first.")?;
+    let mut run: LandRun = read_json(&path)?;
+    if run.bundle_id != active.bundle.id {
+        bail!(
+            "Land run {} belongs to bundle {}, but resolved bundle is {}.",
+            run.id,
+            run.bundle_id,
+            active.bundle.id
+        );
+    }
+    if let Some(rolled_back_at) = &run.rolled_back_at {
+        bail!(
+            "Land run {} was already rolled back at {rolled_back_at}.",
+            run.id
+        );
+    }
+    match run.status {
+        LandStatus::Failed => {}
+        LandStatus::Succeeded => bail!(
+            "Land run {} succeeded. Use `knit revert <landed-node> --apply` to revert a fully landed bundle.",
+            run.id
+        ),
+        status => bail!(
+            "Land run {} is {status}, expected failed. Only failed runs can be rolled back.",
+            run.id
+        ),
+    }
+
+    let merged = merged_steps(&run);
+    if merged.is_empty() {
+        bail!(
+            "Land run {} merged no PRs before failing; there is nothing to roll back. Fix the issue and run `knit land resume`.",
+            run.id
+        );
+    }
+
+    println!(
+        "{} {} {}",
+        out::heading("Land rollback"),
+        out::node(&run.id),
+        out::muted(format!("({} merged PR(s))", merged.len()))
+    );
+    println!(
+        "{} {}",
+        out::heading("Run file:"),
+        out::path(path.display())
+    );
+    println!("{} {}", out::heading("Provider:"), run.provider);
+    println!();
+
+    preflight_merged(&active, &run, &merged)?;
+
+    if !apply {
+        println!();
+        println!(
+            "{} knit land rollback --apply",
+            out::heading("Create revert PRs:")
+        );
+        return Ok(());
+    }
+
+    let group_id = rollback_merged_steps(&mut active, &mut run, &path)?
+        .expect("merged steps were checked to be non-empty");
+    println!(
+        "{} {} {}",
+        out::heading("Rolled back"),
+        out::node(&run.id),
+        out::muted(format!("revert group {group_id}"))
+    );
+    Ok(())
+}
+
+/// Create revert PRs for every merge step the run completed, then mark the
+/// run rolled back. Returns the revert group id, or `None` when the run had
+/// no merged steps. Shared by `knit land rollback --apply` and the
+/// `onFailure: rollback` path in the executor.
+pub(super) fn rollback_merged_steps(
+    active: &mut ActiveBundle,
+    run: &mut LandRun,
+    run_path: &Path,
+) -> Result<Option<String>> {
+    let merged = merged_steps(run);
+    if merged.is_empty() {
+        return Ok(None);
+    }
+
+    let group_id = create_provider_revert_prs(
+        active,
+        Some(&run.provider),
+        &run.id,
+        &format!("failed land run {}", run.id),
+        &merged,
+    )?;
+    run.rolled_back_at = Some(now_iso());
+    run.updated_at = now_iso();
+    write_json(run_path, run)?;
+    Ok(Some(group_id))
+}
+
+/// The `(repo id, PR url)` pairs for every merge step the run completed. A
+/// succeeded merge step always records its publication URL.
+fn merged_steps(run: &LandRun) -> Vec<(String, String)> {
+    run.steps
+        .iter()
+        .filter(|step| {
+            step.step_type == LandStepKind::MergePr && step.status == LandStatus::Succeeded
+        })
+        .filter_map(|step| Some((step.repo_id.clone()?, step.publication_url.clone()?)))
+        .collect()
+}
+
+/// Verify each recorded merge actually shows as MERGED on the provider and
+/// print its live state, so the preview reflects reality and apply fails
+/// before creating any revert PR.
+fn preflight_merged(
+    active: &ActiveBundle,
+    run: &LandRun,
+    merged: &[(String, String)],
+) -> Result<()> {
+    for (repo_id, url) in merged {
+        let (_, target, forge) = provider_revert_context(active, Some(&run.provider), repo_id)?;
+        let pr = forge
+            .view(&target, url)
+            .with_context(|| format!("{repo_id}: failed to load {url}"))?;
+        let state = pr.state.as_deref().unwrap_or("UNKNOWN");
+        println!(
+            "{} {} #{} {} {}",
+            out::repo(repo_id),
+            out::movement("prRevert"),
+            pr.number,
+            out::status(state),
+            out::muted(url)
+        );
+        if state != "MERGED" {
+            bail!(
+                "{repo_id}: PR #{} is {state}, expected MERGED. The run recorded this merge as succeeded; refresh with `knit land status` and retry.",
+                pr.number
+            );
+        }
+    }
+    Ok(())
+}

--- a/src/commands/land/types.rs
+++ b/src/commands/land/types.rs
@@ -76,6 +76,11 @@ pub(super) struct LandPlan {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(super) source_project_id: Option<String>,
     pub(super) created_at: String,
+    /// What `knit land apply` does when a step fails: stop and wait for
+    /// `knit land resume` (default), or create revert PRs for the merge steps
+    /// that already landed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) on_failure: Option<crate::model::LandOnFailure>,
     pub(super) steps: Vec<LandStep>,
 }
 
@@ -138,6 +143,10 @@ pub(super) struct LandRun {
     pub(super) status: LandStatus,
     pub(super) created_at: String,
     pub(super) updated_at: String,
+    /// Set when `knit land rollback` (or `onFailure: rollback`) created revert
+    /// PRs for this run's merged steps. A rolled-back run cannot be resumed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(super) rolled_back_at: Option<String>,
     pub(super) steps: Vec<LandRunStep>,
 }
 

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -47,7 +47,7 @@ pub use history::{refresh_history, show_history, show_related_history};
 pub use init::{init_bundle, start_bundle};
 pub use land::{
     apply_land_from_artifact, apply_land_plan, check_landing, generate_land_plan, land_default,
-    resume_land_run, show_land_status, update_land_branches,
+    resume_land_run, rollback_land_run, show_land_status, update_land_branches,
 };
 pub use log::{show_log, show_target};
 pub use merge::merge_command;

--- a/src/commands/revert/apply.rs
+++ b/src/commands/revert/apply.rs
@@ -129,63 +129,79 @@ pub(super) fn apply_provider_revert(
     plan: &RevertPlan,
     path: PathBuf,
 ) -> Result<()> {
+    let mut items = Vec::new();
+    for repo_plan in &plan.repos {
+        for operation in &repo_plan.operations {
+            let selector = operation_selector(operation)?;
+            items.push((repo_plan.repo_id.clone(), selector.to_string()));
+        }
+    }
+
+    create_provider_revert_prs(
+        active,
+        plan.provider.as_deref(),
+        &plan.target_node_id,
+        &plan.target_message,
+        &items,
+    )?;
+    let _ = fs::remove_file(path);
+    Ok(())
+}
+
+/// Create provider-side revert PRs for a group of merged PRs and record the
+/// `pr.revert` ledger node. `items` pairs each repo id with the merged PR's
+/// selector (URL). Shared by `knit revert --apply` (landed nodes) and
+/// `knit land rollback` (half-failed land runs). Returns the revert group id.
+pub(crate) fn create_provider_revert_prs(
+    active: &mut ActiveBundle,
+    provider: Option<&str>,
+    target_node_id: &str,
+    target_message: &str,
+    items: &[(String, String)],
+) -> Result<String> {
     let group_id = revert_group_id();
     let created_at = now_iso();
-    let logical_message = format!("Revert {}", plan.target_message);
+    let logical_message = format!("Revert {target_message}");
     let mut repo_ids = BTreeSet::new();
     let mut publication_urls = BTreeSet::new();
     let mut failures = Vec::new();
 
-    for repo_plan in &plan.repos {
-        let (repo_index, target, forge) = provider_context(active, plan, &repo_plan.repo_id)?;
+    for (repo_id, selector) in items {
+        let (repo_index, target, forge) = provider_revert_context(active, provider, repo_id)?;
         let repo = active.bundle.repos[repo_index].clone();
 
-        for operation in &repo_plan.operations {
-            let selector = match operation_selector(operation) {
-                Ok(selector) => selector,
-                Err(error) => {
-                    failures.push(format!("{}: {error:#}", repo_plan.repo_id));
-                    continue;
-                }
-            };
-            let title = format!("Revert {} ({})", active.bundle.title, repo_plan.repo_id);
-            let body = format!(
-                "Reverts {selector}\n\nKnit-Reverts: {}\nKnit-Group: {group_id}\nKnit-Bundle: {}",
-                plan.target_node_id, active.bundle.id
-            );
-            match forge.revert_pull_request(&target, selector, &title, &body) {
-                Ok(url) => {
-                    let summary = forge.view(&target, &url).unwrap_or_else(|_| PullRequest {
-                        number: pr_number_from_url(&url).unwrap_or(0),
-                        url: url.clone(),
-                        state: Some("OPEN".to_string()),
-                        title: Some(title.clone()),
-                        base_ref_name: Some(repo.base_branch.clone()),
-                        head_ref_name: None,
-                        body: None,
-                        is_draft: None,
-                        head_ref_oid: None,
-                        mergeable: None,
-                        merge_state_status: None,
-                        review_decision: None,
-                    });
-                    providers::upsert_publication(
-                        &mut active.bundle,
-                        &repo,
-                        forge.as_ref(),
-                        &summary,
-                    );
-                    repo_ids.insert(repo_plan.repo_id.clone());
-                    publication_urls.insert(summary.url.clone());
-                    println!(
-                        "{}: {} {}",
-                        out::repo(&repo_plan.repo_id),
-                        out::movement("revert PR"),
-                        summary.url
-                    );
-                }
-                Err(error) => failures.push(format!("{}: {error:#}", repo_plan.repo_id)),
+        let title = format!("Revert {} ({})", active.bundle.title, repo_id);
+        let body = format!(
+            "Reverts {selector}\n\nKnit-Reverts: {target_node_id}\nKnit-Group: {group_id}\nKnit-Bundle: {}",
+            active.bundle.id
+        );
+        match forge.revert_pull_request(&target, selector, &title, &body) {
+            Ok(url) => {
+                let summary = forge.view(&target, &url).unwrap_or_else(|_| PullRequest {
+                    number: pr_number_from_url(&url).unwrap_or(0),
+                    url: url.clone(),
+                    state: Some("OPEN".to_string()),
+                    title: Some(title.clone()),
+                    base_ref_name: Some(repo.base_branch.clone()),
+                    head_ref_name: None,
+                    body: None,
+                    is_draft: None,
+                    head_ref_oid: None,
+                    mergeable: None,
+                    merge_state_status: None,
+                    review_decision: None,
+                });
+                providers::upsert_publication(&mut active.bundle, &repo, forge.as_ref(), &summary);
+                repo_ids.insert(repo_id.clone());
+                publication_urls.insert(summary.url.clone());
+                println!(
+                    "{}: {} {}",
+                    out::repo(repo_id),
+                    out::movement("revert PR"),
+                    summary.url
+                );
             }
+            Err(error) => failures.push(format!("{repo_id}: {error:#}")),
         }
     }
 
@@ -200,14 +216,11 @@ pub(super) fn apply_provider_revert(
         bail!("PR revert produced no review objects.");
     }
 
-    let provider = plan
-        .provider
-        .clone()
-        .unwrap_or_else(|| "provider".to_string());
+    let provider = provider.unwrap_or("provider").to_string();
     active.bundle.nodes.push(BundleNode::pr_revert(
         group_id.clone(),
         created_at,
-        plan.target_node_id.clone(),
+        target_node_id.to_string(),
         logical_message,
         provider,
         repo_ids.into_iter().collect(),
@@ -216,14 +229,13 @@ pub(super) fn apply_provider_revert(
     active.bundle.head_node_id = active.bundle.nodes.last().map(|node| node.id.clone());
     active.bundle.updated_at = now_iso();
     save_active_bundle(active)?;
-    let _ = fs::remove_file(path);
 
     println!(
         "{} {}",
         out::heading("Recorded PR revert group"),
-        out::node(group_id)
+        out::node(&group_id)
     );
-    Ok(())
+    Ok(group_id)
 }
 
 pub(super) fn preflight_plan(active: &ActiveBundle, plan: &RevertPlan) -> Result<()> {
@@ -314,7 +326,8 @@ fn preflight_provider_revert(
         );
     }
 
-    let (_, target, forge) = provider_context(active, plan, &repo_plan.repo_id)?;
+    let (_, target, forge) =
+        provider_revert_context(active, plan.provider.as_deref(), &repo_plan.repo_id)?;
     for operation in &repo_plan.operations {
         let selector = operation_selector(operation)?;
         let pr = forge
@@ -397,9 +410,11 @@ pub(super) fn plan_uses_provider_revert(plan: &RevertPlan) -> bool {
     })
 }
 
-fn provider_context(
+/// Resolve the forge and PR target for provider-side operations on a repo,
+/// preferring an explicit provider id over per-repo remote detection.
+pub(crate) fn provider_revert_context(
     active: &ActiveBundle,
-    plan: &RevertPlan,
+    provider: Option<&str>,
     repo_id: &str,
 ) -> Result<(usize, PrTarget, Box<dyn providers::Forge>)> {
     let (index, repo) = active
@@ -409,7 +424,7 @@ fn provider_context(
         .enumerate()
         .find(|(_, repo)| repo.id == repo_id)
         .with_context(|| format!("{repo_id}: repo is no longer tracked in this bundle"))?;
-    let forge = match plan.provider.as_deref() {
+    let forge = match provider {
         Some(provider) => providers::by_id(provider)
             .with_context(|| format!("{repo_id}: unknown provider `{provider}`"))?,
         None => providers::for_repo(repo)?,

--- a/src/commands/revert/mod.rs
+++ b/src/commands/revert/mod.rs
@@ -18,6 +18,8 @@ use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::PathBuf;
 
+pub(crate) use apply::{create_provider_revert_prs, provider_revert_context};
+
 use apply::{apply_local_revert, apply_provider_revert, plan_uses_provider_revert, preflight_plan};
 use plan::build_plan;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -401,6 +401,9 @@ pub fn run(cli: Cli) -> Result<()> {
                 Some(path) => commands::apply_land_from_artifact(&path, out.as_deref()),
                 None => commands::apply_land_plan(plan.as_deref(), &remote, no_remote),
             },
+            Some(LandCommand::Rollback { run, apply }) => {
+                commands::rollback_land_run(run.as_deref(), apply)
+            }
             Some(LandCommand::Resume {
                 run,
                 remote,

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -72,6 +72,32 @@ impl std::fmt::Display for DeployMode {
     }
 }
 
+/// What `knit land apply` does when a step fails: stop so the run can be
+/// resumed (default), or create revert PRs for the merge steps that already
+/// landed. Shared by project landing templates and land plans.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum LandOnFailure {
+    #[default]
+    Resume,
+    Rollback,
+}
+
+impl LandOnFailure {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            LandOnFailure::Resume => "resume",
+            LandOnFailure::Rollback => "rollback",
+        }
+    }
+}
+
+impl std::fmt::Display for LandOnFailure {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter.pad(self.as_str())
+    }
+}
+
 /// How a deploy checkout is refreshed before deploying.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "lowercase")]

--- a/src/model/project.rs
+++ b/src/model/project.rs
@@ -268,6 +268,11 @@ impl Default for ProjectRuntimePorts {
 pub struct ProjectLandingPlan {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub provider: Option<String>,
+    /// What `knit land apply` does when a step fails: `resume` (default) stops
+    /// and waits for `knit land resume`; `rollback` creates revert PRs for the
+    /// merge steps that already landed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub on_failure: Option<super::LandOnFailure>,
     #[serde(default)]
     pub merge: ProjectLandingMergePlan,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]

--- a/tests/land.rs
+++ b/tests/land.rs
@@ -3,6 +3,7 @@ mod common;
 use common::*;
 use serde_json::{json, Value};
 use std::fs;
+use std::path::Path;
 
 #[test]
 fn artifact_land_apply_can_use_native_ipv4_transport() {
@@ -622,6 +623,148 @@ fn land_resume_skips_succeeded_steps_and_retries_failed_run_steps() {
     let status = knit_with_fake_gh(&workspace, ["land", "status"], &fake_bin, &fake_gh_dir);
     assert!(status.contains("succeeded"));
     assert!(status.contains("deploy"));
+
+    fs::remove_dir_all(root).unwrap();
+}
+
+/// Make the venue-capacity plan land sequentially with a failing gate between
+/// the two merges: merge-backend, then a `run` step that fails, then
+/// merge-frontend. Applying it merges backend only and leaves a failed run.
+fn write_half_failing_plan(workspace: &Path, on_failure: Option<&str>) {
+    let plan_path = workspace.join(".knit/land-plans/venue-capacity.land.json");
+    let mut plan: Value = serde_json::from_str(&fs::read_to_string(&plan_path).unwrap()).unwrap();
+    if let Some(on_failure) = on_failure {
+        plan["onFailure"] = json!(on_failure);
+    }
+    let steps = plan["steps"].as_array_mut().unwrap();
+    for step in steps.iter_mut() {
+        if step["id"].as_str() == Some("merge-frontend") {
+            step["needs"] = json!(["gate"]);
+        }
+    }
+    steps.push(json!({
+        "id": "gate",
+        "type": "run",
+        "cwd": ".",
+        "command": ["sh", "-c", "false"],
+        "needs": ["merge-backend"]
+    }));
+    fs::write(&plan_path, serde_json::to_string_pretty(&plan).unwrap()).unwrap();
+}
+
+fn latest_land_run(workspace: &Path) -> (std::path::PathBuf, Value) {
+    let run_dir = workspace.join(".knit/land-runs");
+    let mut paths: Vec<_> = fs::read_dir(&run_dir)
+        .unwrap()
+        .filter_map(|entry| entry.ok().map(|entry| entry.path()))
+        .collect();
+    paths.sort();
+    let path = paths.pop().unwrap();
+    let run: Value = serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
+    (path, run)
+}
+
+#[test]
+fn land_rollback_creates_revert_prs_for_merged_steps_of_failed_run() {
+    let root = unique_temp_dir();
+    let (workspace, fake_bin, fake_gh_dir) = publish_two_repo_bundle(&root);
+    knit_with_fake_gh(&workspace, ["land", "plan"], &fake_bin, &fake_gh_dir);
+    write_half_failing_plan(&workspace, None);
+
+    let failed = knit_fails_with_fake_gh(
+        &workspace,
+        ["land", "apply", "--no-remote"],
+        &fake_bin,
+        &fake_gh_dir,
+    );
+    assert!(failed.contains("stopped at step gate"), "{failed}");
+    assert!(failed.contains("knit land rollback"), "{failed}");
+    // backend merged before the gate failed; frontend never merged.
+    let order = fs::read_to_string(fake_gh_dir.join("merge-order.txt")).unwrap();
+    assert_eq!(order.lines().collect::<Vec<_>>(), vec!["backend"]);
+    let (_, run) = latest_land_run(&workspace);
+    let run_id = run["id"].as_str().unwrap().to_string();
+    assert_eq!(run["status"].as_str(), Some("failed"));
+
+    // Preview shows the merged step and creates nothing.
+    let preview = knit_with_fake_gh(&workspace, ["land", "rollback"], &fake_bin, &fake_gh_dir);
+    assert!(preview.contains("Land rollback"), "{preview}");
+    assert!(
+        preview.contains("https://github.com/acme/backend/pull/101"),
+        "{preview}"
+    );
+    assert!(preview.contains("MERGED"), "{preview}");
+    assert!(preview.contains("knit land rollback --apply"), "{preview}");
+    assert!(!preview.contains("frontend"), "{preview}");
+    assert!(!fake_gh_dir.join("revert-order.txt").exists());
+
+    let applied = knit_with_fake_gh(
+        &workspace,
+        ["land", "rollback", "--apply"],
+        &fake_bin,
+        &fake_gh_dir,
+    );
+    assert!(applied.contains("Recorded PR revert group"), "{applied}");
+    assert!(applied.contains("Rolled back"), "{applied}");
+    // Only the merged backend PR is reverted.
+    let revert_order = fs::read_to_string(fake_gh_dir.join("revert-order.txt")).unwrap();
+    assert_eq!(revert_order.lines().collect::<Vec<_>>(), vec!["backend"]);
+
+    let bundle = read_bundle(&workspace);
+    let latest = bundle["nodes"].as_array().unwrap().last().unwrap();
+    assert_eq!(latest["type"].as_str(), Some("pr.revert"));
+    assert_eq!(latest["targetNodeId"].as_str(), Some(run_id.as_str()));
+    assert_eq!(latest["provider"].as_str(), Some("github"));
+    assert!(bundle["publications"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|publication| {
+            publication["repoId"].as_str() == Some("backend")
+                && publication["number"].as_u64() == Some(901)
+                && publication["state"].as_str() == Some("OPEN")
+        }));
+    assert!(knit(&workspace, ["bundle", "validate"]).contains("Bundle valid"));
+
+    let (_, run) = latest_land_run(&workspace);
+    assert!(run["rolledBackAt"].as_str().is_some());
+
+    // A rolled-back run can be neither resumed nor rolled back again.
+    let resume = knit_fails_with_fake_gh(&workspace, ["land", "resume"], &fake_bin, &fake_gh_dir);
+    assert!(resume.contains("was rolled back"), "{resume}");
+    let again = knit_fails_with_fake_gh(&workspace, ["land", "rollback"], &fake_bin, &fake_gh_dir);
+    assert!(again.contains("already rolled back"), "{again}");
+
+    fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
+fn land_apply_on_failure_rollback_reverts_merged_steps_automatically() {
+    let root = unique_temp_dir();
+    let (workspace, fake_bin, fake_gh_dir) = publish_two_repo_bundle(&root);
+    knit_with_fake_gh(&workspace, ["land", "plan"], &fake_bin, &fake_gh_dir);
+    write_half_failing_plan(&workspace, Some("rollback"));
+
+    let failed = knit_fails_with_fake_gh(
+        &workspace,
+        ["land", "apply", "--no-remote"],
+        &fake_bin,
+        &fake_gh_dir,
+    );
+    assert!(failed.contains("stopped at step gate"), "{failed}");
+    assert!(failed.contains("rolling back"), "{failed}");
+    assert!(failed.contains("revert group"), "{failed}");
+
+    let revert_order = fs::read_to_string(fake_gh_dir.join("revert-order.txt")).unwrap();
+    assert_eq!(revert_order.lines().collect::<Vec<_>>(), vec!["backend"]);
+    let bundle = read_bundle(&workspace);
+    let latest = bundle["nodes"].as_array().unwrap().last().unwrap();
+    assert_eq!(latest["type"].as_str(), Some("pr.revert"));
+    let (_, run) = latest_land_run(&workspace);
+    assert!(run["rolledBackAt"].as_str().is_some());
+
+    let resume = knit_fails_with_fake_gh(&workspace, ["land", "resume"], &fake_bin, &fake_gh_dir);
+    assert!(resume.contains("was rolled back"), "{resume}");
 
     fs::remove_dir_all(root).unwrap();
 }


### PR DESCRIPTION
Generated by Knit. Cross-links will be refreshed after all review objects are created.

<!-- BEGIN KNIT BUNDLE -->
## Knit Bundle

This PR is part of Knit bundle `land-rollback-on-failure-v2`.

See the other review objects in this bundle:
- `knit`: https://github.com/marc-merino/knit/pull/81 (this PR)

Bundle id: `land-rollback-on-failure-v2`
Bundle title: land rollback on failure v2
<!-- END KNIT BUNDLE -->