### PR TITLE
fix archived landed status (knit)

### DIFF
--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -109,8 +109,7 @@ fn print_closed_summary(active: &crate::store::ActiveBundle, state: BundleStatus
 }
 
 fn print_publication_summary(active: &crate::store::ActiveBundle) {
-    let state = crate::commands::bundle::bundle_state(&active.bundle);
-    if active.bundle.publications.is_empty() || state == BundleStatus::Landed {
+    if active.bundle.publications.is_empty() || has_landed_node(&active.bundle) {
         return;
     }
     let tracked_count = active.bundle.repos.len();
@@ -139,4 +138,11 @@ fn print_publication_summary(active: &crate::store::ActiveBundle) {
 
 fn is_review_publication(publication: &PublicationEntry) -> bool {
     crate::providers::is_review_kind(&publication.kind)
+}
+
+fn has_landed_node(bundle: &crate::model::ChangeGroup) -> bool {
+    bundle
+        .nodes
+        .iter()
+        .any(|node| node.node_type == "feature.landed")
 }

--- a/tests/land.rs
+++ b/tests/land.rs
@@ -224,6 +224,12 @@ fn land_plan_and_apply_merges_recorded_publications_with_fake_gh() {
         ["--bundle", "venue-capacity", "bundle", "validate"]
     )
     .contains("Bundle valid"));
+    let archived_status = knit(&workspace, ["--bundle", "venue-capacity", "status"]);
+    assert!(
+        archived_status.contains("State: archived"),
+        "{archived_status}"
+    );
+    assert!(!archived_status.contains("not landed"), "{archived_status}");
     assert!(knit(&workspace, ["--bundle", "venue-capacity", "log", "-1"]).contains("landed"));
     let sync_error = knit_fails(
         &workspace,


### PR DESCRIPTION
Generated by Knit. Cross-links will be refreshed after all review objects are created.

<!-- BEGIN KNIT BUNDLE -->
## Knit Bundle

This PR is part of Knit bundle `fix-archived-landed-status`.

See the other review objects in this bundle:
- `knit`: https://github.com/marc-merino/knit/pull/96 (this PR)

Bundle id: `fix-archived-landed-status`
Bundle title: fix archived landed status
<!-- END KNIT BUNDLE -->