### PR TITLE
fix-bundle-add-crash-consistency (knit)

### DIFF
--- a/src/commands/track.rs
+++ b/src/commands/track.rs
@@ -38,11 +38,14 @@ pub fn track_repos(
     };
     let plans = resolve_repo_plans(repo_paths, base_override, checkout_mode)?;
     apply_repo_plans(&mut active, plans, materialize)?;
+    // Persist the fully materialized artifact before printing the AGENTS.md
+    // summary, so a SIGPIPE on that final write can no longer drop the recorded
+    // worktree metadata.
+    save_active_bundle(&active)?;
     if materialize {
         let bundle_agents = write_bundle_worktree_agents_md(&active)?;
         print_bundle_worktree_agents_summary(bundle_agents.as_deref());
     }
-    save_active_bundle(&active)?;
     Ok(())
 }
 
@@ -73,11 +76,14 @@ pub fn track_repo_selectors(
     }
     ensure_unique_paths(&plans)?;
     apply_repo_plans(&mut active, plans, materialize)?;
+    // Persist the fully materialized artifact before printing the AGENTS.md
+    // summary, so a SIGPIPE on that final write can no longer drop the recorded
+    // worktree metadata.
+    save_active_bundle(&active)?;
     if materialize {
         let bundle_agents = write_bundle_worktree_agents_md(&active)?;
         print_bundle_worktree_agents_summary(bundle_agents.as_deref());
     }
-    save_active_bundle(&active)?;
     Ok(())
 }
 
@@ -151,19 +157,32 @@ fn apply_repo_plans(
         touched_repo_ids.clone(),
     ));
     active.bundle.head_node_id = active.bundle.nodes.last().map(|node| node.id.clone());
+    active.bundle.updated_at = now_iso();
 
-    if materialize {
-        let materialized_repo_ids = materialize_repos(active, Some(&touched_repo_ids))?;
-        let now = now_iso();
-        active.bundle.nodes.push(BundleNode::worktrees_materialized(
-            node_id("worktree"),
-            now,
-            materialized_repo_ids,
-        ));
-        active.bundle.head_node_id = active.bundle.nodes.last().map(|node| node.id.clone());
+    if !materialize {
+        return Ok(());
     }
 
+    // Crash-consistency: persist the recorded repo entries before creating any
+    // git side effects. If materialization is interrupted (a SIGPIPE from a
+    // closed output pipe, a Ctrl-C, or a crash), the saved artifact already lists
+    // the repo, so the branch and worktree it creates are never orphaned —
+    // `knit bundle worktree` rematerializes the missing checkout. Saving only
+    // after materialization (the previous order) could leave a branch and
+    // worktree the bundle artifact never recorded, which later commit/publish
+    // then silently skipped.
+    save_active_bundle(active)?;
+
+    let materialized_repo_ids = materialize_repos(active, Some(&touched_repo_ids))?;
+    let now = now_iso();
+    active.bundle.nodes.push(BundleNode::worktrees_materialized(
+        node_id("worktree"),
+        now,
+        materialized_repo_ids,
+    ));
+    active.bundle.head_node_id = active.bundle.nodes.last().map(|node| node.id.clone());
     active.bundle.updated_at = now_iso();
+
     Ok(())
 }
 

--- a/tests/bundle.rs
+++ b/tests/bundle.rs
@@ -491,3 +491,67 @@ fn ledger_nodes_record_ambient_actor_identity() {
 
     fs::remove_dir_all(root).unwrap();
 }
+
+// Regression: `knit bundle add` must record the repo in the artifact before it
+// creates any git side effects, so an interruption during materialization (a
+// SIGPIPE from `| head`, a Ctrl-C, or a crash) can never leave a branch and
+// worktree the bundle artifact never recorded. We force materialization to fail
+// deterministically by pre-planting a non-git directory where the worktree would
+// go, then assert the repo is already in the artifact even though the command
+// failed — and that `knit bundle worktree` recovers the missing checkout.
+#[test]
+fn bundle_add_records_repo_before_materializing_worktree() {
+    let root = unique_temp_dir();
+    let backend = root.join("backend");
+    let workspace = root.join("workspace");
+    fs::create_dir_all(&workspace).unwrap();
+
+    init_repo(&backend, "backend");
+    knit(&workspace, ["bundle", "crash consistency"]);
+
+    // A plain (non-git) directory at the worktree target makes materialization
+    // bail with "exists but is not a git worktree" — a clean stand-in for any
+    // interruption after the artifact-first save but before materialization
+    // finishes.
+    let blocker = workspace.join(".knit/worktrees/crash-consistency/backend");
+    fs::create_dir_all(&blocker).unwrap();
+    fs::write(blocker.join("stray.txt"), "not a worktree\n").unwrap();
+
+    let failure = knit_fails(&workspace, ["bundle", "add", backend.to_str().unwrap()]);
+    assert!(
+        failure.contains("worktree"),
+        "expected materialization to fail, got: {failure}"
+    );
+
+    // Crash-consistency invariant: the artifact already lists the repo even
+    // though the command died during materialization.
+    assert!(
+        bundle_repo_ids(&workspace, "crash-consistency").contains(&"backend".to_string()),
+        "bundle add must persist the repo entry before materializing worktrees"
+    );
+
+    // The entry is recorded but not yet materialized (recoverable state).
+    let bundle: Value = serde_json::from_str(
+        &fs::read_to_string(workspace.join(".knit/bundles/crash-consistency.bundle.json")).unwrap(),
+    )
+    .unwrap();
+    assert!(
+        bundle["repos"][0]["worktreePath"].is_null(),
+        "unmaterialized repo should have no recorded worktree path"
+    );
+
+    // Recovery: clear the blocker and rematerialize the missing checkout.
+    fs::remove_dir_all(&blocker).unwrap();
+    knit(&workspace, ["bundle", "worktree"]);
+    assert!(blocker.join("app.txt").exists());
+    let recovered: Value = serde_json::from_str(
+        &fs::read_to_string(workspace.join(".knit/bundles/crash-consistency.bundle.json")).unwrap(),
+    )
+    .unwrap();
+    assert_eq!(
+        recovered["repos"][0]["worktreePath"].as_str(),
+        Some(".knit/worktrees/crash-consistency/backend")
+    );
+
+    fs::remove_dir_all(root).unwrap();
+}


### PR DESCRIPTION
Generated by Knit. Cross-links will be refreshed after all review objects are created.

<!-- BEGIN KNIT BUNDLE -->
## Knit Bundle

This PR is part of Knit bundle `fix-bundle-add-crash-consistency`.

See the other review objects in this bundle:
- `knit`: https://github.com/marc-merino/knit/pull/115 (this PR)

Bundle id: `fix-bundle-add-crash-consistency`
Bundle title: fix-bundle-add-crash-consistency
<!-- END KNIT BUNDLE -->