### PR TITLE
prune removes bundle worktree container (knit)

### DIFF
--- a/src/commands/clean.rs
+++ b/src/commands/clean.rs
@@ -130,7 +130,7 @@ pub(crate) fn clean_worktrees_for_bundle(active: &mut ActiveBundle, force: bool)
         bail!("failed to clean worktrees:\n{}", failures.join("\n"));
     }
 
-    remove_empty_dirs(active.root.join(".knit/worktrees").join(&active.bundle.id));
+    remove_bundle_worktree_container(&active.root, &active.bundle.id);
     Ok(removed)
 }
 
@@ -178,7 +178,7 @@ pub(crate) fn remove_repo_worktree(
         out::path(path.display())
     );
     repo.worktree_path = None;
-    remove_empty_dirs(root.join(".knit/worktrees").join(bundle_id));
+    remove_bundle_worktree_container(root, bundle_id);
     Ok(())
 }
 
@@ -231,6 +231,25 @@ fn remove_empty_dirs(path: PathBuf) {
         remove_empty_dirs(entry.path());
     }
     let _ = fs::remove_dir(path);
+}
+
+fn remove_bundle_worktree_container(root: &Path, bundle_id: &str) {
+    let dir = root.join(".knit/worktrees").join(bundle_id);
+    if !dir.is_dir() {
+        return;
+    }
+    let has_checkout = fs::read_dir(&dir)
+        .map(|entries| {
+            entries
+                .flatten()
+                .any(|entry| entry.file_type().map(|t| t.is_dir()).unwrap_or(false))
+        })
+        .unwrap_or(false);
+    if has_checkout {
+        return;
+    }
+    let _ = fs::remove_file(dir.join("AGENTS.md"));
+    remove_empty_dirs(dir);
 }
 
 fn clean_archived_bundle_worktrees(force: bool) -> Result<()> {

--- a/tests/cleanup.rs
+++ b/tests/cleanup.rs
@@ -623,6 +623,35 @@ fn prune_can_remove_generated_worktrees_local_branches_and_remote_branches() {
 }
 
 #[test]
+fn prune_removes_bundle_worktree_container_dir_and_agents_md() {
+    let root = unique_temp_dir();
+    let backend = root.join("backend");
+    let workspace = root.join("workspace");
+    fs::create_dir_all(&workspace).unwrap();
+    init_repo(&backend, "backend");
+
+    knit(&workspace, ["bundle", "container cleanup"]);
+    knit(&workspace, ["bundle", "add", backend.to_str().unwrap()]);
+
+    let bundle_root = workspace.join(".knit/worktrees/container-cleanup");
+    let feature = bundle_root.join("backend");
+    assert!(feature.exists());
+    assert!(bundle_root.join("AGENTS.md").exists());
+
+    let pruned = knit(
+        &workspace,
+        ["bundle", "prune", "--no-refresh", "--apply", "--worktrees"],
+    );
+    assert!(pruned.contains("Deleted bundle"));
+    assert!(pruned.contains("container-cleanup"));
+    assert!(!feature.exists());
+    assert!(!bundle_root.join("AGENTS.md").exists());
+    assert!(!bundle_root.exists());
+
+    fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
 fn bundle_prune_keeps_bundles_with_unpublished_commits() {
     let root = unique_temp_dir();
     let workspace = root.join("workspace");


### PR DESCRIPTION
Generated by Knit. Cross-links will be refreshed after all review objects are created.

<!-- BEGIN KNIT BUNDLE -->
## Knit Bundle

This PR is part of Knit bundle `prune-removes-bundle-worktree-container`.

See the other review objects in this bundle:
- `knit`: https://github.com/marc-merino/knit/pull/100 (this PR)

Bundle id: `prune-removes-bundle-worktree-container`
Bundle title: prune removes bundle worktree container
<!-- END KNIT BUNDLE -->