### PR TITLE
intel mac release runner (knit)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,8 +28,10 @@ jobs:
             os: ubuntu-latest
           - target: aarch64-unknown-linux-musl
             os: ubuntu-latest
+          # Intel macOS is cross-compiled from the arm64 runner; the macos-13
+          # (last Intel) runner pool was retired by GitHub.
           - target: x86_64-apple-darwin
-            os: macos-13
+            os: macos-latest
           - target: aarch64-apple-darwin
             os: macos-latest
           - target: x86_64-pc-windows-msvc

--- a/dist/README.md
+++ b/dist/README.md
@@ -34,7 +34,7 @@ Users install with `brew tap marc-merino/knit && brew install knit`. To release:
 #   - bump the `version` stanza in homebrew/knit.rb (URLs derive from it)
 #   - replace each sha256 with the matching .sha256 asset, e.g.:
 gh release view v0.1.0-alpha.2 --repo marc-merino/knit --json assets -q '.assets[].name'
-curl -sL https://github.com/marc-merino/knit/releases/download/v0.1.0-alpha.2/knit-v0.1.0-alpha.2-aarch64-apple-darwin.tar.gz.sha256
+curl -sL https://github.com/marc-merino/knit/releases/download/v0.1.0-alpha.2/knit-v0.1.0-alpha.2-aarch64-apple-darwin.sha256
 
 # Copy homebrew/knit.rb into the tap as Formula/knit.rb, commit, push:
 #   github.com/marc-merino/homebrew-knit


### PR DESCRIPTION
Generated by Knit. Cross-links will be refreshed after all review objects are created.

<!-- BEGIN KNIT BUNDLE -->
## Knit Bundle

This PR is part of Knit bundle `intel-mac-release-runner`.

See the other review objects in this bundle:
- `knit`: https://github.com/marc-merino/knit/pull/86 (this PR)

Bundle id: `intel-mac-release-runner`
Bundle title: intel mac release runner
<!-- END KNIT BUNDLE -->