### PR TITLE
cli hint papercuts (knit)

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -350,7 +350,7 @@ Gloss should read this bundle and inspect the referenced repos, branches, and SH
 ```sh
 knit bundle archive feature-x --reason "merged"
 knit bundle archive feature-x --keep-worktrees   # ledger/state change only
-knit bundle restore feature-x                    # reopen; `knit worktree` rematerializes checkouts
+knit bundle restore feature-x                    # reopen; `knit bundle worktree` rematerializes checkouts
 ```
 
 Archiving refuses to discard dirty generated worktrees unless `--force` is passed.

--- a/src/commands/bundle/lifecycle.rs
+++ b/src/commands/bundle/lifecycle.rs
@@ -87,7 +87,7 @@ pub fn restore_bundle(bundle_id: &str) -> Result<()> {
     );
     crate::advice::print(
         &root,
-        format!("run `knit --bundle {bundle_id} worktree` to rematerialize its checkouts."),
+        format!("run `knit --bundle {bundle_id} bundle worktree` to rematerialize its checkouts."),
     );
     Ok(())
 }

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -235,7 +235,7 @@ fn ensure_no_remote_slug_collision(
     };
     match crate::commands::remote::remote_bundle_lifecycle(&config, &project_id, bundle_id) {
         Ok(Some(state)) => bail!(
-            "Bundle `{bundle_id}` already exists on the KnitHub sync remote for project `{project_id}` ({state}). Join the existing bundle with `knit fetch` and `knit --bundle {bundle_id} worktree`, pick another title, or pass --force to create a local bundle with the same id anyway."
+            "Bundle `{bundle_id}` already exists on the KnitHub sync remote for project `{project_id}` ({state}). Join the existing bundle with `knit fetch` and `knit --bundle {bundle_id} bundle worktree`, pick another title, or pass --force to create a local bundle with the same id anyway."
         ),
         // Offline, missing remote/token, or a server error must never block
         // local bundle creation; the push-time ledger gate still protects the
@@ -582,7 +582,7 @@ knit cherrypick --from feature-a --repo backend abc123
 - `knit bundle validate` checks the bundle artifact.
 - `knit bundle list` shows workspace bundles.
 - `knit bundle archive <bundle> [--reason "merged"]` marks a bundle done: it records an archive node and removes generated worktrees while preserving local feature branches (`--keep-worktrees` to leave them, `--force` to discard dirty checkouts).
-- `knit bundle restore <bundle>` reopens an archived bundle; run `knit worktree` afterwards to rematerialize checkouts.
+- `knit bundle restore <bundle>` reopens an archived bundle; run `knit bundle worktree` afterwards to rematerialize checkouts.
 - `knit bundle delete <bundle> --force` moves the bundle artifact to `.knit/deleted/bundles/` and preserves git state.
 - `knit bundle delete <bundle> --force --worktrees --branches --force-branches` discards generated worktrees and local feature branches for that bundle.
 - `knit bundle delete <bundle> --force --worktrees --branches --force-branches --remote-branches` also deletes the matching feature branches from `origin`.

--- a/src/commands/land/update.rs
+++ b/src/commands/land/update.rs
@@ -69,21 +69,28 @@ pub(super) fn run_branch_update(
                 }
                 Err(error) => {
                     bail!(
-                        "{}: failed to update from base: {error:#}\nResolve the merge in {}, commit it, then run `knit land update --continue-merge{}`.",
+                        "{}: failed to update from base: {error:#}\nResolve the merge in {}, commit it, then run `knit land update --continue-merge --push` so the host PR sees the resolution.",
                         target.repo_id,
-                        target.cwd.display(),
-                        if push { " --push" } else { "" }
+                        target.cwd.display()
                     );
                 }
             }
         }
     }
 
-    if !changes.is_empty() {
+    let recorded_updates = !changes.is_empty();
+    if recorded_updates {
         append_land_update_node(&mut active, changes)?;
         save_active_bundle(&active)?;
     } else {
         println!("{}", out::ok("No feature branches needed base updates."));
+    }
+
+    if !push && recorded_updates {
+        println!(
+            "{} updated branches are local only. Push them with `knit push` (or rerun with --push) before `knit land check`/`apply`, or the host PR will still show the old head.",
+            out::warn("Note:")
+        );
     }
 
     if push {


### PR DESCRIPTION
Generated by Knit. Cross-links will be refreshed after all review objects are created.

<!-- BEGIN KNIT BUNDLE -->
## Knit Bundle

This PR is part of Knit bundle `cli-hint-papercuts`.

See the other review objects in this bundle:
- `knit`: https://github.com/marc-merino/knit/pull/88 (this PR)

Bundle id: `cli-hint-papercuts`
Bundle title: cli hint papercuts
<!-- END KNIT BUNDLE -->