### PR TITLE
cross-collab clone fetch pull audit (knit)

### DIFF
--- a/src/commands/bundle/mod.rs
+++ b/src/commands/bundle/mod.rs
@@ -194,6 +194,10 @@ pub fn switch_bundle(bundle_id: &str, workspace: bool) -> Result<()> {
         out::heading("Active bundle:"),
         out::node(&bundle_id)
     );
+    crate::advice::print(
+        &root,
+        format!("run `knit pull` to materialize and update `{bundle_id}`."),
+    );
 
     Ok(())
 }

--- a/src/commands/fetch.rs
+++ b/src/commands/fetch.rs
@@ -1,7 +1,6 @@
 use crate::cli::FetchMode;
 use crate::git::{git_output, git_output_optional};
 use crate::ids::short_sha;
-use crate::model::RepoEntry;
 use crate::output as out;
 use crate::repo_selectors::resolve_repo_indexes;
 use crate::store::load_active_bundle;
@@ -21,23 +20,14 @@ pub fn fetch_repos(
     let mut knit_result = Ok(());
 
     if fetch_git {
-        let active = load_active_bundle()?;
-        if active.bundle.repos.is_empty() {
-            bail!("The resolved bundle has no repos. Run `knit bundle add <repo-path>` first.");
-        }
-
-        let indexes = resolve_repo_indexes(&active, selectors, false)?;
-        let repos: Vec<&RepoEntry> = indexes
-            .iter()
-            .map(|index| &active.bundle.repos[*index])
-            .collect();
+        let targets = resolve_fetch_targets(selectors)?;
 
         let results: Vec<(String, Result<FetchOutcome>)> = std::thread::scope(|scope| {
-            let handles: Vec<_> = repos
+            let handles: Vec<_> = targets
                 .iter()
-                .map(|repo| {
-                    let repo_id = repo.id.clone();
-                    scope.spawn(move || (repo_id, fetch_repo(repo)))
+                .map(|target| {
+                    let repo_id = target.repo_id.clone();
+                    scope.spawn(move || (repo_id, fetch_repo(target)))
                 })
                 .collect();
 
@@ -95,6 +85,63 @@ pub fn fetch_repos(
     Ok(())
 }
 
+struct FetchTarget {
+    repo_id: String,
+    path: String,
+    base_branch: String,
+}
+
+/// Resolve which repos the git side of `knit fetch` updates. Inside a resolved
+/// bundle that is the bundle's repos; when no bundle resolves (a fresh
+/// collaborator workspace, before any bundle exists locally) fall back to the
+/// active project's repos so fetch still refreshes git refs — and the bundle
+/// fetch below still runs — instead of failing outright.
+fn resolve_fetch_targets(selectors: &[String]) -> Result<Vec<FetchTarget>> {
+    let bundle_error = match load_active_bundle() {
+        Ok(active) => {
+            if active.bundle.repos.is_empty() {
+                bail!("The resolved bundle has no repos. Run `knit bundle add <repo-path>` first.");
+            }
+            let indexes = resolve_repo_indexes(&active, selectors, false)?;
+            return Ok(indexes
+                .iter()
+                .map(|index| {
+                    let repo = &active.bundle.repos[*index];
+                    FetchTarget {
+                        repo_id: repo.id.clone(),
+                        path: repo.path.clone(),
+                        base_branch: repo.base_branch.clone(),
+                    }
+                })
+                .collect());
+        }
+        Err(error) => error,
+    };
+
+    let cwd = std::env::current_dir().context("failed to read current directory")?;
+    let Some(root) = crate::store::find_knit_root(&cwd) else {
+        return Err(bundle_error);
+    };
+    let Some(project_id) = crate::store::load_config(&root)?.active_project else {
+        return Err(bundle_error);
+    };
+    let project = crate::commands::project::load_project_by_id(&root, &project_id)?;
+    let targets: Vec<FetchTarget> = project
+        .repos
+        .iter()
+        .filter(|repo| selectors.is_empty() || selectors.iter().any(|s| s == &repo.id))
+        .map(|repo| FetchTarget {
+            repo_id: repo.id.clone(),
+            path: repo.path.clone(),
+            base_branch: repo.base_branch.clone(),
+        })
+        .collect();
+    if targets.is_empty() {
+        return Err(bundle_error);
+    }
+    Ok(targets)
+}
+
 struct FetchOutcome {
     repo_id: String,
     remote_ref: String,
@@ -102,7 +149,7 @@ struct FetchOutcome {
     after: Option<String>,
 }
 
-fn fetch_repo(repo: &RepoEntry) -> Result<FetchOutcome> {
+fn fetch_repo(repo: &FetchTarget) -> Result<FetchOutcome> {
     let cwd = PathBuf::from(&repo.path);
     if !cwd.exists() {
         bail!("original repo path does not exist: {}", cwd.display());
@@ -118,7 +165,7 @@ fn fetch_repo(repo: &RepoEntry) -> Result<FetchOutcome> {
     let after = ref_sha(&cwd, &remote_ref)?;
 
     Ok(FetchOutcome {
-        repo_id: repo.id.clone(),
+        repo_id: repo.repo_id.clone(),
         remote_ref,
         before,
         after,

--- a/src/commands/pull.rs
+++ b/src/commands/pull.rs
@@ -304,6 +304,7 @@ enum Outcome {
     Advanced { before: String, after: String },
     Unchanged(String),
     Synced(String),
+    Refreshed(String),
     Skipped(String),
     Failed(String),
 }
@@ -406,9 +407,15 @@ fn aggregate_pull(
                 let context = remote_context.as_ref();
                 let root = root.as_path();
                 let paths = bundle_repo_paths.get(id).cloned().unwrap_or_default();
+                // The workspace's pointed-at bundle gets the deep refresh:
+                // missing worktrees are materialized so `knit fetch` +
+                // `knit switch` + `knit pull` yields a usable checkout. Other
+                // open bundles only refresh checkouts they already have.
+                let materialize = config.active_bundle.as_deref() == Some(id.as_str());
                 scope.spawn(move || {
-                    let outcome =
-                        gate.lock_all(&paths, || pull_one_bundle(root, context, id, merge));
+                    let outcome = gate.lock_all(&paths, || {
+                        pull_one_bundle(root, context, id, merge, materialize)
+                    });
                     (id.clone(), outcome)
                 })
             })
@@ -472,15 +479,17 @@ fn pull_one_bundle(
     context: Option<&RemotePullContext>,
     bundle_id: &str,
     merge: bool,
+    materialize: bool,
 ) -> Outcome {
     let Some(context) = context else {
         return Outcome::Skipped("no KnitHub remote configured".to_string());
     };
-    match pull_bundle_remote_state(root, context, bundle_id, merge) {
+    match pull_bundle_remote_state(root, context, bundle_id, merge, materialize) {
         Ok(RemoteBundleOutcome::Pulled(hash)) => Outcome::Synced(hash),
         Ok(RemoteBundleOutcome::Merged(hash)) => {
             Outcome::Synced(format!("{hash} (merged ledgers)"))
         }
+        Ok(RemoteBundleOutcome::Refreshed(summary)) => Outcome::Refreshed(summary),
         Ok(RemoteBundleOutcome::Skipped(reason)) => Outcome::Skipped(reason),
         Err(error) => Outcome::Failed(condense(&error)),
     }
@@ -530,11 +539,12 @@ fn report(main_results: &[(String, Outcome)], bundle_results: &[(String, Outcome
         return;
     }
     println!(
-        "{} {} advanced, {} unchanged, {} synced, {} skipped, {} failed",
+        "{} {} advanced, {} unchanged, {} synced, {} refreshed, {} skipped, {} failed",
         out::heading("Pulled:"),
         totals.advanced,
         totals.unchanged,
         totals.synced,
+        totals.refreshed,
         totals.skipped,
         totals.failed
     );
@@ -545,6 +555,7 @@ struct Totals {
     advanced: usize,
     unchanged: usize,
     synced: usize,
+    refreshed: usize,
     skipped: usize,
     failed: usize,
 }
@@ -555,6 +566,7 @@ impl Totals {
             Outcome::Advanced { .. } => self.advanced += 1,
             Outcome::Unchanged(_) => self.unchanged += 1,
             Outcome::Synced(_) => self.synced += 1,
+            Outcome::Refreshed(_) => self.refreshed += 1,
             Outcome::Skipped(_) => self.skipped += 1,
             Outcome::Failed(_) => self.failed += 1,
         }
@@ -581,6 +593,12 @@ fn print_outcome(id: &str, outcome: &Outcome) {
             out::repo(id),
             out::movement("pulled"),
             out::muted(hash)
+        ),
+        Outcome::Refreshed(summary) => println!(
+            "  {} {} {}",
+            out::repo(id),
+            out::movement("refreshed"),
+            out::muted(summary)
         ),
         Outcome::Skipped(reason) => println!(
             "  {} {} ({})",

--- a/src/commands/remote/clone.rs
+++ b/src/commands/remote/clone.rs
@@ -144,6 +144,12 @@ pub fn clone_project_from_remote(
             println!("  {}: {}", out::repo(local_id), out::muted(error));
         }
     }
+    if let Some(omitted) = export.omitted_repository_count.filter(|count| *count > 0) {
+        println!(
+            "{} the export omitted {omitted} private repo(s) this token cannot see; the cloned project is incomplete. Ask a project maintainer for access.",
+            out::warn("Not exported:")
+        );
+    }
     if !skipped_bundles.is_empty() {
         println!(
             "{} {} bundle(s) referencing skipped repo(s): {}",

--- a/src/commands/remote/mod.rs
+++ b/src/commands/remote/mod.rs
@@ -82,6 +82,11 @@ struct RemoteProjectExport {
     bundles: Vec<RemoteExportBundle>,
     #[serde(default)]
     history_events: Vec<HistoryEvent>,
+    /// Repos the server withheld from this export (private repos the caller
+    /// cannot see). Lets clone/pull say "the export is incomplete for you"
+    /// instead of silently presenting a partial project as the whole thing.
+    #[serde(default)]
+    omitted_repository_count: Option<u64>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/commands/remote/pull.rs
+++ b/src/commands/remote/pull.rs
@@ -81,6 +81,9 @@ pub enum RemoteBundleOutcome {
     /// Diverged ledgers were union-merged into the local artifact; carries the
     /// remote artifact hash that was merged in.
     Merged(String),
+    /// The artifact was already current but local checkouts were materialized
+    /// and/or fast-forwarded; carries a human-readable summary.
+    Refreshed(String),
     /// Nothing to apply; carries a human-readable reason.
     Skipped(String),
 }
@@ -158,14 +161,20 @@ fn reconcile_project_repositories(
         .map(export_repo_local_id)
         .collect();
 
+    // When the server withheld private repos from this export, an absent repo
+    // is indistinguishable from a hidden one — never drop local project repos
+    // on an admittedly incomplete export.
+    let export_complete = export.omitted_repository_count.unwrap_or(0) == 0;
     let mut removed = Vec::new();
-    project.repos.retain(|repo| {
-        let keep = export_ids.contains(&repo.id);
-        if !keep {
-            removed.push(repo.id.clone());
-        }
-        keep
-    });
+    if export_complete {
+        project.repos.retain(|repo| {
+            let keep = export_ids.contains(&repo.id);
+            if !keep {
+                removed.push(repo.id.clone());
+            }
+            keep
+        });
+    }
 
     let existing: BTreeSet<String> = project.repos.iter().map(|repo| repo.id.clone()).collect();
     let to_add: Vec<&RemoteExportRepository> = export
@@ -240,11 +249,18 @@ fn reconcile_project_repositories(
 /// instead of skipped: the saved artifact records both sides' nodes, and any
 /// feature checkout that cannot fast-forward onto origin is reported for
 /// manual git-level merging without failing the artifact merge.
+/// With `materialize` set (the resolved/active bundle), an artifact that is
+/// already current still gets its feature branches fetched, missing worktrees
+/// created, and checkouts fast-forwarded — `knit fetch` advances the artifact
+/// without touching checkouts, so pull must close that gap or a fetched bundle
+/// never becomes usable. Without `materialize`, only checkouts that already
+/// exist on disk are refreshed; none are created.
 pub fn pull_bundle_remote_state(
     root: &Path,
     context: &RemotePullContext,
     bundle_id: &str,
     merge: bool,
+    materialize: bool,
 ) -> Result<RemoteBundleOutcome> {
     let path = bundle_path(root, bundle_id);
     if !path.exists() {
@@ -273,11 +289,17 @@ pub fn pull_bundle_remote_state(
     };
     let remote_payload = decode_bundle_payload(&artifact.payload, &remote_bundle.slug)?;
     match ledger_relation(&local.node_id_sequence(), &remote_payload.node_id_sequence()) {
-        LedgerRelation::Equal => return Ok(RemoteBundleOutcome::Skipped("up to date".to_string())),
+        LedgerRelation::Equal => {
+            return refresh_bundle_checkouts(root, path, local, materialize, "up to date")
+        }
         LedgerRelation::LocalAhead => {
-            return Ok(RemoteBundleOutcome::Skipped(
-                "local is ahead of remote".to_string(),
-            ))
+            return refresh_bundle_checkouts(
+                root,
+                path,
+                local,
+                materialize,
+                "local is ahead of remote",
+            )
         }
         LedgerRelation::Diverged if !merge => {
             return Ok(RemoteBundleOutcome::Skipped(format!(
@@ -321,12 +343,121 @@ pub fn pull_bundle_remote_state(
     Ok(RemoteBundleOutcome::Pulled(artifact.artifact_hash.clone()))
 }
 
+/// Refresh a bundle whose artifact needs no update. Fetches feature branches,
+/// materializes missing worktrees when `materialize` is set, re-records
+/// checkouts that exist on disk but are missing from the artifact (a
+/// remote-localized artifact carries no worktree paths), and fast-forwards
+/// every checkout onto origin. Returns `Skipped(reason)` when there was
+/// nothing to touch, so callers keep today's quiet no-op behavior.
+fn refresh_bundle_checkouts(
+    root: &Path,
+    path: std::path::PathBuf,
+    bundle: ChangeGroup,
+    materialize: bool,
+    reason: &str,
+) -> Result<RemoteBundleOutcome> {
+    let mut existing_dirs: Vec<(String, std::path::PathBuf)> = Vec::new();
+    let mut unrecorded_on_disk = Vec::new();
+    let mut absent = Vec::new();
+    for repo in &bundle.repos {
+        if repo.feature_branch.is_none() {
+            continue;
+        }
+        if let Some(dir) = recorded_checkout_dir(root, repo) {
+            existing_dirs.push((repo.id.clone(), dir));
+            continue;
+        }
+        // A worktree can exist at the conventional location even though the
+        // artifact does not record it — the state a remote-localized artifact
+        // leaves behind for checkouts created earlier. Re-record it.
+        let conventional = root.join(".knit/worktrees").join(&bundle.id).join(&repo.id);
+        if conventional.exists() {
+            existing_dirs.push((repo.id.clone(), conventional));
+            unrecorded_on_disk.push(repo.id.clone());
+        } else {
+            absent.push(repo.id.clone());
+        }
+    }
+
+    let mut to_materialize = unrecorded_on_disk;
+    if materialize {
+        to_materialize.extend(absent.iter().cloned());
+    }
+    if existing_dirs.is_empty() && to_materialize.is_empty() {
+        return Ok(RemoteBundleOutcome::Skipped(reason.to_string()));
+    }
+
+    let checkout_head = |dir: &Path| crate::git::git_output(dir, ["rev-parse", "HEAD"]).ok();
+    let heads_before: Vec<Option<String>> = existing_dirs
+        .iter()
+        .map(|(_, dir)| checkout_head(dir))
+        .collect();
+    prepare_feature_branches(&bundle)?;
+    let mut active = ActiveBundle::unlocked(root.to_path_buf(), path, bundle);
+    let mut created = 0usize;
+    if !to_materialize.is_empty() {
+        materialize_repos(&mut active, Some(&to_materialize))?;
+        if materialize {
+            created = absent.len();
+        }
+        if created > 0 {
+            crate::commands::agents::write_bundle_worktree_agents_md(&active)?;
+        }
+    }
+    fast_forward_feature_checkouts(&mut active)?;
+
+    let advanced = existing_dirs
+        .iter()
+        .zip(heads_before.iter())
+        .filter(|((_, dir), before)| checkout_head(dir) != **before)
+        .count();
+    let rerecorded = to_materialize.len() - created;
+    if created == 0 && advanced == 0 && rerecorded == 0 {
+        return Ok(RemoteBundleOutcome::Skipped(reason.to_string()));
+    }
+
+    save_active_bundle(&active)?;
+    let mut parts = Vec::new();
+    if created > 0 {
+        parts.push(format!("materialized {created} checkout(s)"));
+    }
+    if advanced > 0 {
+        parts.push(format!("fast-forwarded {advanced} checkout(s)"));
+    }
+    if parts.is_empty() {
+        parts.push("re-recorded existing checkout(s)".to_string());
+    }
+    Ok(RemoteBundleOutcome::Refreshed(parts.join(", ")))
+}
+
+/// The checkout dir (worktree path or in-place) the artifact records, when it
+/// exists on disk.
+fn recorded_checkout_dir(
+    root: &Path,
+    repo: &crate::model::RepoEntry,
+) -> Option<std::path::PathBuf> {
+    if let Some(worktree_path) = &repo.worktree_path {
+        let path = std::path::PathBuf::from(worktree_path);
+        let path = if path.is_absolute() {
+            path
+        } else {
+            root.join(path)
+        };
+        return path.exists().then_some(path);
+    }
+    if crate::checkout::is_in_place(repo) {
+        let path = std::path::PathBuf::from(&repo.path);
+        return path.exists().then_some(path);
+    }
+    None
+}
+
 pub fn pull_remote_state(remote_name: Option<&str>, skip_remote: bool, merge: bool) -> Result<()> {
     let Some(context) = prepare_remote_pull(remote_name, skip_remote)? else {
         return Ok(());
     };
     let active = load_active_bundle()?;
-    match pull_bundle_remote_state(&active.root, &context, &active.bundle.id, merge)? {
+    match pull_bundle_remote_state(&active.root, &context, &active.bundle.id, merge, true)? {
         RemoteBundleOutcome::Pulled(hash) => println!(
             "{} {} {}",
             out::movement("pulled"),
@@ -338,6 +469,12 @@ pub fn pull_remote_state(remote_name: Option<&str>, skip_remote: bool, merge: bo
             out::movement("merged ledgers"),
             out::repo(&active.bundle.id),
             out::muted(&hash)
+        ),
+        RemoteBundleOutcome::Refreshed(summary) => println!(
+            "{} {} {}",
+            out::movement("refreshed"),
+            out::repo(&active.bundle.id),
+            out::muted(&summary)
         ),
         RemoteBundleOutcome::Skipped(reason) => println!(
             "{} {}",
@@ -491,6 +628,7 @@ pub fn fetch_bundles_from_remote(
     })?;
 
     let mut fetched_count = 0;
+    let mut quarantined_count = 0;
     for remote_bundle in export.bundles {
         if remote_bundle.lifecycle_state == "deleted" {
             continue;
@@ -501,6 +639,7 @@ pub fn fetch_bundles_from_remote(
 
         let mut bundle = decode_bundle_payload(&artifact.payload, &remote_bundle.slug)
             .with_context(|| format!("failed to decode bundle `{}`", remote_bundle.slug))?;
+        let branch_mapping = bundle_branch_mapping(&bundle);
 
         let bundle_path = bundles_dir.join(format!("{}.bundle.json", bundle.id));
         // Discovery is for bundles you might act on: a remote bundle with no
@@ -509,6 +648,7 @@ pub fn fetch_bundles_from_remote(
         // and undo `knit bundle prune` on every sync. Existing local
         // artifacts still fast-forward whatever their state, so work landed
         // or archived on another machine is reflected here.
+        let status;
         if !bundle_path.exists() {
             if remote_bundle.lifecycle_state != "open" {
                 continue;
@@ -522,37 +662,70 @@ pub fn fetch_bundles_from_remote(
                 .join(format!("{}.bundle.json", bundle.id))
                 .exists()
             {
+                quarantined_count += 1;
                 continue;
             }
-        }
-        // An existing local artifact is only refreshed when the remote ledger is
-        // strictly ahead (a fast-forward). Equal/local-ahead artifacts are left
-        // untouched; diverged ledgers keep local and warn.
-        if bundle_path.exists() {
+            bundle = localize_bundle(bundle, &local_project)
+                .with_context(|| format!("failed to localize bundle `{}`", remote_bundle.slug))?;
+            crate::store::write_json(&bundle_path, &bundle)
+                .with_context(|| format!("failed to write bundle `{}`", remote_bundle.slug))?;
+            fetched_count += 1;
+            status = out::movement("new").to_string();
+        } else {
+            // An existing local artifact is only refreshed when the remote
+            // ledger is strictly ahead (a fast-forward). Equal/local-ahead
+            // artifacts are left untouched; diverged ledgers keep local.
             let local: ChangeGroup = read_json(&bundle_path)
                 .with_context(|| format!("failed to read local bundle `{}`", bundle.id))?;
             match ledger_relation(&local.node_id_sequence(), &bundle.node_id_sequence()) {
-                LedgerRelation::Equal | LedgerRelation::LocalAhead => continue,
+                LedgerRelation::Equal => status = out::muted("up to date").to_string(),
+                LedgerRelation::LocalAhead => status = out::muted("local ahead").to_string(),
                 LedgerRelation::Diverged => {
-                    println!(
-                        "{} bundle {}: local and remote ledgers have diverged; keeping local (run `knit pull --merge` to combine them)",
-                        out::warn("warning:"),
-                        out::node(&bundle.id)
-                    );
-                    continue;
+                    status = out::warn(
+                        "diverged; kept local (run `knit pull --merge` to combine the ledgers)",
+                    )
+                    .to_string()
                 }
-                LedgerRelation::RemoteAhead => {}
+                LedgerRelation::RemoteAhead => {
+                    bundle = localize_bundle(bundle, &local_project).with_context(|| {
+                        format!("failed to localize bundle `{}`", remote_bundle.slug)
+                    })?;
+                    // Localizing wipes checkout recordings (they are per
+                    // machine); carry over this workspace's so an artifact
+                    // fast-forward does not orphan existing worktrees.
+                    for repo in &mut bundle.repos {
+                        if repo.worktree_path.is_none() {
+                            repo.worktree_path = local
+                                .repos
+                                .iter()
+                                .find(|local_repo| local_repo.id == repo.id)
+                                .and_then(|local_repo| local_repo.worktree_path.clone());
+                        }
+                    }
+                    crate::store::write_json(&bundle_path, &bundle).with_context(|| {
+                        format!("failed to write bundle `{}`", remote_bundle.slug)
+                    })?;
+                    fetched_count += 1;
+                    status = out::movement("updated").to_string();
+                }
             }
         }
-
-        bundle = localize_bundle(bundle, &local_project)
-            .with_context(|| format!("failed to localize bundle `{}`", remote_bundle.slug))?;
-
-        crate::store::write_json(&bundle_path, &bundle)
-            .with_context(|| format!("failed to write bundle `{}`", remote_bundle.slug))?;
-        fetched_count += 1;
+        println!(
+            "  {} {} {} [{status}]",
+            out::node(&remote_bundle.slug),
+            out::muted(&remote_bundle.lifecycle_state),
+            branch_mapping
+        );
     }
 
+    if quarantined_count > 0 {
+        println!(
+            "  {}",
+            out::muted(format!(
+                "{quarantined_count} locally deleted bundle(s) left deleted"
+            ))
+        );
+    }
     if fetched_count > 0 {
         println!(
             "{} {} bundle(s) from {}",
@@ -568,4 +741,22 @@ pub fn fetch_bundles_from_remote(
         );
     }
     Ok(())
+}
+
+/// Render a bundle's repo -> feature-branch mapping for fetch/list output, so
+/// discovery answers "which branches does this bundle map to" without opening
+/// the artifact.
+fn bundle_branch_mapping(bundle: &ChangeGroup) -> String {
+    bundle
+        .repos
+        .iter()
+        .map(|repo| {
+            let branch = repo
+                .feature_branch
+                .clone()
+                .unwrap_or_else(|| format!("knit/{}", bundle.id));
+            format!("{} -> {}", out::repo(&repo.id), out::branch(&branch))
+        })
+        .collect::<Vec<_>>()
+        .join(", ")
 }

--- a/tests/bundle.rs
+++ b/tests/bundle.rs
@@ -375,7 +375,11 @@ fn ledger_nodes_record_ambient_session_identity() {
     // node written by commands run in that session carries it.
     let env = [("KNIT_SESSION", "k3-thread-123")];
     knit_with_env(&workspace, ["bundle", "venue capacity"], &env);
-    knit_with_env(&workspace, ["bundle", "add", backend.to_str().unwrap()], &env);
+    knit_with_env(
+        &workspace,
+        ["bundle", "add", backend.to_str().unwrap()],
+        &env,
+    );
     append_line(
         &workspace.join(".knit/worktrees/venue-capacity/backend/app.txt"),
         "session work",

--- a/tests/sync.rs
+++ b/tests/sync.rs
@@ -791,3 +791,191 @@ fn sync_pull_does_not_resurrect_locally_deleted_bundles() {
 
     fs::remove_dir_all(root).unwrap();
 }
+
+/// A collaborator workspace with no local bundle at all (fresh `knit init` +
+/// `knit project add`, or every bundle erased) must still be able to run a
+/// bare `knit fetch`: the git side falls back to the project's repos and the
+/// KnitHub side lists each remote bundle with its repo -> branch mapping.
+#[test]
+fn fetch_without_resolvable_bundle_falls_back_to_project_and_lists_remote_bundles() {
+    let root = unique_temp_dir();
+    let (_remote, backend, _collaborator) = init_remote_repo(&root, "backend");
+    let workspace = root.join("workspace");
+    fs::create_dir_all(&workspace).unwrap();
+
+    knit(&workspace, ["init", "demo"]);
+    knit(
+        &workspace,
+        ["project", "add", "backend", backend.to_str().unwrap()],
+    );
+
+    // Author the bundle another machine would have pushed, then erase every
+    // local trace of it: no bundle resolves in this workspace anymore.
+    knit(&workspace, ["bundle", "svartal made", "--repo", "backend"]);
+    let feature = workspace.join(".knit/worktrees/svartal-made/backend");
+    append_line(&feature.join("app.txt"), "work from another machine");
+    knit(&workspace, ["commit", "--all", "-m", "Remote-machine work"]);
+    knit(&workspace, ["push", "--set-upstream"]);
+    let artifact_path = workspace.join(".knit/bundles/svartal-made.bundle.json");
+    let payload: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(&artifact_path).unwrap()).unwrap();
+    fs::remove_file(&artifact_path).unwrap();
+    fs::remove_dir_all(workspace.join(".knit/worktrees/svartal-made")).unwrap();
+    git(&backend, ["worktree", "prune"]);
+    git(&backend, ["branch", "-D", "knit/svartal-made"]);
+
+    let export = serde_json::json!({
+        "data": {
+            "project": {"slug": "demo"},
+            "knitProject": null,
+            "repositories": [],
+            "bundles": [{
+                "id": "rb-1",
+                "slug": "svartal-made",
+                "lifecycleState": "open",
+                "currentArtifact": {"artifactHash": "hash-1", "payload": payload},
+            }],
+            "historyEvents": [],
+        }
+    });
+    let base_url = spawn_fake_knithub_with_body(export.to_string());
+    knit(&workspace, ["remote", "add", "hosted", &base_url]);
+    let env = [("KNIT_REMOTE_TOKEN", "test-token")];
+
+    let output = knit_with_env(&workspace, ["fetch"], &env);
+    assert!(output.contains("origin/main"), "{output}");
+    assert!(output.contains("backend -> knit/svartal-made"), "{output}");
+    assert!(output.contains("fetched"), "{output}");
+    assert!(artifact_path.exists());
+
+    fs::remove_dir_all(root).unwrap();
+}
+
+/// `knit fetch` + `knit switch` + `knit pull` is the cross-machine flow: after
+/// fetch localizes a remote bundle's artifact, pointing the workspace at it
+/// and pulling must materialize its worktrees from origin — an artifact that
+/// is "up to date" is not the same as a usable checkout.
+#[test]
+fn pull_materializes_the_pointed_at_bundle_after_fetch() {
+    let root = unique_temp_dir();
+    let (_remote, backend, _collaborator) = init_remote_repo(&root, "backend");
+    let workspace = root.join("workspace");
+    fs::create_dir_all(&workspace).unwrap();
+
+    knit(&workspace, ["init", "demo"]);
+    knit(
+        &workspace,
+        ["project", "add", "backend", backend.to_str().unwrap()],
+    );
+
+    knit(&workspace, ["bundle", "svartal made", "--repo", "backend"]);
+    let feature = workspace.join(".knit/worktrees/svartal-made/backend");
+    append_line(&feature.join("app.txt"), "work from another machine");
+    knit(&workspace, ["commit", "--all", "-m", "Remote-machine work"]);
+    knit(&workspace, ["push", "--set-upstream"]);
+    let artifact_path = workspace.join(".knit/bundles/svartal-made.bundle.json");
+    let payload: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(&artifact_path).unwrap()).unwrap();
+    fs::remove_file(&artifact_path).unwrap();
+    fs::remove_dir_all(workspace.join(".knit/worktrees/svartal-made")).unwrap();
+    git(&backend, ["worktree", "prune"]);
+    git(&backend, ["branch", "-D", "knit/svartal-made"]);
+
+    let export = serde_json::json!({
+        "data": {
+            "project": {"slug": "demo"},
+            "knitProject": null,
+            "repositories": [],
+            "bundles": [{
+                "id": "rb-1",
+                "slug": "svartal-made",
+                "lifecycleState": "open",
+                "currentArtifact": {"artifactHash": "hash-1", "payload": payload},
+            }],
+            "historyEvents": [],
+        }
+    });
+    let base_url = spawn_fake_knithub_with_body(export.to_string());
+    knit(&workspace, ["remote", "add", "hosted", &base_url]);
+    let env = [("KNIT_REMOTE_TOKEN", "test-token")];
+
+    let fetch_output = knit_with_env(&workspace, ["fetch", "--mode", "knit"], &env);
+    assert!(fetch_output.contains("new"), "{fetch_output}");
+    knit(&workspace, ["switch", "svartal-made", "--workspace"]);
+
+    let pull = knit_with_env(&workspace, ["pull"], &env);
+    assert!(pull.contains("materialized 1 checkout(s)"), "{pull}");
+    let text = fs::read_to_string(feature.join("app.txt")).unwrap();
+    assert!(text.contains("work from another machine"), "{text}");
+
+    // A second pull has nothing left to do.
+    let again = knit_with_env(&workspace, ["pull"], &env);
+    assert!(again.contains("up to date"), "{again}");
+
+    fs::remove_dir_all(root).unwrap();
+}
+
+/// `knit fetch` fast-forwards the bundle artifact without touching checkouts.
+/// The following `knit pull` must still fast-forward the feature checkout onto
+/// origin instead of treating the already-current artifact as "nothing to do".
+#[test]
+fn pull_fast_forwards_checkouts_after_fetch_advanced_the_artifact() {
+    let root = unique_temp_dir();
+    let (_remote, backend, _collaborator) = init_remote_repo(&root, "backend");
+    let workspace = root.join("workspace");
+    fs::create_dir_all(&workspace).unwrap();
+
+    knit(&workspace, ["init", "demo"]);
+    knit(
+        &workspace,
+        ["project", "add", "backend", backend.to_str().unwrap()],
+    );
+
+    knit(&workspace, ["bundle", "svartal made", "--repo", "backend"]);
+    let feature = workspace.join(".knit/worktrees/svartal-made/backend");
+    append_line(&feature.join("app.txt"), "first line");
+    knit(&workspace, ["commit", "--all", "-m", "First"]);
+    knit(&workspace, ["push", "--set-upstream"]);
+    let artifact_path = workspace.join(".knit/bundles/svartal-made.bundle.json");
+    let artifact_v1 = fs::read_to_string(&artifact_path).unwrap();
+
+    // The second commit plays the collaborator: origin and the remote artifact
+    // advance past the state this workspace is then rewound to.
+    append_line(&feature.join("app.txt"), "second line");
+    knit(&workspace, ["commit", "--all", "-m", "Second"]);
+    knit(&workspace, ["push"]);
+    let payload_v2: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(&artifact_path).unwrap()).unwrap();
+    fs::write(&artifact_path, artifact_v1).unwrap();
+    git(&feature, ["reset", "--hard", "HEAD~1"]);
+
+    let export = serde_json::json!({
+        "data": {
+            "project": {"slug": "demo"},
+            "knitProject": null,
+            "repositories": [],
+            "bundles": [{
+                "id": "rb-1",
+                "slug": "svartal-made",
+                "lifecycleState": "open",
+                "currentArtifact": {"artifactHash": "hash-2", "payload": payload_v2},
+            }],
+            "historyEvents": [],
+        }
+    });
+    let base_url = spawn_fake_knithub_with_body(export.to_string());
+    knit(&workspace, ["remote", "add", "hosted", &base_url]);
+    let env = [("KNIT_REMOTE_TOKEN", "test-token")];
+
+    let fetch_output = knit_with_env(&workspace, ["fetch", "--mode", "knit"], &env);
+    assert!(fetch_output.contains("updated"), "{fetch_output}");
+    let stale = fs::read_to_string(feature.join("app.txt")).unwrap();
+    assert!(!stale.contains("second line"), "{stale}");
+
+    let pull = knit_with_env(&workspace, ["pull"], &env);
+    assert!(pull.contains("fast-forwarded 1 checkout(s)"), "{pull}");
+    let text = fs::read_to_string(feature.join("app.txt")).unwrap();
+    assert!(text.contains("second line"), "{text}");
+
+    fs::remove_dir_all(root).unwrap();
+}


### PR DESCRIPTION
Generated by Knit. Cross-links will be refreshed after all review objects are created.

<!-- BEGIN KNIT BUNDLE -->
## Knit Bundle

This PR is part of Knit bundle `cross-collab-clone-fetch-pull-audit`.

See the other review objects in this bundle:
- `knit`: https://github.com/marc-merino/knit/pull/113 (this PR)
- `knithub`: https://github.com/marc-merino/knithub/pull/59

Bundle id: `cross-collab-clone-fetch-pull-audit`
Bundle title: cross-collab clone fetch pull audit
<!-- END KNIT BUNDLE -->