### PR TITLE
resilient remote pull (knit)

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ The [quickstart](docs/quickstart.md) walks this loop end to end with two toy rep
 - **Parallel by construction.** The same repo can sit in many bundles at once, each on its own branch and generated worktree. Run one coding agent per bundle — they cannot collide, and each worktree carries its own `AGENTS.md` so agents wake up oriented.
 - **An append-only ledger, not just branches.** Every bundle is a JSON artifact recording commits, observed changes, check verdicts, landings, and reverts. Other tools read it; nothing is locked in a database.
 - **Verdicts you can trust.** `knit check` pins pass/fail to the exact per-repo commits it ran against — a verdict goes stale the moment the bundle moves, and projects can require green-and-fresh checks before landing. With five agent bundles in flight, "which one is ready?" has a ledger answer, not a chat claim.
-- **Local-first, host optional.** Everything works against plain git repos. [KnitHub](https://knithub.dev) adds hosted dashboards, history sync, `knit clone` to rebuild a workspace anywhere, and [Gloss](https://github.com/marc-merino/gloss) cross-repo reviews on top of the same artifact.
+- **Local-first, host optional.** Everything works against plain git repos. A KnitHub deployment adds hosted dashboards, history sync, `knit clone` to rebuild a workspace anywhere, and [Gloss](https://github.com/marc-merino/gloss) cross-repo reviews on top of the same artifact.
 
 ## Concepts in one breath
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -131,7 +131,7 @@ This is consolidated into one verb family. `knit sync` keeps its original meanin
 - `knit sync push [--bundles|--history|--views|--all] [--remote <name>]...`
 - `knit sync pull [--bundles|--history|--views|--all] [--remote <name>]...`
 
-With no target flag, both move every relevant artifact family. Remote selection resolves explicit `--remote` overrides first, then configured sync remotes, then a remote named `knithub`.
+With no target flag, both move every relevant artifact family. Remote selection resolves explicit `--remote` overrides first, then configured sync remotes, then the sole configured remote.
 
 The absorbed verbs are deleted, not aliased or hidden: `knit bundle push`, `knit history push/pull/sync` (only `history list` and `history refresh` remain), `knit view push/pull`, and `knit land sync` no longer exist. The philosophy is one way per outcome — delete, do not hide.
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -175,11 +175,12 @@ history ledger from a KnitHub remote first.
 ## 10. Host it on KnitHub (optional)
 
 Knit is local-first, but bundles, project history, and saved views can be
-hosted on [knithub.dev](https://knithub.dev) so they survive machines and show
-up in dashboards:
+hosted on your KnitHub deployment so they survive machines and show up in
+dashboards:
 
 ```sh
-knit remote add knithub https://knithub.dev --token <your-token> --global
+knit remote add hosted https://<your-knit-api-url> --token <your-token> --global
+knit config set --global sync-remotes hosted
 knit project push                       # create the hosted project (uploads views too)
 KNIT_BUNDLE=my-feature knit sync push   # bundles + history for the walkthrough bundle
 ```
@@ -195,7 +196,7 @@ sync automatically, hosted dashboards show bundles and project history, and
 machine. `knit related --pull` and `knit sync pull` read the same hosted
 history back.
 
-<!-- image: docs/assets/knithub-dashboard.png — a project's bundles on knithub.dev -->
+<!-- image: docs/assets/knithub-dashboard.png — a project's bundles in a KnitHub deployment -->
 
 Projects can also be cloned from Knit. `knit clone` will rebuild the project
 as it is set up in Knit, given your git and KnitHub tokens allow it.

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -505,10 +505,10 @@ knit sync push --history       # push only project history events
 knit sync push --views         # push only your saved views
 knit sync pull                 # pull bundle + history + views
 knit sync pull --history       # pull only project history events
-knit sync push --remote local --remote knithub   # fan out to several remotes
+knit sync push --remote hosted    # use an explicit remote
 ```
 
-With no target flag (`--bundles`/`--history`/`--views`/`--all`), `knit sync push`/`pull` move every relevant artifact family. Remotes default to the configured sync remotes (`knit config set sync-remotes ...`, then `sync-remote`), falling back to a remote named `knithub`; override with one or more `--remote <name>`.
+With no target flag (`--bundles`/`--history`/`--views`/`--all`), `knit sync push`/`pull` move every relevant artifact family. Remotes default to the configured sync remotes (`knit config set sync-remotes ...`, then `sync-remote`), falling back to the sole configured remote; override with one or more `--remote <name>`.
 
 The git-shaped verbs keep their git semantics but route through the same internal sync module: `knit push --remote <name>` still pushes branches and then the bundle artifact, and `knit fetch --bundles` / `knit pull --bundles` still pull recorded bundle state. Landing's automatic artifact sync (when `push-sync` is enabled) goes through the same module too. There is one implementation behind several differently shaped doors.
 
@@ -516,18 +516,18 @@ The git-shaped verbs keep their git semantics but route through the same interna
 Remotes can be workspace-local or user-global. Workspace `.knit/config.json` remotes override global remotes of the same name; otherwise commands fall back to the user-level config at `$KNIT_HOME/config.json`, `$XDG_CONFIG_HOME/knit/config.json`, or `~/.config/knit/config.json`. This lets every workspace share the same hosted KnitHub remote unless a workspace deliberately points that name somewhere else:
 
 ```sh
-knit remote add --global knithub https://api.knithub.dev
-export KNIT_REMOTE_KNITHUB_TOKEN="<KnitHub API token>"
-knit config set --global sync-remotes knithub
+knit remote add --global hosted https://<your-knit-api-url>
+export KNIT_REMOTE_HOSTED_TOKEN="<KnitHub API token>"
+knit config set --global sync-remotes hosted
 knit config show
-knit remote show knithub
+knit remote show hosted
 ```
 
 Workspace-only overrides stay local:
 
 ```sh
-knit remote add local http://localhost:4000
-knit config set sync-remotes local,knithub
+knit remote add staging http://localhost:4000
+knit config set sync-remotes staging
 knit push
 ```
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -57,13 +57,13 @@ pub enum Commands {
         project: String,
         /// Directory to create. Defaults to the project slug.
         target: Option<PathBuf>,
-        /// Named KnitHub remote.
-        #[arg(long, default_value = "knithub")]
-        remote: String,
-        /// KnitHub base URL. Required outside an existing configured workspace unless KNITHUB_URL is set.
+        /// Named KnitHub remote. Defaults to the configured sync remote.
+        #[arg(long)]
+        remote: Option<String>,
+        /// KnitHub base URL. Required when the remote is not configured.
         #[arg(long)]
         url: Option<String>,
-        /// KnitHub token. Prefer KNITHUB_TOKEN or KNIT_REMOTE_<NAME>_TOKEN.
+        /// KnitHub token. Prefer KNIT_REMOTE_<NAME>_TOKEN or KNIT_REMOTE_TOKEN.
         #[arg(long)]
         token: Option<String>,
         /// Bundle to make active after clone. Defaults to the latest open exported bundle.
@@ -174,7 +174,7 @@ pub enum Commands {
         /// Fetch mode: --all (default), --git only, --knit only.
         #[arg(long, default_value = "all", value_name = "MODE")]
         mode: FetchMode,
-        /// Named KnitHub remote for knit fetch. Uses `knithub` or sync_remote if not specified.
+        /// Named KnitHub remote for knit fetch. Defaults to the configured sync remote.
         #[arg(long, value_name = "REMOTE")]
         remote: Option<String>,
         /// (Deprecated, use --git) Skip KnitHub remote sync.
@@ -205,8 +205,8 @@ pub enum Commands {
         /// Update every open bundle's checkouts from its KnitHub artifact. Combine with --main.
         #[arg(long)]
         bundles: bool,
-        /// Also pull the current bundle artifact from a KnitHub remote. With no value, uses `knithub`.
-        #[arg(long, value_name = "REMOTE", num_args = 0..=1, default_missing_value = "knithub")]
+        /// Also pull the current bundle artifact from a named KnitHub remote.
+        #[arg(long, value_name = "REMOTE")]
         remote: Option<String>,
         /// Skip configured KnitHub remote sync for this pull.
         #[arg(long)]
@@ -349,8 +349,8 @@ pub enum Commands {
         #[arg(long)]
         pull: bool,
         /// Named KnitHub remote used with --pull.
-        #[arg(long, default_value = "knithub")]
-        remote: String,
+        #[arg(long)]
+        remote: Option<String>,
     },
     /// Commit staged changes across tracked checkouts.
     Commit {
@@ -425,8 +425,7 @@ pub enum SyncCommand {
     Push {
         #[command(flatten)]
         targets: SyncTargetArgs,
-        /// Named KnitHub remote(s). Repeat for several. Defaults to configured
-        /// sync remotes, then a remote named `knithub`.
+        /// Named KnitHub remote(s). Repeat for several. Defaults to configured sync remotes.
         #[arg(long, value_name = "REMOTE")]
         remote: Vec<String>,
     },
@@ -435,8 +434,7 @@ pub enum SyncCommand {
     Pull {
         #[command(flatten)]
         targets: SyncTargetArgs,
-        /// Named KnitHub remote(s). Repeat for several. Defaults to configured
-        /// sync remotes, then a remote named `knithub`.
+        /// Named KnitHub remote(s). Repeat for several. Defaults to configured sync remotes.
         #[arg(long, value_name = "REMOTE")]
         remote: Vec<String>,
     },
@@ -666,9 +664,9 @@ pub enum ProjectCommand {
     Push {
         /// Project name. Defaults to the active project.
         name: Option<String>,
-        /// Named KnitHub remote.
-        #[arg(long, default_value = "knithub")]
-        remote: String,
+        /// Named KnitHub remote. Defaults to the configured sync remote.
+        #[arg(long)]
+        remote: Option<String>,
     },
     /// Write or refresh project-specific AGENTS.md guidance.
     Agents {
@@ -821,11 +819,11 @@ pub enum ViewCommand {
 pub enum RemoteCommand {
     /// Add or replace a named KnitHub API remote.
     Add {
-        /// Remote name, for example `knithub`.
+        /// Remote name, for example `hosted`.
         name: String,
-        /// KnitHub base URL, for example `http://localhost:4000` or `https://api.knithub.example`.
+        /// KnitHub base URL, for example `http://localhost:4000` or `https://host.example`.
         url: String,
-        /// Optional KnitHub token. Prefer KNITHUB_TOKEN or KNIT_REMOTE_<NAME>_TOKEN for shared workspaces.
+        /// Optional KnitHub token. Prefer KNIT_REMOTE_<NAME>_TOKEN or KNIT_REMOTE_TOKEN for shared workspaces.
         #[arg(long)]
         token: Option<String>,
         /// Store this remote in the user-level Knit config instead of the workspace.

--- a/src/commands/config.rs
+++ b/src/commands/config.rs
@@ -221,7 +221,7 @@ fn parse_remote_names(value: &str) -> Result<Vec<String>> {
         }
     }
     if names.is_empty() {
-        bail!("Expected at least one remote name, for example `local,knithub`.");
+        bail!("Expected at least one remote name, for example `prod,staging`.");
     }
     Ok(names)
 }

--- a/src/commands/history/mod.rs
+++ b/src/commands/history/mod.rs
@@ -78,7 +78,7 @@ pub fn show_related_history(
     limit: usize,
     commit_limit: usize,
     pull: bool,
-    remote: &str,
+    remote: Option<&str>,
 ) -> Result<()> {
     if paths.is_empty() {
         bail!("Pass at least one path to inspect.");

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -502,8 +502,8 @@ knit --bundle feature-a push --set-upstream
 Push the bundle to one or more KnitHub remotes so it appears in hosted dashboards. `knit push --remote` pushes feature branches and the bundle artifact together; `knit sync push` is the artifact-only door and is the one verb family for moving bundles, history, and views to KnitHub:
 
 ```sh
-knit --bundle feature-a push --remote local --remote knithub
-knit --bundle feature-a sync push --remote local --remote knithub
+knit --bundle feature-a push --remote hosted
+knit --bundle feature-a sync push --remote hosted
 knit --bundle feature-a sync push --bundles
 knit --bundle feature-a sync pull --history
 ```
@@ -605,14 +605,14 @@ knit cherrypick --from feature-a --repo backend abc123
 - `knit doctor` checks workspace JSON, stale locks, and missing paths.
 - `knit migrate --check` reports additive JSON migrations; `knit migrate` applies them.
 - `knit config set advice false` disables sparse `Next:` advice.
-- `knit config set sync-remotes local,knithub` makes push-sync upload bundle artifacts to multiple KnitHub remotes.
+- `knit config set sync-remotes hosted` makes push-sync upload bundle artifacts to your configured KnitHub remote.
 - `knit show HEAD` explains the latest bundle ledger entry.
 - `knit sync` records Git commits made outside Knit (local reconcile, no network).
 - `knit sync push [--bundles|--history|--views|--all] [--remote <name>]...` is the one verb family for moving artifacts to KnitHub; with no target flag it pushes bundle, history, and views.
 - `knit sync pull [--bundles|--history|--views|--all] [--remote <name>]...` pulls those same artifacts from KnitHub.
 - `knit pull --merge` union-merges the bundle ledger when the local and KnitHub artifacts have diverged (two users recorded work concurrently); diverged feature branches still need a git merge in the worktree afterwards.
 - `knit push --set-upstream` pushes every tracked feature branch in the resolved bundle to `origin` and sets upstream tracking.
-- `knit push --remote local --remote knithub` pushes the resolved bundle's branches and artifact to both configured KnitHub remotes so it is visible in hosted dashboards.
+- `knit push --remote hosted` pushes the resolved bundle's branches and artifact to the configured KnitHub remote so it is visible in hosted dashboards.
 - `knit git --all status --short` runs Git across tracked checkouts.
 - `knit clean --archived --worktrees` removes generated worktrees left behind by bundles archived with `--keep-worktrees`.
 

--- a/src/commands/remote/client.rs
+++ b/src/commands/remote/client.rs
@@ -64,7 +64,7 @@ pub(super) fn resolve_remote<'a>(config: &'a KnitConfig, name: &str) -> Result<&
 pub(super) fn resolve_token(name: &str, remote: &KnitRemote) -> Result<String> {
     token_from_env(&slugify(name))
         .or_else(|| remote.token.clone())
-        .context("No KnitHub token configured. Set KNITHUB_TOKEN, KNIT_REMOTE_<NAME>_TOKEN, or `knit remote token <name> <token>`.")
+        .context("No KnitHub token configured. Set KNIT_REMOTE_<NAME>_TOKEN, KNIT_REMOTE_TOKEN, or `knit remote token <name> <token>`.")
 }
 
 pub(super) fn token_from_env(name: &str) -> Option<String> {
@@ -81,12 +81,16 @@ pub(super) fn token_from_env(name: &str) -> Option<String> {
     std::env::var(env_name)
         .ok()
         .filter(|value| !value.trim().is_empty())
+        .or_else(|| std::env::var("KNIT_REMOTE_TOKEN").ok())
+        .filter(|value| !value.trim().is_empty())
         .or_else(|| std::env::var("KNITHUB_TOKEN").ok())
         .filter(|value| !value.trim().is_empty())
 }
 
 /// Return configured KnitHub sync remotes in priority order. `syncRemotes` is the
-/// multi-target form; `syncRemote` remains the legacy single-target form.
+/// multi-target form; `syncRemote` remains the legacy single-target form. If a
+/// config has exactly one remote and no explicit sync remote, that sole remote
+/// is the sync remote by convention.
 pub fn configured_sync_remote_names(config: &KnitConfig) -> Vec<String> {
     let mut names = Vec::new();
     if !config.sync_remotes.is_empty() {
@@ -99,8 +103,10 @@ pub fn configured_sync_remote_names(config: &KnitConfig) -> Vec<String> {
             push_unique_remote_name(&mut names, name);
         }
     }
-    if names.is_empty() && config.remotes.contains_key("knithub") {
-        names.push("knithub".to_string());
+    if names.is_empty() && config.remotes.len() == 1 {
+        if let Some(name) = config.remotes.keys().next() {
+            push_unique_remote_name(&mut names, name);
+        }
     }
     names
 }
@@ -132,10 +138,10 @@ fn push_unique_remote_name(names: &mut Vec<String>, name: &str) {
 }
 
 /// Resolve the primary KnitHub sync remote, preferring `syncRemotes[0]`, then
-/// legacy `syncRemote`, then a remote literally named `knithub`.
+/// legacy `syncRemote`, then the sole configured remote.
 pub(super) fn resolve_sync_remote_name(config: &KnitConfig) -> Result<String> {
     configured_sync_remote_names(config).into_iter().next().context(
-        "No KnitHub sync remote configured. Run `knit remote add knithub <url>`, `knit config set sync-remote <name>`, or use explicit prune flags instead of --all.",
+        "No KnitHub sync remote configured. Run `knit remote add <name> <url>`, `knit config set sync-remote <name>`, or use explicit prune flags instead of --all.",
     )
 }
 

--- a/src/commands/remote/clone.rs
+++ b/src/commands/remote/clone.rs
@@ -3,8 +3,9 @@
 //! optionally materialize the active bundle.
 
 use super::client::{
-    decode_bundle_payload, fast_forward_feature_checkouts, fetch_project_export, localize_bundle,
-    normalize_base_url, prepare_feature_branches, token_from_env,
+    configured_sync_remote_names, decode_bundle_payload, fast_forward_feature_checkouts,
+    fetch_project_export, localize_bundle, normalize_base_url, prepare_feature_branches,
+    token_from_env,
 };
 use super::{RemoteExportRepository, RemoteProjectExport};
 use crate::commands::agents::{
@@ -33,14 +34,14 @@ use std::path::{Path, PathBuf};
 pub fn clone_project_from_remote(
     project_identifier: &str,
     target: Option<&Path>,
-    remote_name: &str,
+    remote_name: Option<&str>,
     url: Option<&str>,
     token: Option<&str>,
     active_bundle: Option<&str>,
     materialize: bool,
 ) -> Result<()> {
-    let remote_name = slugify(remote_name);
-    let (remote, stored_token, token) = resolve_remote_for_clone(&remote_name, url, token)?;
+    let (remote_name, remote, stored_token, token) =
+        resolve_remote_for_clone(remote_name, url, token)?;
     let export = fetch_project_export(&remote, &token, project_identifier)?;
     let target_root = resolve_clone_target(target, project_identifier)?;
     prepare_clone_target(&target_root)?;
@@ -155,25 +156,39 @@ pub fn clone_project_from_remote(
 }
 
 fn resolve_remote_for_clone(
-    remote_name: &str,
+    remote_name: Option<&str>,
     url: Option<&str>,
     token: Option<&str>,
-) -> Result<(KnitRemote, Option<String>, String)> {
+) -> Result<(String, KnitRemote, Option<String>, String)> {
     let cwd = std::env::current_dir().context("failed to read current directory")?;
     // Inside a workspace, the effective config already merges global remotes in.
     // Outside one, fall back to the user-global config so `knit clone` works from
     // any directory, not just an existing Knit workspace.
-    let configured = match find_knit_root(&cwd) {
+    let config = match find_knit_root(&cwd) {
         Some(root) => crate::store::load_effective_config(&root).ok(),
         None => crate::store::load_global_config().ok(),
-    }
-    .and_then(|config| config.remotes.get(remote_name).cloned());
+    };
+    let requested_name = remote_name.map(slugify).filter(|name| !name.is_empty());
+    let configured_name = config
+        .as_ref()
+        .and_then(|config| configured_sync_remote_names(config).into_iter().next());
+    let remote_name = requested_name.or(configured_name).with_context(|| {
+        "No KnitHub remote selected. Pass `--remote <name>` with `--url <url>`, or configure a sync remote first."
+    })?;
+    let configured = config
+        .as_ref()
+        .and_then(|config| config.remotes.get(&remote_name).cloned());
+    let env_url = std::env::var("KNIT_REMOTE_URL")
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+        .or_else(|| std::env::var("KNITHUB_URL").ok())
+        .filter(|value| !value.trim().is_empty());
     let remote_url = url
         .map(ToString::to_string)
-        .or_else(|| std::env::var("KNITHUB_URL").ok())
+        .or(env_url)
         .or_else(|| configured.as_ref().map(|remote| remote.url.clone()))
         .with_context(|| {
-            format!("No KnitHub URL configured. Pass --url, set KNITHUB_URL, or run `knit remote add {remote_name} <url>`.")
+            format!("No KnitHub URL configured for remote `{remote_name}`. Pass --url, set KNIT_REMOTE_URL, or run `knit remote add {remote_name} <url>`.")
         })?;
     let stored_token = token
         .map(ToString::to_string)
@@ -184,11 +199,11 @@ fn resolve_remote_for_clone(
     };
     let resolved_token = token
         .map(ToString::to_string)
-        .or_else(|| token_from_env(remote_name))
+        .or_else(|| token_from_env(&remote_name))
         .or_else(|| remote.token.clone())
-        .context("No KnitHub token configured. Set KNITHUB_TOKEN, KNIT_REMOTE_<NAME>_TOKEN, pass --token, or configure a stored remote token.")?;
+        .context("No KnitHub token configured. Set KNIT_REMOTE_<NAME>_TOKEN or KNIT_REMOTE_TOKEN, pass --token, or configure a stored remote token.")?;
 
-    Ok((remote, stored_token, resolved_token))
+    Ok((remote_name, remote, stored_token, resolved_token))
 }
 
 fn resolve_clone_target(target: Option<&Path>, project_identifier: &str) -> Result<PathBuf> {

--- a/src/commands/remote/facade.rs
+++ b/src/commands/remote/facade.rs
@@ -47,13 +47,13 @@ impl SyncTargets {
 
 /// Resolve the remote names this sync should hit. Explicit `--remote` overrides
 /// win; otherwise fall back to configured sync remotes (`syncRemotes`,
-/// `sync_remote`, then a remote literally named `knithub`).
+/// `sync_remote`, then the sole configured remote).
 fn resolve_remotes(remote_overrides: &[String]) -> Result<Vec<String>> {
     let (_, config) = effective_workspace_config()?;
     let remotes = resolve_sync_remote_names(&config, remote_overrides);
     if remotes.is_empty() {
         bail!(
-            "No KnitHub remote configured. Run `knit remote add --global knithub <url>`, `knit remote add knithub <url>`, or `knit config set sync-remotes <name>[,<name>...]` first."
+            "No KnitHub remote configured. Run `knit remote add --global <name> <url>`, `knit remote add <name> <url>`, or `knit config set sync-remotes <name>[,<name>...]` first."
         );
     }
     Ok(remotes)
@@ -121,7 +121,7 @@ pub fn sync_pull(targets: SyncTargets, remote_overrides: &[String]) -> Result<()
             }
         }
         if targets.history {
-            if let Err(error) = pull_history_from_remote(None, remote) {
+            if let Err(error) = pull_history_from_remote(None, Some(remote)) {
                 failures.push(format!("{remote} history: {error:#}"));
             }
         }

--- a/src/commands/remote/history.rs
+++ b/src/commands/remote/history.rs
@@ -2,7 +2,7 @@
 
 use super::client::{
     effective_workspace_config, load_project_if_present, request_json, resolve_project_id,
-    resolve_remote, resolve_token,
+    resolve_remote, resolve_sync_remote_name, resolve_token,
 };
 use crate::history::{append_history_events, load_history_events, refresh_project_history};
 use crate::model::{HistoryEvent, KnitRemote};
@@ -50,11 +50,15 @@ pub fn push_history_to_remote(project: Option<&str>, remote_name: &str) -> Resul
     Ok(())
 }
 
-pub fn pull_history_from_remote(project: Option<&str>, remote_name: &str) -> Result<()> {
+pub fn pull_history_from_remote(project: Option<&str>, remote_name: Option<&str>) -> Result<()> {
     let (root, config) = effective_workspace_config()?;
     let project_id = resolve_project_id(&root, &config, project)?;
-    let remote = resolve_remote(&config, remote_name)?;
-    let token = resolve_token(remote_name, remote)?;
+    let remote_name = match remote_name {
+        Some(remote_name) => crate::ids::slugify(remote_name),
+        None => resolve_sync_remote_name(&config)?,
+    };
+    let remote = resolve_remote(&config, &remote_name)?;
+    let token = resolve_token(&remote_name, remote)?;
     let events = fetch_project_history_events(remote, &token, &project_id)?;
     let appended = append_history_events(&root, &project_id, &events)?;
     println!(

--- a/src/commands/remote/pull.rs
+++ b/src/commands/remote/pull.rs
@@ -98,7 +98,7 @@ pub struct RemoteBundleRecord {
 /// time. Returns `None` when the pull opts out (`--no-remote`) or no remote is
 /// configured, so callers can skip the artifact step without it being an error.
 /// Remote resolution matches the primary push-sync remote: explicit override,
-/// then `syncRemotes[0]`/`sync_remote`, then a remote literally named `knithub`.
+/// then `syncRemotes[0]`/`sync_remote`, then the sole configured remote.
 pub fn prepare_remote_pull(
     remote_override: Option<&str>,
     skip_remote: bool,

--- a/src/commands/remote/push.rs
+++ b/src/commands/remote/push.rs
@@ -5,7 +5,8 @@
 use super::client::{
     configured_sync_remote_names, decode_response, effective_workspace_config,
     load_project_if_present, normalize_base_url, request, request_json, resolve_project_id,
-    resolve_remote, resolve_sync_remote_names, resolve_token, token_from_env, workspace_config,
+    resolve_remote, resolve_sync_remote_name, resolve_sync_remote_names, resolve_token,
+    token_from_env, workspace_config,
 };
 use super::{RemoteArtifact, RemoteBundle, RemoteProject};
 use crate::ids::slugify;
@@ -218,11 +219,15 @@ pub fn set_remote_token(name: &str, token: Option<&str>, clear: bool, global: bo
     Ok(())
 }
 
-pub fn push_project_to_remote(name: Option<&str>, remote_name: &str) -> Result<()> {
+pub fn push_project_to_remote(name: Option<&str>, remote_name: Option<&str>) -> Result<()> {
     let (root, config) = effective_workspace_config()?;
     let project_id = resolve_project_id(&root, &config, name)?;
-    let remote = resolve_remote(&config, remote_name)?;
-    let token = resolve_token(remote_name, remote)?;
+    let remote_name = match remote_name {
+        Some(remote_name) => slugify(remote_name),
+        None => resolve_sync_remote_name(&config)?,
+    };
+    let remote = resolve_remote(&config, &remote_name)?;
+    let token = resolve_token(&remote_name, remote)?;
     let project = load_project_if_present(&root, &project_id)?;
     let pushed = upsert_project(remote, &token, &project_id, project.as_ref())?;
     let repo_count = match project.as_ref() {
@@ -351,11 +356,11 @@ pub fn push_bundle_to_remote(remote_name: &str, project: Option<&str>) -> Result
 /// git push, when enabled.
 ///
 /// Resolution order for remotes: repeated explicit `--remote`, then
-/// `syncRemotes`, then legacy `sync_remote`, then a remote literally named
-/// `knithub`. With no remote configured this is a silent no-op. The `push_sync`
-/// config disables implicit sync, but explicit `--remote` still forces it.
-/// `--no-remote` always skips. Sync failures are reported as warnings and never
-/// fail the git push that already succeeded.
+/// `syncRemotes`, then legacy `sync_remote`, then the sole configured remote.
+/// With no remote configured this is a silent no-op. The `push_sync` config
+/// disables implicit sync, but explicit `--remote` still forces it. `--no-remote`
+/// always skips. Sync failures are reported as warnings and never fail the git
+/// push that already succeeded.
 pub fn maybe_sync_bundle_to_remote(remote_overrides: &[String], no_remote: bool) -> Result<()> {
     if no_remote {
         return Ok(());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,7 +40,7 @@ pub fn run(cli: Cli) -> Result<()> {
             ProjectCommand::Show { name } => commands::show_project(name.as_deref()),
             ProjectCommand::Remove { name, force } => commands::remove_project(&name, force),
             ProjectCommand::Push { name, remote } => {
-                commands::push_project_to_remote(name.as_deref(), &remote)
+                commands::push_project_to_remote(name.as_deref(), remote.as_deref())
             }
             ProjectCommand::Agents { name } => commands::refresh_project_agents(name.as_deref()),
             ProjectCommand::Pull { name, repo, agents } => {
@@ -127,7 +127,7 @@ pub fn run(cli: Cli) -> Result<()> {
         } => commands::clone_project_from_remote(
             &project,
             target.as_deref(),
-            &remote,
+            remote.as_deref(),
             url.as_deref(),
             token.as_deref(),
             active_bundle.as_deref(),
@@ -519,7 +519,7 @@ pub fn run(cli: Cli) -> Result<()> {
             limit,
             commit_limit,
             pull,
-            &remote,
+            remote.as_deref(),
         ),
         Commands::Commit { message, all } => commands::commit_staged(&message, all),
         Commands::Log {

--- a/tests/bundle.rs
+++ b/tests/bundle.rs
@@ -263,8 +263,8 @@ fn bundle_creation_refuses_slug_taken_on_sync_remote() {
     setup_three_repo_project(&workspace, &root);
 
     let base_url = spawn_fake_knithub_export("payment-flow", "open");
-    knit(&workspace, ["remote", "add", "knithub", &base_url]);
-    let env = [("KNITHUB_TOKEN", "test-token")];
+    knit(&workspace, ["remote", "add", "hosted", &base_url]);
+    let env = [("KNIT_REMOTE_TOKEN", "test-token")];
 
     let refused = knit_fails_with_env(&workspace, ["bundle", "payment flow"], &env);
     assert!(refused.contains("already exists on the KnitHub sync remote"));

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -103,8 +103,8 @@ fn remote_config_supports_global_fallback_and_workspace_override() {
             "remote",
             "add",
             "--global",
-            "knithub",
-            "https://api.knithub.dev",
+            "hosted",
+            "https://remote.example.invalid",
             "--token",
             "global-token",
         ],
@@ -113,33 +113,33 @@ fn remote_config_supports_global_fallback_and_workspace_override() {
     let global_config: Value =
         serde_json::from_str(&fs::read_to_string(knit_home.join("config.json")).unwrap()).unwrap();
     assert_eq!(
-        global_config["remotes"]["knithub"]["url"].as_str(),
-        Some("https://api.knithub.dev")
+        global_config["remotes"]["hosted"]["url"].as_str(),
+        Some("https://remote.example.invalid")
     );
 
     knit_with_env(&workspace, ["init", "demo"], &env);
-    let inherited = knit_with_env(&workspace, ["remote", "show", "knithub"], &env);
-    assert!(inherited.contains("https://api.knithub.dev"));
+    let inherited = knit_with_env(&workspace, ["remote", "show", "hosted"], &env);
+    assert!(inherited.contains("https://remote.example.invalid"));
     assert!(inherited.contains("Scope: global"));
     assert!(inherited.contains("Token: stored"));
 
     knit_with_env(
         &workspace,
-        ["remote", "add", "knithub", "http://localhost:4000"],
+        ["remote", "add", "hosted", "http://localhost:4000"],
         &env,
     );
-    let overridden = knit_with_env(&workspace, ["remote", "show", "knithub"], &env);
+    let overridden = knit_with_env(&workspace, ["remote", "show", "hosted"], &env);
     assert!(overridden.contains("http://localhost:4000"));
     assert!(overridden.contains("Scope: workspace"));
 
-    let global_only = knit_with_env(&workspace, ["remote", "show", "--global", "knithub"], &env);
-    assert!(global_only.contains("https://api.knithub.dev"));
+    let global_only = knit_with_env(&workspace, ["remote", "show", "--global", "hosted"], &env);
+    assert!(global_only.contains("https://remote.example.invalid"));
     assert!(global_only.contains("Scope: global"));
 
     let show = knit_with_env(&workspace, ["config", "show"], &env);
     assert!(show.contains("Global config"));
     assert!(show.contains("Effective config"));
-    assert!(show.contains("https://api.knithub.dev"));
+    assert!(show.contains("https://remote.example.invalid"));
 
     fs::remove_dir_all(root).unwrap();
 }
@@ -161,7 +161,7 @@ fn clone_resolves_url_and_token_from_global_config_outside_a_workspace() {
             "remote",
             "add",
             "--global",
-            "knithub",
+            "hosted",
             "http://127.0.0.1:9",
             "--token",
             "global-token",
@@ -200,7 +200,10 @@ fn config_can_target_multiple_knithub_sync_remotes() {
         &workspace,
         ["remote", "add", "local", "http://localhost:4000"],
     );
-    knit(&workspace, ["remote", "add", "prod", "https://knithub.dev"]);
+    knit(
+        &workspace,
+        ["remote", "add", "prod", "https://prod.example.invalid"],
+    );
 
     let set = knit(&workspace, ["config", "set", "sync-remotes", "local,prod"]);
     assert!(set.contains("sync-remotes=local,prod"), "{set}");

--- a/tests/sync.rs
+++ b/tests/sync.rs
@@ -566,8 +566,8 @@ fn pull_merge_unions_diverged_bundle_ledgers() {
         }
     });
     let base_url = spawn_fake_knithub_with_body(export.to_string());
-    knit(&workspace, ["remote", "add", "knithub", &base_url]);
-    let env = [("KNITHUB_TOKEN", "test-token")];
+    knit(&workspace, ["remote", "add", "hosted", &base_url]);
+    let env = [("KNIT_REMOTE_TOKEN", "test-token")];
 
     // Without --merge, diverged ledgers are kept local and reported.
     let plain = knit_with_env(&workspace, ["pull"], &env);


### PR DESCRIPTION
Generated by Knit. Cross-links will be refreshed after all review objects are created.

<!-- BEGIN KNIT BUNDLE -->
## Knit Bundle

This PR is part of Knit bundle `resilient-remote-pull`.

See the other review objects in this bundle:
- `knit`: https://github.com/marc-merino/knit/pull/90 (this PR)

Bundle id: `resilient-remote-pull`
Bundle title: resilient remote pull
<!-- END KNIT BUNDLE -->