### PR TITLE
explicit kg push instead of sync push all (knit)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -128,10 +128,10 @@ Three kinds of Knit artifact move between the workspace and KnitHub remotes: bun
 
 This is consolidated into one verb family. `knit sync` keeps its original meaning exactly — a local-only reconcile that records git commits made outside Knit — and gains two subcommands that are the one explicit way to move artifacts:
 
-- `knit sync push [--bundles|--history|--views|--all] [--remote <name>]...`
+- `knit sync push [--bundles|--history|--views|--architecture|--kg|--all] [--remote <name>]...`
 - `knit sync pull [--bundles|--history|--views|--all] [--remote <name>]...`
 
-With no target flag, both move every relevant artifact family. Remote selection resolves explicit `--remote` overrides first, then configured sync remotes, then the sole configured remote.
+With no target flag, both move every routine artifact family; the knowledge-graph viz slice is bulky and moves only on an explicit `--kg`. Remote selection resolves explicit `--remote` overrides first, then configured sync remotes, then the sole configured remote.
 
 The absorbed verbs are deleted, not aliased or hidden: `knit bundle push`, `knit history push/pull/sync` (only `history list` and `history refresh` remain), `knit view push/pull`, and `knit land sync` no longer exist. The philosophy is one way per outcome — delete, do not hide.
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -117,7 +117,7 @@ knit schema print <bundle|project|merge-run|land-plan|land-run|config>
 knit doctor
 knit migrate [--check]
 knit sync                                      # record git commits made outside Knit (local reconcile)
-knit sync push [--bundles] [--history] [--views] [--all] [--remote <name>]...
+knit sync push [--bundles] [--history] [--views] [--architecture] [--kg] [--all] [--remote <name>]...
 knit sync pull [--bundles] [--history] [--views] [--all] [--remote <name>]...
 knit history [list] [-n <count>] [--repo <repo>] [--bundle <bundle>] [--project <project>]
 knit history refresh [--project <project>]
@@ -504,16 +504,17 @@ When KnitHub sync remotes are configured, `knit publish create` and `knit push` 
 `knit sync` with no subcommand is a local-only reconcile: it records git commits made outside Knit as `git.observed` nodes and never touches the network. Its `push`/`pull` subcommands are the one verb family for moving Knit artifacts (bundles, project history, and saved views) between the workspace and KnitHub remotes:
 
 ```sh
-knit sync push                 # push bundle + history + views for the resolved project/bundle
+knit sync push                 # push bundle + history + views + architecture for the resolved project/bundle
 knit sync push --bundles       # push only the bundle artifact (e.g. after landing)
 knit sync push --history       # push only project history events
 knit sync push --views         # push only your saved views
+knit sync push --kg            # push the knowledge-graph viz slice (explicit only)
 knit sync pull                 # pull bundle + history + views
 knit sync pull --history       # pull only project history events
 knit sync push --remote hosted    # use an explicit remote
 ```
 
