### PR TITLE
prerelease install docs (knit)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ This walkthrough takes you from install to a landed multi-repo change in about t
 
 ```sh
 brew tap marc-merino/knit && brew install knit   # macOS / Linux binaries
-cargo install knit-cli        # from crates.io (the binary is named `knit`)
+cargo install knit-cli --version 0.1.0-alpha.1   # from crates.io (the binary is named `knit`;
+                                                 # cargo needs the explicit version while only pre-releases exist)
 # or from a checkout:
 cargo install --path .
 ```


### PR DESCRIPTION
Generated by Knit. Cross-links will be refreshed after all review objects are created.

<!-- BEGIN KNIT BUNDLE -->
## Knit Bundle

This PR is part of Knit bundle `prerelease-install-docs`.

See the other review objects in this bundle:
- `knit`: https://github.com/marc-merino/knit/pull/87 (this PR)

Bundle id: `prerelease-install-docs`
Bundle title: prerelease install docs
<!-- END KNIT BUNDLE -->