### PR TITLE
fix discovery resurrection and unclickable bundles (knit)

### DIFF
--- a/src/commands/remote/pull.rs
+++ b/src/commands/remote/pull.rs
@@ -509,8 +509,21 @@ pub fn fetch_bundles_from_remote(
         // and undo `knit bundle prune` on every sync. Existing local
         // artifacts still fast-forward whatever their state, so work landed
         // or archived on another machine is reflected here.
-        if !bundle_path.exists() && remote_bundle.lifecycle_state != "open" {
-            continue;
+        if !bundle_path.exists() {
+            if remote_bundle.lifecycle_state != "open" {
+                continue;
+            }
+            // The remote lifecycle can still read "open" for a bundle that was
+            // landed or pruned here (nothing pushes terminal state back), so
+            // the local delete quarantine is the authority: a bundle deleted
+            // locally stays deleted.
+            if root
+                .join(".knit/deleted/bundles")
+                .join(format!("{}.bundle.json", bundle.id))
+                .exists()
+            {
+                continue;
+            }
         }
         // An existing local artifact is only refreshed when the remote ledger is
         // strictly ahead (a fast-forward). Equal/local-ahead artifacts are left

--- a/tests/sync.rs
+++ b/tests/sync.rs
@@ -728,3 +728,66 @@ fn sync_pull_discovers_remote_bundles_project_wide() {
 
     fs::remove_dir_all(root).unwrap();
 }
+
+#[test]
+fn sync_pull_does_not_resurrect_locally_deleted_bundles() {
+    let root = unique_temp_dir();
+    let (_remote, backend, _collaborator) = init_remote_repo(&root, "backend");
+    let workspace = root.join("workspace");
+    fs::create_dir_all(&workspace).unwrap();
+
+    knit(&workspace, ["init", "demo"]);
+    knit(
+        &workspace,
+        ["project", "add", "backend", backend.to_str().unwrap()],
+    );
+
+    // Author a bundle and capture the artifact the remote still holds — the
+    // copy pushed at publish time, before the bundle was landed and pruned
+    // here. Nothing pushes terminal state back, so the remote says "open".
+    knit(&workspace, ["bundle", "pruned work", "--repo", "backend"]);
+    let feature = workspace.join(".knit/worktrees/pruned-work/backend");
+    append_line(&feature.join("app.txt"), "work later landed and pruned");
+    knit(&workspace, ["commit", "--all", "-m", "Landed work"]);
+    let artifact_path = workspace.join(".knit/bundles/pruned-work.bundle.json");
+    let payload: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(&artifact_path).unwrap()).unwrap();
+    knit(&workspace, ["bundle", "delete", "pruned-work", "--force"]);
+    assert!(!artifact_path.exists());
+    assert!(workspace
+        .join(".knit/deleted/bundles/pruned-work.bundle.json")
+        .exists());
+
+    let export = serde_json::json!({
+        "data": {
+            "project": {"slug": "demo"},
+            "knitProject": null,
+            "repositories": [],
+            "bundles": [{
+                "id": "rb-1",
+                "slug": "pruned-work",
+                "lifecycleState": "open",
+                "currentArtifact": {"artifactHash": "hash-stale-open", "payload": payload},
+            }],
+            "historyEvents": [],
+        }
+    });
+    let base_url = spawn_fake_knithub_with_body(export.to_string());
+    knit(&workspace, ["remote", "add", "hosted", &base_url]);
+    let env = [("KNIT_REMOTE_TOKEN", "test-token")];
+
+    let output = knit_with_env(
+        &workspace,
+        ["sync", "pull", "--bundles", "--remote", "hosted"],
+        &env,
+    );
+    assert!(output.contains("up-to-date"), "{output}");
+
+    // The local delete quarantine is the authority: the stale-open remote
+    // record must not come back as an open, worktree-less bundle.
+    assert!(!artifact_path.exists());
+    let list = knit(&workspace, ["bundle", "list"]);
+    assert!(!list.contains("pruned-work"), "{list}");
+
+    fs::remove_dir_all(root).unwrap();
+}


### PR DESCRIPTION
Generated by Knit. Cross-links will be refreshed after all review objects are created.

<!-- BEGIN KNIT BUNDLE -->
## Knit Bundle

This PR is part of Knit bundle `fix-discovery-resurrection-and-unclickable-bundles`.

See the other review objects in this bundle:
- `knit`: https://github.com/marc-merino/knit/pull/109 (this PR)
- `k3`: https://github.com/marc-merino/K3/pull/5

Bundle id: `fix-discovery-resurrection-and-unclickable-bundles`
Bundle title: fix discovery resurrection and unclickable bundles
<!-- END KNIT BUNDLE -->