### PR TITLE
project context storage (knit)

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,8 @@ The [quickstart](docs/quickstart.md) walks this loop end to end with two toy rep
 - **Parallel by construction.** The same repo can sit in many bundles at once, each on its own branch and generated worktree. Run one coding agent per bundle — they cannot collide, and each worktree carries its own `AGENTS.md` so agents wake up oriented.
 - **An append-only ledger, not just branches.** Every bundle is a JSON artifact recording commits, observed changes, check verdicts, landings, and reverts. Other tools read it; nothing is locked in a database.
 - **Verdicts you can trust.** `knit check` pins pass/fail to the exact per-repo commits it ran against — a verdict goes stale the moment the bundle moves, and projects can require green-and-fresh checks before landing. With five agent bundles in flight, "which one is ready?" has a ledger answer, not a chat claim.
-- **Local-first, host optional.** Everything works against plain git repos. A KnitHub deployment adds hosted dashboards, history sync, `knit clone` to rebuild a workspace anywhere, and [Gloss](https://github.com/marc-merino/gloss) cross-repo reviews on top of the same artifact.
-- **Gloss-ready review.** The same bundle artifact gives `gloss` enough cross-repo context to prepare reviews and explanations.
+- **Local-first, host optional.** Everything works against plain git repos. A KnitHub deployment adds hosted dashboards, history sync, `knit clone` to rebuild a workspace anywhere, and Urdir/Gloss cross-repo reviews on top of the same artifact.
+- **Review-ready artifact.** The same bundle artifact gives `urdir` enough cross-repo context to prepare review analysis that `gloss` can display and explain.
 
 ## Concepts in one breath
 
@@ -69,6 +69,6 @@ The full versions live in the [quickstart](docs/quickstart.md#concepts) and the 
 - **[docs/change-group-schema.md](docs/change-group-schema.md)** — the bundle (`ChangeGroup`) schema.
 - **[dist/README.md](dist/README.md)** — how releases are cut (binaries, crates.io, Homebrew/Scoop/winget).
 
-## Knit and Gloss
+## Knit, Urdir, and Gloss
 
-Knit and Gloss share a single artifact: the bundle. Knit owns authoring and workspace mechanics — repos, worktrees, feature branches, commit groups, ledger updates. Gloss reads a bundle later and produces cross-repo review, ranking, and explanation output; on KnitHub the two meet in one page.
+Knit, Urdir, and Gloss share a simple handoff. Knit owns authoring and workspace mechanics — repos, worktrees, feature branches, commit groups, ledger updates. Urdir reads a bundle later and produces cross-repo review analysis. Gloss displays and explains that review artifact; on KnitHub the three meet in one page.

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -621,15 +621,15 @@ knit cherrypick --from feature-a --repo backend abc123
 
 Knit resolves bundle context from `--bundle`, then `KNIT_BUNDLE`, then generated worktree cwd, then the workspace fallback. Inside `.knit/worktrees/<bundle>/<repo>/`, agents do not need to run `knit switch`.
 
-## Knit And Gloss
+## Knit, Urdir, And Gloss
 
-Knit owns authoring: worktrees, feature branches, commits, sync, reverts, and the bundle ledger. Gloss reads Knit bundles later to prepare review plans, explanations, and UI views.
+Knit owns authoring: worktrees, feature branches, commits, sync, reverts, and the bundle ledger. Urdir reads Knit bundles later to produce review analysis artifacts. Gloss displays and explains those artifacts.
 
-When using Gloss from this workspace, the active Knit bundle can usually be discovered automatically:
+When using Gloss from this workspace, first ask Urdir to build the review artifact, then open it in Gloss:
 
 ```sh
-gloss prepare
-gloss view
+urdir review --bundle path/to/feature.bundle.json --out .gloss/reviews/feature.review.json
+gloss view --review feature
 ```
 <!-- END KNIT AGENTS -->
 "#,

--- a/tests/project.rs
+++ b/tests/project.rs
@@ -34,7 +34,8 @@ fn init_can_generate_agents_tutorial() {
     assert!(agents.contains("minimum capable subagent/model"));
     assert!(agents.contains("Project JSON can define a default `landing` template"));
     assert!(agents.contains(".knit/land-plans/<bundle>.land.json"));
-    assert!(agents.contains("gloss prepare"));
+    assert!(agents.contains("urdir review --bundle"));
+    assert!(agents.contains("gloss view --review"));
 
     fs::remove_file(workspace.join("AGENTS.md")).unwrap();
     let existing_workspace_output = knit(&workspace, ["bundle", "venue capacity", "--agents"]);


### PR DESCRIPTION
Generated by Knit. Cross-links will be refreshed after all review objects are created.

<!-- BEGIN KNIT BUNDLE -->
## Knit Bundle

This PR is part of Knit bundle `project-context-storage`.

See the other review objects in this bundle:
- `urdir`: https://github.com/marc-merino/urdir/pull/6
- `knithub`: https://github.com/marc-merino/knithub/pull/53
- `gloss`: https://github.com/marc-merino/gloss/pull/14
- `knit`: https://github.com/marc-merino/knit/pull/92 (this PR)
- `knithub-frontend`: https://github.com/marc-merino/knithub-frontend/pull/82

Bundle id: `project-context-storage`
Bundle title: project context storage
<!-- END KNIT BUNDLE -->