### PR TITLE
Prepare 0.1.0-alpha.4 release (knit)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,3 +59,97 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh release edit ${{ github.ref_name }} --prerelease
+
+  bump-homebrew-tap:
+    needs: upload-assets
+    runs-on: ubuntu-latest
+    env:
+      TAP_REPO: marc-merino/homebrew-knit
+      TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+    steps:
+      - name: Skip when tap token is not configured
+        if: env.TAP_TOKEN == ''
+        run: |
+          echo "::notice::HOMEBREW_TAP_TOKEN is not configured; skipping Homebrew tap PR."
+
+      - name: Download release checksums
+        if: env.TAP_TOKEN != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release download "${GITHUB_REF_NAME}" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --pattern "*.sha256" \
+            --dir shas
+
+      - name: Open tap formula bump PR
+        if: env.TAP_TOKEN != ''
+        env:
+          GH_TOKEN: ${{ env.TAP_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          version="${GITHUB_REF_NAME#v}"
+          branch="bump-knit-${version}-${GITHUB_RUN_ID}"
+
+          read_sha() {
+            local target="$1"
+            awk '{print $1}' "shas/knit-v${version}-${target}.tar.gz.sha256"
+          }
+
+          arm_macos_sha="$(read_sha aarch64-apple-darwin)"
+          intel_macos_sha="$(read_sha x86_64-apple-darwin)"
+          arm_linux_sha="$(read_sha aarch64-unknown-linux-musl)"
+          intel_linux_sha="$(read_sha x86_64-unknown-linux-musl)"
+
+          git clone "https://x-access-token:${GH_TOKEN}@github.com/${TAP_REPO}.git" tap
+          cd tap
+          git switch -c "${branch}"
+
+          python3 - \
+            "${version}" \
+            "${arm_macos_sha}" \
+            "${intel_macos_sha}" \
+            "${arm_linux_sha}" \
+            "${intel_linux_sha}" <<'PY'
+          import re
+          import sys
+
+          version, arm_macos, intel_macos, arm_linux, intel_linux = sys.argv[1:6]
+          path = "Formula/knit.rb"
+          with open(path, encoding="utf-8") as handle:
+              formula = handle.read()
+
+          formula = re.sub(r'version "[^"]*"', f'version "{version}"', formula, count=1)
+          replacements = {
+              "aarch64-apple-darwin": arm_macos,
+              "x86_64-apple-darwin": intel_macos,
+              "aarch64-unknown-linux-musl": arm_linux,
+              "x86_64-unknown-linux-musl": intel_linux,
+          }
+          for target, sha in replacements.items():
+              pattern = rf'(knit-v#\{{version\}}-{re.escape(target)}\.tar\.gz"\n\s*sha256 ")[0-9a-f]{{64}}'
+              formula, count = re.subn(pattern, rf'\g<1>{sha}', formula, count=1)
+              if count != 1:
+                  raise SystemExit(f"failed to update sha for {target}")
+
+          with open(path, "w", encoding="utf-8") as handle:
+              handle.write(formula)
+          PY
+
+          if git diff --quiet; then
+            echo "::notice::Homebrew formula already points at ${version}."
+            exit 0
+          fi
+
+          git config user.name "knit-release-bot"
+          git config user.email "release-bot@users.noreply.github.com"
+          git add Formula/knit.rb
+          git commit -m "knit ${version}"
+          git push -u origin "${branch}"
+          gh pr create \
+            --repo "${TAP_REPO}" \
+            --title "knit ${version}" \
+            --body "Automated formula bump for knit ${version}." \
+            --head "${branch}" \
+            --base main

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -418,7 +418,7 @@ dependencies = [
 
 [[package]]
 name = "knit-cli"
-version = "0.1.0-alpha.3"
+version = "0.1.0-alpha.4"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 # Published as `knit-cli` (the crates.io name `knit` is taken); the installed
 # binary is still `knit`.
 name = "knit-cli"
-version = "0.1.0-alpha.3"
+version = "0.1.0-alpha.4"
 edition = "2021"
 license = "Apache-2.0"
 description = "A local-first CLI for coordinating cross-repo feature bundles."

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ brew tap marc-merino/knit && brew install knit   # macOS / Linux binaries
 ```
 Cargo:
 ```sh
-cargo install knit-cli --version 0.1.0-alpha.3   # from crates.io (the binary is named `knit`;
+cargo install knit-cli --version 0.1.0-alpha.4   # from crates.io (the binary is named `knit`;
                                                  # cargo needs the explicit version while only pre-releases exist)
 # or from a checkout:
 cargo install --path .

--- a/dist/README.md
+++ b/dist/README.md
@@ -12,9 +12,9 @@ Templates for publishing knit to package managers. The canonical release flow:
 # 2. Tag and push — triggers .github/workflows/release.yml, which builds
 #    macOS (x64/arm64), Linux (x64/arm64 musl), and Windows (x64) binaries
 #    and uploads them (plus .sha256 files) to a GitHub release. A tag
-#    containing `-` (e.g. v0.1.0-alpha.3) is marked as a pre-release.
-git tag v0.1.0-alpha.3
-git push origin v0.1.0-alpha.3
+#    containing `-` (e.g. v0.1.0-alpha.4) is marked as a pre-release.
+git tag v0.1.0-alpha.4
+git push origin v0.1.0-alpha.4
 
 # 3. Wait for the Release workflow to finish:
 gh run watch --repo marc-merino/knit "$(gh run list --repo marc-merino/knit --workflow Release --limit 1 --json databaseId -q '.[0].databaseId')"
@@ -33,8 +33,8 @@ Users install with `brew tap marc-merino/knit && brew install knit`. To release:
 # Fill the formula from the release assets:
 #   - bump the `version` stanza in homebrew/knit.rb (URLs derive from it)
 #   - replace each sha256 with the matching .sha256 asset, e.g.:
-gh release view v0.1.0-alpha.3 --repo marc-merino/knit --json assets -q '.assets[].name'
-curl -sL https://github.com/marc-merino/knit/releases/download/v0.1.0-alpha.3/knit-v0.1.0-alpha.3-aarch64-apple-darwin.sha256
+gh release view v0.1.0-alpha.4 --repo marc-merino/knit --json assets -q '.assets[].name'
+curl -sL https://github.com/marc-merino/knit/releases/download/v0.1.0-alpha.4/knit-v0.1.0-alpha.4-aarch64-apple-darwin.sha256
 
 # Copy homebrew/knit.rb into the tap as Formula/knit.rb, commit, push:
 #   github.com/marc-merino/homebrew-knit

--- a/dist/README.md
+++ b/dist/README.md
@@ -22,7 +22,8 @@ gh run watch --repo marc-merino/knit "$(gh run list --repo marc-merino/knit --wo
 # 4. Publish to crates.io (the crate is `knit-cli`; the installed binary stays `knit`):
 cargo publish
 
-# 5. Update the Homebrew tap (see below).
+# 5. Update the Homebrew tap (see below). If HOMEBREW_TAP_TOKEN is configured,
+#    the release workflow opens this PR automatically after assets upload.
 ```
 
 ## Homebrew tap (`marc-merino/homebrew-knit`)
@@ -30,7 +31,11 @@ cargo publish
 Users install with `brew tap marc-merino/knit && brew install knit`. To release:
 
 ```sh
-# Fill the formula from the release assets:
+# The release workflow opens a formula bump PR automatically when the
+# HOMEBREW_TAP_TOKEN secret is configured with Contents:write and
+# Pull requests:write access to marc-merino/homebrew-knit.
+#
+# If that secret is not configured, fill the formula from the release assets:
 #   - bump the `version` stanza in homebrew/knit.rb (URLs derive from it)
 #   - replace each sha256 with the matching .sha256 asset, e.g.:
 gh release view v0.1.0-alpha.4 --repo marc-merino/knit --json assets -q '.assets[].name'
@@ -53,6 +58,6 @@ curl -sL https://github.com/marc-merino/knit/releases/download/v0.1.0-alpha.4/kn
 1. Bump `version` in `Cargo.toml`, land it
 2. Tag `v<version>` and push; wait for the Release workflow
 3. `cargo publish`
-4. Homebrew: bump the formula `version` stanza, refresh the four sha256s, push to the tap
+4. Homebrew: merge the automatically opened tap PR, or manually bump the formula `version` stanza, refresh the four sha256s, and push to the tap
 5. Scoop: bump version + hash (`autoupdate` handles URLs)
 6. Winget: submit a new manifest for the new version

--- a/dist/homebrew/knit.rb
+++ b/dist/homebrew/knit.rb
@@ -2,7 +2,7 @@ class Knit < Formula
   desc "Local-first CLI for coordinating cross-repo feature bundles"
   homepage "https://github.com/marc-merino/knit"
   license "Apache-2.0"
-  version "0.1.0-alpha.3"
+  version "0.1.0-alpha.4"
 
   on_macos do
     if Hardware::CPU.arm?

--- a/dist/scoop/knit.json
+++ b/dist/scoop/knit.json
@@ -1,11 +1,11 @@
 {
-    "version": "0.1.0-alpha.3",
+    "version": "0.1.0-alpha.4",
     "description": "Local-first CLI for coordinating cross-repo feature bundles",
     "homepage": "https://github.com/marc-merino/knit",
     "license": "Apache-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/marc-merino/knit/releases/download/v0.1.0-alpha.3/knit-v0.1.0-alpha.3-x86_64-pc-windows-msvc.zip",
+            "url": "https://github.com/marc-merino/knit/releases/download/v0.1.0-alpha.4/knit-v0.1.0-alpha.4-x86_64-pc-windows-msvc.zip",
             "hash": "REPLACE_WITH_SHA256"
         }
     },

--- a/dist/winget/marc-merino.knit.yaml
+++ b/dist/winget/marc-merino.knit.yaml
@@ -1,5 +1,5 @@
 PackageIdentifier: marc-merino.knit
-PackageVersion: 0.1.0-alpha.3
+PackageVersion: 0.1.0-alpha.4
 PackageLocale: en-US
 Publisher: marc-merino
 PackageName: knit
@@ -12,7 +12,7 @@ Installers:
     NestedInstallerFiles:
       - RelativeFilePath: knit.exe
         PortableCommandAlias: knit
-    InstallerUrl: https://github.com/marc-merino/knit/releases/download/v0.1.0-alpha.3/knit-v0.1.0-alpha.3-x86_64-pc-windows-msvc.zip
+    InstallerUrl: https://github.com/marc-merino/knit/releases/download/v0.1.0-alpha.4/knit-v0.1.0-alpha.4-x86_64-pc-windows-msvc.zip
     InstallerSha256: REPLACE_WITH_SHA256
 ManifestType: singleton
 ManifestVersion: 1.6.0

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -9,7 +9,7 @@ brew tap marc-merino/knit && brew install knit   # macOS / Linux binaries
 ```
 Cargo:
 ```sh
-cargo install knit-cli --version 0.1.0-alpha.3   # from crates.io (the binary is named `knit`;
+cargo install knit-cli --version 0.1.0-alpha.4   # from crates.io (the binary is named `knit`;
                                                  # cargo needs the explicit version while only pre-releases exist)
 # or from a checkout:
 cargo install --path .


### PR DESCRIPTION
Generated by Knit. Cross-links will be refreshed after all review objects are created.

<!-- BEGIN KNIT BUNDLE -->
## Knit Bundle

This PR is part of Knit bundle `prepare-0-1-0-alpha-4-release`.

See the other review objects in this bundle:
- `knit`: https://github.com/marc-merino/knit/pull/99 (this PR)

Bundle id: `prepare-0-1-0-alpha-4-release`
Bundle title: Prepare 0.1.0-alpha.4 release
<!-- END KNIT BUNDLE -->