### PR TITLE
sync pull discovers remote bundles (knit)

### DIFF
--- a/src/commands/fetch.rs
+++ b/src/commands/fetch.rs
@@ -66,10 +66,14 @@ pub fn fetch_repos(
     }
 
     if fetch_knit {
-        let active = load_active_bundle()?;
+        // Bundle fetch is project-wide and needs only the workspace, not a
+        // resolvable bundle — it must work from the source root even when
+        // several open bundles make the fallback ambiguous.
+        let cwd = std::env::current_dir().context("failed to read current directory")?;
+        let root = crate::store::find_knit_root(&cwd).context("No Knit workspace found.")?;
         knit_result = crate::commands::fetch_bundles_from_remote(
-            &active.root,
-            &crate::store::load_config(&active.root)?,
+            &root,
+            &crate::store::load_config(&root)?,
             remote,
         );
         if let Err(ref error) = knit_result {

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -612,7 +612,7 @@ knit cherrypick --from feature-a --repo backend abc123
 - `knit show HEAD` explains the latest bundle ledger entry.
 - `knit sync` records Git commits made outside Knit (local reconcile, no network).
 - `knit sync push [--bundles|--history|--views|--all] [--remote <name>]...` is the one verb family for moving artifacts to KnitHub; with no target flag it pushes bundle, history, and views.
-- `knit sync pull [--bundles|--history|--views|--all] [--remote <name>]...` pulls those same artifacts from KnitHub.
+- `knit sync pull [--bundles|--history|--views|--all] [--remote <name>]...` pulls those same artifacts from KnitHub. Bundle pull is project-wide: open bundles created on other machines (and their recorded PRs) are localized into `.knit/bundles/`, and stale local artifacts fast-forward whatever their state; materialize checkouts for a discovered bundle with `knit --bundle <slug> bundle worktree`.
 - `knit pull --merge` union-merges the bundle ledger when the local and KnitHub artifacts have diverged (two users recorded work concurrently); diverged feature branches still need a git merge in the worktree afterwards.
 - `knit push --set-upstream` pushes every tracked feature branch in the resolved bundle to `origin` and sets upstream tracking.
 - `knit push --remote hosted` pushes the resolved bundle's branches and artifact to the configured KnitHub remote so it is visible in hosted dashboards.

--- a/src/commands/remote/facade.rs
+++ b/src/commands/remote/facade.rs
@@ -139,12 +139,32 @@ pub fn sync_pull(targets: SyncTargets, remote_overrides: &[String]) -> Result<()
             println!("{} {}", out::heading("Remote:"), out::repo(remote));
         }
         if targets.bundles {
-            // Reuse the existing active-bundle pull, which performs the
-            // fast-forward localize/refresh that another change owns. Diverged
-            // ledgers are reported, not merged; `knit pull --merge` is the
-            // explicit door for that.
-            if let Err(error) = super::pull::pull_remote_state(Some(remote), false, false) {
-                failures.push(format!("{remote} bundle: {error:#}"));
+            // Deep refresh (feature branches, worktree checkouts) for the
+            // resolved bundle when one resolves. From the workspace root with
+            // several open bundles there is no resolvable bundle — that is
+            // fine, the project-wide artifact sync below still runs. Order
+            // matters: the artifact-only sync would fast-forward the active
+            // bundle's artifact first and turn this into a skip, leaving its
+            // checkouts stale.
+            if crate::store::load_active_bundle().is_ok() {
+                if let Err(error) = super::pull::pull_remote_state(Some(remote), false, false) {
+                    failures.push(format!("{remote} bundle: {error:#}"));
+                }
+            }
+            // Project-wide: localize remote bundles absent locally and
+            // fast-forward stale artifacts, so bundles (and their recorded
+            // PRs) created on other machines appear here without knowing
+            // their slugs. Diverged ledgers are reported, not merged;
+            // `knit pull --merge` is the explicit door for that.
+            match effective_workspace_config() {
+                Ok((root, config)) => {
+                    if let Err(error) =
+                        super::pull::fetch_bundles_from_remote(&root, &config, Some(remote))
+                    {
+                        failures.push(format!("{remote} bundles: {error:#}"));
+                    }
+                }
+                Err(error) => failures.push(format!("{remote} bundles: {error:#}")),
             }
         }
         if targets.history {

--- a/src/commands/remote/pull.rs
+++ b/src/commands/remote/pull.rs
@@ -503,6 +503,15 @@ pub fn fetch_bundles_from_remote(
             .with_context(|| format!("failed to decode bundle `{}`", remote_bundle.slug))?;
 
         let bundle_path = bundles_dir.join(format!("{}.bundle.json", bundle.id));
+        // Discovery is for bundles you might act on: a remote bundle with no
+        // local artifact is only localized while it is open. Resurrecting the
+        // project's full landed/archived history would flood the workspace
+        // and undo `knit bundle prune` on every sync. Existing local
+        // artifacts still fast-forward whatever their state, so work landed
+        // or archived on another machine is reflected here.
+        if !bundle_path.exists() && remote_bundle.lifecycle_state != "open" {
+            continue;
+        }
         // An existing local artifact is only refreshed when the remote ledger is
         // strictly ahead (a fast-forward). Equal/local-ahead artifacts are left
         // untouched; diverged ledgers keep local and warn.

--- a/tests/sync.rs
+++ b/tests/sync.rs
@@ -633,3 +633,98 @@ fn pull_merge_unions_diverged_bundle_ledgers() {
 
     fs::remove_dir_all(root).unwrap();
 }
+
+#[test]
+fn sync_pull_discovers_remote_bundles_project_wide() {
+    let root = unique_temp_dir();
+    let (_remote, backend, _collaborator) = init_remote_repo(&root, "backend");
+    let workspace = root.join("workspace");
+    fs::create_dir_all(&workspace).unwrap();
+
+    knit(&workspace, ["init", "demo"]);
+    knit(
+        &workspace,
+        ["project", "add", "backend", backend.to_str().unwrap()],
+    );
+
+    // Author a bundle with a commit and capture its artifact — the payload
+    // another machine would have pushed to KnitHub — then erase it locally as
+    // if it had never existed here.
+    knit(&workspace, ["bundle", "svartal made", "--repo", "backend"]);
+    let feature = workspace.join(".knit/worktrees/svartal-made/backend");
+    append_line(&feature.join("app.txt"), "work from another machine");
+    knit(&workspace, ["commit", "--all", "-m", "Remote-machine work"]);
+    let artifact_path = workspace.join(".knit/bundles/svartal-made.bundle.json");
+    let payload: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(&artifact_path).unwrap()).unwrap();
+    fs::remove_file(&artifact_path).unwrap();
+    fs::remove_dir_all(workspace.join(".knit/worktrees/svartal-made")).unwrap();
+
+    // Two other open bundles make the source-root fallback ambiguous — the
+    // situation where the old active-bundle-only sync pull broke.
+    knit(&workspace, ["bundle", "other work", "--repo", "backend"]);
+    knit(&workspace, ["bundle", "third work", "--repo", "backend"]);
+
+    let mut archived_payload = payload.clone();
+    archived_payload["id"] = serde_json::json!("old-landed");
+    let export = serde_json::json!({
+        "data": {
+            "project": {"slug": "demo"},
+            "knitProject": null,
+            "repositories": [],
+            "bundles": [
+                {
+                    "id": "rb-1",
+                    "slug": "svartal-made",
+                    "lifecycleState": "open",
+                    "currentArtifact": {"artifactHash": "hash-svartal", "payload": payload},
+                },
+                {
+                    "id": "rb-2",
+                    "slug": "dead-bundle",
+                    "lifecycleState": "deleted",
+                    "currentArtifact": null,
+                },
+                {
+                    "id": "rb-3",
+                    "slug": "old-landed",
+                    "lifecycleState": "archived",
+                    "currentArtifact": {"artifactHash": "hash-old", "payload": archived_payload},
+                },
+            ],
+            "historyEvents": [],
+        }
+    });
+    let base_url = spawn_fake_knithub_with_body(export.to_string());
+    knit(&workspace, ["remote", "add", "hosted", &base_url]);
+    let env = [("KNIT_REMOTE_TOKEN", "test-token")];
+
+    let output = knit_with_env(
+        &workspace,
+        ["sync", "pull", "--bundles", "--remote", "hosted"],
+        &env,
+    );
+    assert!(output.contains("fetched"), "{output}");
+
+    // The open remote-only bundle is localized as an artifact; deleted and
+    // archived remote records are not — discovery never resurrects the
+    // project's dead-work history.
+    assert!(artifact_path.exists());
+    let list = knit(&workspace, ["bundle", "list"]);
+    assert!(list.contains("svartal-made"), "{list}");
+    assert!(!list.contains("dead-bundle"), "{list}");
+    assert!(!list.contains("old-landed"), "{list}");
+    assert!(!workspace
+        .join(".knit/bundles/old-landed.bundle.json")
+        .exists());
+
+    // `knit fetch --mode knit` shares the project-wide path and must also work
+    // from the source root while several open bundles exist.
+    let fetch_output = knit_with_env(&workspace, ["fetch", "--mode", "knit"], &env);
+    assert!(
+        fetch_output.contains("up-to-date") || fetch_output.contains("fetched"),
+        "{fetch_output}"
+    );
+
+    fs::remove_dir_all(root).unwrap();
+}


### PR DESCRIPTION
Generated by Knit. Cross-links will be refreshed after all review objects are created.

<!-- BEGIN KNIT BUNDLE -->
## Knit Bundle

This PR is part of Knit bundle `sync-pull-discovers-remote-bundles`.

See the other review objects in this bundle:
- `knit`: https://github.com/marc-merino/knit/pull/107 (this PR)

Bundle id: `sync-pull-discovers-remote-bundles`
Bundle title: sync pull discovers remote bundles
<!-- END KNIT BUNDLE -->