-With no target flag (`--bundles`/`--history`/`--views`/`--all`), `knit sync push`/`pull` move every relevant artifact family. Remotes default to the configured sync remotes (`knit config set sync-remotes ...`, then `sync-remote`), falling back to the sole configured remote; override with one or more `--remote <name>`.
+With no target flag (`--bundles`/`--history`/`--views`/`--architecture`/`--all`), `knit sync push`/`pull` move every routine artifact family. The knowledge-graph viz slice (produced by `urdir kg viz`, often several MB) is deliberately excluded from `--all` and bare invocations — push it with an explicit `knit sync push --kg` after regenerating it. Remotes default to the configured sync remotes (`knit config set sync-remotes ...`, then `sync-remote`), falling back to the sole configured remote; override with one or more `--remote <name>`.
 
 The git-shaped verbs keep their git semantics but route through the same internal sync module: `knit push --remote <name>` still pushes branches and then the bundle artifact, and `knit fetch --bundles` / `knit pull --bundles` still pull recorded bundle state. Landing's automatic artifact sync (when `push-sync` is enabled) goes through the same module too. There is one implementation behind several differently shaped doors.
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -424,7 +424,8 @@ pub enum Commands {
 #[derive(Subcommand)]
 pub enum SyncCommand {
     /// Push artifacts to KnitHub. With no target flags, pushes bundle, history,
-    /// and views for the resolved project/bundle.
+    /// views, and architecture for the resolved project/bundle; the
+    /// knowledge-graph viz slice moves only with an explicit `--kg`.
     Push {
         #[command(flatten)]
         targets: SyncTargetArgs,
@@ -457,10 +458,14 @@ pub struct SyncTargetArgs {
     /// Sync the project architecture artifact (produced by `urdir kg architecture`).
     #[arg(long)]
     pub architecture: bool,
-    /// Sync the knowledge-graph viz slice (produced by `urdir kg viz`).
+    /// Sync the knowledge-graph viz slice (produced by `urdir kg viz`). The
+    /// slice is often several MB, so it moves only with this explicit flag —
+    /// never as part of `--all` or a bare invocation.
     #[arg(long)]
     pub kg: bool,
-    /// Sync every artifact family. This is also the default with no target flags.
+    /// Sync every routine artifact family (bundles, history, views,
+    /// architecture). This is also the default with no target flags. The
+    /// knowledge-graph viz slice needs an explicit `--kg`.
     #[arg(long)]
     pub all: bool,
 }

--- a/src/commands/remote/facade.rs
+++ b/src/commands/remote/facade.rs
@@ -20,7 +20,8 @@ use crate::output as out;
 use anyhow::{bail, Result};
 
 /// Which artifact families a `knit sync push`/`pull` should move. With no flags
-/// passed on the CLI, the resolver below treats that as "everything".
+/// passed on the CLI, the resolver below treats that as "every routine family";
+/// the knowledge-graph viz slice is not routine and moves only on explicit `--kg`.
 #[derive(Clone, Copy, Debug)]
 pub struct SyncTargets {
     pub bundles: bool,
@@ -32,8 +33,12 @@ pub struct SyncTargets {
 
 impl SyncTargets {
     /// Resolve the artifact selection from the CLI flags. Bare invocation (no
-    /// `--bundles/--history/--views/--architecture/--kg/--all`) means everything;
-    /// architecture/kg are no-op-with-note when no artifact has been produced.
+    /// `--bundles/--history/--views/--architecture/--kg/--all`) and `--all` mean
+    /// every routine family. The knowledge-graph viz slice is excluded from both:
+    /// it is a bulky, slowly-changing artifact (often several MB) that has no
+    /// business riding along on every sync, so it moves only when `--kg` is
+    /// passed explicitly. Architecture/kg are no-op-with-note when no artifact
+    /// has been produced.
     pub fn resolve(
         bundles: bool,
         history: bool,
@@ -48,7 +53,7 @@ impl SyncTargets {
                 history: true,
                 views: true,
                 architecture: true,
-                kg: true,
+                kg,
             }
         } else {
             SyncTargets {
@@ -191,5 +196,60 @@ fn finish(failures: Vec<String>, verb: &str) -> Result<()> {
             failures.len(),
             failures.join("\n")
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::SyncTargets;
+
+    #[test]
+    fn bare_invocation_moves_routine_families_but_not_kg() {
+        let targets = SyncTargets::resolve(false, false, false, false, false, false);
+        assert!(targets.bundles);
+        assert!(targets.history);
+        assert!(targets.views);
+        assert!(targets.architecture);
+        assert!(!targets.kg);
+    }
+
+    #[test]
+    fn all_flag_moves_routine_families_but_not_kg() {
+        let targets = SyncTargets::resolve(false, false, false, false, false, true);
+        assert!(targets.bundles);
+        assert!(targets.history);
+        assert!(targets.views);
+        assert!(targets.architecture);
+        assert!(!targets.kg);
+    }
+
+    #[test]
+    fn explicit_kg_flag_moves_only_kg() {
+        let targets = SyncTargets::resolve(false, false, false, false, true, false);
+        assert!(!targets.bundles);
+        assert!(!targets.history);
+        assert!(!targets.views);
+        assert!(!targets.architecture);
+        assert!(targets.kg);
+    }
+
+    #[test]
+    fn all_plus_explicit_kg_moves_everything() {
+        let targets = SyncTargets::resolve(false, false, false, false, true, true);
+        assert!(targets.bundles);
+        assert!(targets.history);
+        assert!(targets.views);
+        assert!(targets.architecture);
+        assert!(targets.kg);
+    }
+
+    #[test]
+    fn explicit_family_selection_is_untouched() {
+        let targets = SyncTargets::resolve(true, false, true, false, false, false);
+        assert!(targets.bundles);
+        assert!(!targets.history);
+        assert!(targets.views);
+        assert!(!targets.architecture);
+        assert!(!targets.kg);
     }
 }


### PR DESCRIPTION
Generated by Knit. Cross-links will be refreshed after all review objects are created.

<!-- BEGIN KNIT BUNDLE -->
## Knit Bundle

This PR is part of Knit bundle `explicit-kg-push-instead-of-sync-push-all`.

See the other review objects in this bundle:
- `knit`: https://github.com/marc-merino/knit/pull/112 (this PR)
- `k3`: https://github.com/marc-merino/K3/pull/18

Bundle id: `explicit-kg-push-instead-of-sync-push-all`
Bundle title: explicit kg push instead of sync push all
<!-- END KNIT BUNDLE -->