### PR TITLE
Sync bundle archive state to KnitHub (knit)

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -71,7 +71,7 @@ knit bundle list [--all] [--archived] [--deleted]
 knit bundle archive <bundle> [--reason <reason>] [--keep-worktrees] [--force]
 knit bundle restore <bundle>
 knit bundle delete <bundle> --force [--worktrees] [--branches] [--force-branches] [--remote-branches]
-knit bundle prune [--no-refresh] [--apply] [--all] [--worktrees] [--force] [--branches] [--force-branches] [--remote-branches] [--remote-bundles]
+knit bundle prune [--no-refresh] [--apply] [--all] [--worktrees] [--force] [--branches] [--force-branches] [--remote-branches] [--remote-bundles] [--archived]
 knit bundle path
 knit bundle print
 knit bundle validate
@@ -380,6 +380,8 @@ knit bundle prune --no-refresh
 knit bundle prune --apply --worktrees --branches
 knit bundle prune --apply --all
 ```
+
+Landed and archived bundles are finished work, not dead work: their artifacts are the audit record of what shipped, so prune keeps them (and says how many it kept) unless `--archived` opts them into the scan. `--all` deliberately does not imply `--archived`.
 
 A bundle whose only uncommitted work is untracked files is otherwise dead work, so prune does not delete it by default; instead it lists it under "Blocked by untracked files". Pass `--untracked` to treat those bundles as dead-work candidates — combine with `--worktrees` (or `--all`) on `--apply` so the untracked files are discarded with the generated checkout. Bundles with tracked, uncommitted changes are still preserved even with `--untracked`.
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -593,6 +593,10 @@ pub enum BundleCommand {
         /// Delete matching KnitHub remote bundle records.
         #[arg(long = "remote-bundles")]
         remote_bundles: bool,
+        /// Also prune finished (landed/archived) bundle artifacts. By default
+        /// finished bundles are history and only open dead work is pruned.
+        #[arg(long)]
+        archived: bool,
     },
     /// Mark a bundle done: archive its artifact and remove generated worktrees, keeping branches.
     Archive {

--- a/src/commands/bundle/lifecycle.rs
+++ b/src/commands/bundle/lifecycle.rs
@@ -45,7 +45,21 @@ pub fn archive_bundle(
         "{} local feature branches and the bundle artifact",
         out::heading("Preserved:")
     );
+    sync_lifecycle_state_to_remote(&active);
     Ok(())
+}
+
+/// Mirror an archive/restore onto configured KnitHub remotes by pushing the
+/// updated artifact, so hosted dashboards flip lifecycle state together with
+/// the local ledger. Best-effort: the local transition already succeeded, so
+/// sync failures warn instead of failing the command. A workspace with no
+/// push-sync remotes configured is a silent no-op.
+fn sync_lifecycle_state_to_remote(active: &ActiveBundle) {
+    if let Err(error) =
+        crate::commands::remote::sync_active_bundle_to_remote_if_enabled(active, &[], false)
+    {
+        println!("{} {error:#}", out::warn("KnitHub sync skipped:"));
+    }
 }
 
 pub(crate) fn archive_active_bundle(
@@ -117,6 +131,8 @@ pub fn restore_bundle(bundle_id: &str) -> Result<()> {
         &root,
         format!("run `knit --bundle {bundle_id} bundle worktree` to rematerialize its checkouts."),
     );
+    let active = ActiveBundle::unlocked(root, path, bundle);
+    sync_lifecycle_state_to_remote(&active);
     Ok(())
 }
 

--- a/src/commands/bundle/prune/assess.rs
+++ b/src/commands/bundle/prune/assess.rs
@@ -37,6 +37,7 @@ impl Pending {
 /// prune decision, the `--untracked` relaxation, and the `--report` view.
 pub(super) struct PruneAssessment {
     pub(super) id: String,
+    pub(super) status: crate::commands::bundle::BundleStatus,
     pub(super) repo_count: usize,
     pub(super) saw_publication: bool,
     pub(super) saw_open_publication: bool,
@@ -331,6 +332,7 @@ fn assess_bundle(
 
     Ok(PruneAssessment {
         id: bundle.id.clone(),
+        status: crate::commands::bundle::bundle_state(bundle),
         repo_count: bundle.repos.len(),
         saw_publication,
         saw_open_publication,

--- a/src/commands/bundle/prune/mod.rs
+++ b/src/commands/bundle/prune/mod.rs
@@ -38,6 +38,7 @@ pub fn prune_merged_bundles(
     force_branches: bool,
     remote_branches: bool,
     remote_bundles: bool,
+    include_finished: bool,
 ) -> Result<()> {
     if force_branches && !branches {
         bail!("Use --branches with --force-branches.");
@@ -70,7 +71,21 @@ pub fn prune_merged_bundles(
 
     let mut candidates = Vec::new();
     let mut blocked_untracked = Vec::new();
+    let mut kept_finished = 0usize;
     for assessment in &assessments {
+        // Landed and archived bundles are finished work, not dead work: their
+        // artifacts are the audit record of what shipped. Only `--archived`
+        // opts them into pruning; open dead work is pruned as before.
+        if !include_finished
+            && matches!(
+                assessment.status,
+                crate::commands::bundle::BundleStatus::Landed
+                    | crate::commands::bundle::BundleStatus::Archived
+            )
+        {
+            kept_finished += 1;
+            continue;
+        }
         if let Some(reason) = assessment.candidate_reason(untracked) {
             candidates.push(PruneCandidate {
                 id: assessment.id.clone(),
@@ -95,6 +110,15 @@ pub fn prune_merged_bundles(
 
     if report {
         print_prune_report(&assessments, untracked);
+    }
+
+    if kept_finished > 0 {
+        println!(
+            "{}",
+            out::muted(format!(
+                "Kept {kept_finished} finished (landed/archived) bundle artifact(s) as history; pass --archived to prune them too."
+            ))
+        );
     }
 
     if candidates.is_empty()

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -580,12 +580,12 @@ knit cherrypick --from feature-a --repo backend abc123
 - `knit bundle path` prints the resolved bundle file.
 - `knit bundle validate` checks the bundle artifact.
 - `knit bundle list` shows workspace bundles.
-- `knit bundle archive <bundle> [--reason "merged"]` marks a bundle done: it records an archive node and removes generated worktrees while preserving local feature branches (`--keep-worktrees` to leave them, `--force` to discard dirty checkouts).
+- `knit bundle archive <bundle> [--reason "merged"]` marks a bundle done: it records an archive node and removes generated worktrees while preserving local feature branches (`--keep-worktrees` to leave them, `--force` to discard dirty checkouts). With push-sync remotes configured, archive and restore also push the updated artifact so KnitHub dashboards flip lifecycle state together with the local ledger.
 - `knit bundle restore <bundle>` reopens an archived bundle; run `knit bundle worktree` afterwards to rematerialize checkouts.
 - `knit bundle delete <bundle> --force` moves the bundle artifact to `.knit/deleted/bundles/` and preserves git state.
 - `knit bundle delete <bundle> --force --worktrees --branches --force-branches` discards generated worktrees and local feature branches for that bundle.
 - `knit bundle delete <bundle> --force --worktrees --branches --force-branches --remote-branches` also deletes the matching feature branches from `origin`.
-- `knit bundle prune` refreshes GitHub PR states and lists clean dead-work bundles with no recorded open PRs.
+- `knit bundle prune` refreshes GitHub PR states and lists clean dead-work bundles with no recorded open PRs. Landed and archived bundle artifacts are kept as history unless `--archived` is passed.
 - `knit bundle prune --no-refresh` performs the same scan using cached recorded PR states only.
 - `knit bundle prune --apply --worktrees --branches` is the short form for deleting dead bundle artifacts and their generated local state.
 - `knit bundle prune --apply --all` removes dead bundle artifacts, generated and orphaned worktrees, local feature branches, matching `origin` branches, and matching KnitHub remote bundle records.
@@ -607,7 +607,7 @@ knit cherrypick --from feature-a --repo backend abc123
 - `knit config set sync-remotes hosted` makes push-sync upload bundle artifacts to your configured KnitHub remote.
 - `knit show HEAD` explains the latest bundle ledger entry.
 - `knit sync` records Git commits made outside Knit (local reconcile, no network).
-- `knit sync push [--bundles|--history|--views|--all] [--remote <name>]...` is the one verb family for moving artifacts to KnitHub; with no target flag it pushes bundle, history, and views.
+- `knit sync push [--bundles|--history|--views|--all] [--remote <name>]...` is the one verb family for moving artifacts to KnitHub; with no target flag it pushes bundle, history, and views. Bundle push is project-wide: every local bundle artifact — open, landed, archived — is swept so remote lifecycle state converges on the local ledger.
 - `knit sync pull [--bundles|--history|--views|--all] [--remote <name>]...` pulls those same artifacts from KnitHub. Bundle pull is project-wide: open bundles created on other machines (and their recorded PRs) are localized into `.knit/bundles/`, and stale local artifacts fast-forward whatever their state; materialize checkouts for a discovered bundle with `knit --bundle <slug> bundle worktree`.
 - `knit pull --merge` union-merges the bundle ledger when the local and KnitHub artifacts have diverged (two users recorded work concurrently); diverged feature branches still need a git merge in the worktree afterwards.
 - `knit push --set-upstream` pushes every tracked feature branch in the resolved bundle to `origin` and sets upstream tracking.

--- a/src/commands/remote/facade.rs
+++ b/src/commands/remote/facade.rs
@@ -13,8 +13,8 @@ use super::client::{effective_workspace_config, resolve_sync_remote_names};
 use super::history::{pull_history_from_remote, push_history_to_remote};
 use super::pull::pull_views_from_remote;
 use super::push::{
-    push_architecture_to_remote, push_bundle_to_remote, push_kg_graph_to_remote,
-    push_views_to_remote,
+    push_all_bundles_to_remote, push_architecture_to_remote, push_bundle_to_remote,
+    push_kg_graph_to_remote, push_views_to_remote,
 };
 use crate::output as out;
 use anyhow::{bail, Result};
@@ -100,8 +100,30 @@ pub fn sync_push(targets: SyncTargets, remote_overrides: &[String]) -> Result<()
         // history are requested we let it cover history and avoid a redundant
         // second history push to the same remote.
         if targets.bundles {
-            if let Err(error) = push_bundle_to_remote(remote, None) {
-                failures.push(format!("{remote} bundle: {error:#}"));
+            // Bundle push is project-wide, mirroring bundle pull: the resolved
+            // bundle (when one resolves) gets the rich push including history,
+            // and every other local bundle artifact — open, landed, archived —
+            // is swept as well so remote lifecycle state converges on the
+            // local ledger. From a root with several open bundles nothing
+            // resolves; the sweep covers everything and history is pushed
+            // separately.
+            let active_id = crate::store::load_active_bundle()
+                .ok()
+                .map(|active| active.bundle.id);
+            match &active_id {
+                Some(_) => {
+                    if let Err(error) = push_bundle_to_remote(remote, None) {
+                        failures.push(format!("{remote} bundle: {error:#}"));
+                    }
+                }
+                None => {
+                    if let Err(error) = push_history_to_remote(None, remote) {
+                        failures.push(format!("{remote} history: {error:#}"));
+                    }
+                }
+            }
+            if let Err(error) = push_all_bundles_to_remote(remote, None, active_id.as_deref()) {
+                failures.push(format!("{remote} bundles: {error:#}"));
             }
         } else if targets.history {
             if let Err(error) = push_history_to_remote(None, remote) {

--- a/src/commands/remote/mod.rs
+++ b/src/commands/remote/mod.rs
@@ -25,9 +25,10 @@ pub use pull::{
     RemotePullContext,
 };
 pub use push::{
-    add_remote, list_remotes, maybe_sync_bundle_to_remote, push_bundle_to_remote,
-    push_project_to_remote, push_views_to_remote, remove_remote, set_remote_token, show_remote,
-    sync_active_bundle_to_remote_if_enabled, sync_bundle_to_remote_if_enabled,
+    add_remote, list_remotes, maybe_sync_bundle_to_remote, push_all_bundles_to_remote,
+    push_bundle_to_remote, push_project_to_remote, push_views_to_remote, remove_remote,
+    set_remote_token, show_remote, sync_active_bundle_to_remote_if_enabled,
+    sync_bundle_to_remote_if_enabled,
 };
 
 use crate::model::{HistoryEvent, KnitProject, ProjectView};

--- a/src/commands/remote/push.rs
+++ b/src/commands/remote/push.rs
@@ -695,12 +695,17 @@ fn upsert_bundle(
     )
 }
 
-fn push_bundle_artifact(
+enum ArtifactPushOutcome {
+    Pushed(RemoteArtifact),
+    RemoteAhead,
+}
+
+fn push_bundle_artifact_outcome(
     remote: &KnitRemote,
     token: &str,
     bundle_id: &str,
     bundle: &ChangeGroup,
-) -> Result<RemoteArtifact> {
+) -> Result<ArtifactPushOutcome> {
     let payload = json!({
         "kind": "bundle",
         "schema_version": bundle.schema_version,
@@ -719,12 +724,118 @@ fn push_bundle_artifact(
     // current remote artifact records: another user (or another machine)
     // pushed work this workspace has not seen yet.
     if response.status == 409 {
-        bail!(
+        return Ok(ArtifactPushOutcome::RemoteAhead);
+    }
+    decode_response(response).map(ArtifactPushOutcome::Pushed)
+}
+
+fn push_bundle_artifact(
+    remote: &KnitRemote,
+    token: &str,
+    bundle_id: &str,
+    bundle: &ChangeGroup,
+) -> Result<RemoteArtifact> {
+    match push_bundle_artifact_outcome(remote, token, bundle_id, bundle)? {
+        ArtifactPushOutcome::Pushed(artifact) => Ok(artifact),
+        ArtifactPushOutcome::RemoteAhead => bail!(
             "{}: the KnitHub remote has recorded bundle work this workspace does not include. Run `knit pull` to fast-forward (or `knit pull --merge` if the ledgers diverged), then push again.",
             bundle.id
+        ),
+    }
+}
+
+/// Push every local bundle artifact — open, landed, and archived alike — to a
+/// KnitHub remote so the remote's lifecycle state converges on the local
+/// ledger. Bundles whose remote ledger is ahead of this workspace are skipped
+/// with a warning (catching up is `knit sync pull`'s job); other per-bundle
+/// failures are collected and fail the sweep at the end.
+pub fn push_all_bundles_to_remote(
+    remote_name: &str,
+    project: Option<&str>,
+    exclude_bundle: Option<&str>,
+) -> Result<()> {
+    let cwd = std::env::current_dir().context("failed to read current directory")?;
+    let root = find_knit_root(&cwd).context("No Knit workspace found.")?;
+    let config = load_effective_config(&root)?;
+    let remote = resolve_remote(&config, remote_name)?;
+    let token = resolve_token(remote_name, remote)?;
+
+    let dir = root.join(".knit/bundles");
+    if !dir.exists() {
+        return Ok(());
+    }
+    let mut paths: Vec<_> = std::fs::read_dir(&dir)
+        .with_context(|| format!("failed to read {}", dir.display()))?
+        .filter_map(|entry| entry.ok())
+        .map(|entry| entry.path())
+        .filter(|path| path.extension() == Some(std::ffi::OsStr::new("json")))
+        .collect();
+    paths.sort();
+
+    let mut project_slugs: BTreeMap<String, String> = BTreeMap::new();
+    let mut pushed = 0usize;
+    let mut remote_ahead = Vec::new();
+    let mut failures = Vec::new();
+
+    for path in paths {
+        let bundle: ChangeGroup = match crate::store::read_json(&path) {
+            Ok(bundle) => bundle,
+            Err(error) => {
+                failures.push(format!("{}: {error:#}", path.display()));
+                continue;
+            }
+        };
+        if exclude_bundle == Some(bundle.id.as_str()) {
+            continue;
+        }
+        let Some(project_id) = bundle
+            .project_id
+            .clone()
+            .or_else(|| project.map(slugify))
+            .or_else(|| config.active_project.clone())
+        else {
+            failures.push(format!("{}: no project recorded on the bundle", bundle.id));
+            continue;
+        };
+        let project_slug = match project_slugs.get(&project_id) {
+            Some(slug) => slug.clone(),
+            None => {
+                let local_project = load_project_if_present(&root, &project_id)?;
+                let upserted = upsert_project(remote, &token, &project_id, local_project.as_ref())?;
+                if let Some(local) = local_project.as_ref() {
+                    push_repositories(remote, &token, &upserted.slug, &local.repos)?;
+                }
+                project_slugs.insert(project_id.clone(), upserted.slug.clone());
+                upserted.slug
+            }
+        };
+        let outcome =
+            upsert_bundle(remote, &token, &project_slug, &bundle).and_then(|remote_bundle| {
+                push_bundle_artifact_outcome(remote, &token, &remote_bundle.id, &bundle)
+            });
+        match outcome {
+            Ok(ArtifactPushOutcome::Pushed(_)) => pushed += 1,
+            Ok(ArtifactPushOutcome::RemoteAhead) => remote_ahead.push(bundle.id.clone()),
+            Err(error) => failures.push(format!("{}: {error:#}", bundle.id)),
+        }
+    }
+
+    println!("{} {pushed} bundle artifact(s)", out::movement("pushed"));
+    if !remote_ahead.is_empty() {
+        println!(
+            "{} {}: the remote ledger is ahead; run `knit sync pull --bundles` to fast-forward, then push again",
+            out::warn("Skipped"),
+            remote_ahead.join(", ")
         );
     }
-    decode_response(response)
+    if !failures.is_empty() {
+        bail!(
+            "failed to push {} bundle artifact(s):\n{}",
+            failures.len(),
+            failures.join("\n")
+        );
+    }
+    Ok(())
 }
 
 fn project_payload(project_id: &str, project: Option<&KnitProject>) -> Value {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -208,6 +208,7 @@ pub fn run(cli: Cli) -> Result<()> {
                 force_branches,
                 remote_branches,
                 remote_bundles,
+                archived,
             }) => {
                 let refresh = refresh || !no_refresh;
                 let worktrees = all || worktrees;
@@ -227,6 +228,7 @@ pub fn run(cli: Cli) -> Result<()> {
                     force_branches,
                     remote_branches,
                     remote_bundles,
+                    archived,
                 )
             }
             Some(BundleCommand::Archive {

--- a/tests/cleanup.rs
+++ b/tests/cleanup.rs
@@ -705,3 +705,61 @@ fn bundle_prune_keeps_bundles_with_unpublished_commits() {
 
     fs::remove_dir_all(root).unwrap();
 }
+
+#[test]
+fn bundle_prune_keeps_finished_bundles_unless_archived_flag() {
+    let root = unique_temp_dir();
+    let backend = root.join("backend");
+    let workspace = root.join("workspace");
+    fs::create_dir_all(&workspace).unwrap();
+    init_repo(&backend, "backend");
+
+    // Finished work: archived with no PRs recorded — history, not dead work.
+    knit(&workspace, ["bundle", "finished work"]);
+    knit(&workspace, ["bundle", "add", backend.to_str().unwrap()]);
+    knit(&workspace, ["bundle", "archive", "finished-work"]);
+
+    // Dead work: open bundle whose recorded PRs are all merged.
+    knit(&workspace, ["bundle", "dead work"]);
+    knit(&workspace, ["bundle", "add", backend.to_str().unwrap()]);
+    write_bundle_publications(&workspace, "dead-work", "MERGED");
+
+    let preview = knit(&workspace, ["bundle", "prune", "--no-refresh"]);
+    assert!(preview.contains("Kept 1 finished"));
+    assert!(preview.contains("dead-work"));
+    assert!(!preview.contains("finished-work"));
+
+    let pruned = knit(
+        &workspace,
+        ["bundle", "prune", "--no-refresh", "--apply", "--worktrees"],
+    );
+    assert!(pruned.contains("dead-work"));
+    assert!(workspace
+        .join(".knit/bundles/finished-work.bundle.json")
+        .exists());
+    assert!(!workspace
+        .join(".knit/bundles/dead-work.bundle.json")
+        .exists());
+
+    // Explicit opt-in prunes the finished artifact too.
+    let pruned_finished = knit(
+        &workspace,
+        [
+            "bundle",
+            "prune",
+            "--no-refresh",
+            "--archived",
+            "--apply",
+            "--worktrees",
+        ],
+    );
+    assert!(pruned_finished.contains("finished-work"));
+    assert!(!workspace
+        .join(".knit/bundles/finished-work.bundle.json")
+        .exists());
+    assert!(workspace
+        .join(".knit/deleted/bundles/finished-work.bundle.json")
+        .exists());
+
+    fs::remove_dir_all(root).unwrap();
+}

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1030,3 +1030,113 @@ fn respond_with_json(stream: &mut std::net::TcpStream, body: &str) -> std::io::R
     )?;
     stream.flush()
 }
+
+/// Spawn a fake KnitHub push API: enough routes for `knit sync push --bundles`
+/// and the archive/restore lifecycle sync. Every pushed bundle artifact's
+/// payload state is appended to `<dir>/artifact-<slug>.states`, one state per
+/// line, so tests can assert which lifecycle states reached the remote.
+pub fn spawn_fake_knithub_push_api(dir: &Path) -> String {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    let base_url = format!("http://{}", listener.local_addr().unwrap());
+    fs::create_dir_all(dir).unwrap();
+    let dir = dir.to_path_buf();
+    std::thread::spawn(move || {
+        for stream in listener.incoming() {
+            let Ok(mut stream) = stream else { continue };
+            let dir = dir.clone();
+            std::thread::spawn(move || {
+                let _ = handle_fake_knithub_push_request(&mut stream, &dir);
+            });
+        }
+    });
+    base_url
+}
+
+fn handle_fake_knithub_push_request(
+    stream: &mut std::net::TcpStream,
+    dir: &Path,
+) -> std::io::Result<()> {
+    use std::io::{BufRead, BufReader, Read, Write};
+
+    let mut reader = BufReader::new(stream.try_clone()?);
+    let mut request_line = String::new();
+    reader.read_line(&mut request_line)?;
+    let mut parts = request_line.split_whitespace();
+    let method = parts.next().unwrap_or_default().to_string();
+    let target = parts.next().unwrap_or_default().to_string();
+
+    let mut content_length = 0usize;
+    loop {
+        let mut line = String::new();
+        reader.read_line(&mut line)?;
+        let line = line.trim_end();
+        if line.is_empty() {
+            break;
+        }
+        if let Some((name, value)) = line.split_once(':') {
+            if name.trim().eq_ignore_ascii_case("content-length") {
+                content_length = value.trim().parse().unwrap_or(0);
+            }
+        }
+    }
+    let mut body = vec![0u8; content_length];
+    if content_length > 0 {
+        reader.read_exact(&mut body)?;
+    }
+    let body: serde_json::Value = serde_json::from_slice(&body).unwrap_or(serde_json::Value::Null);
+
+    let path = target
+        .split('?')
+        .next()
+        .unwrap_or_default()
+        .trim_start_matches('/')
+        .to_string();
+    let segments: Vec<&str> = path.split('/').collect();
+    let (status, response) = match (method.as_str(), segments.as_slice()) {
+        (_, ["api", "v1", "projects", slug]) => (
+            200,
+            format!("{{\"data\":{{\"id\":\"proj-1\",\"slug\":\"{slug}\"}}}}"),
+        ),
+        ("POST", ["api", "v1", "projects"]) => (
+            201,
+            "{\"data\":{\"id\":\"proj-1\",\"slug\":\"demo\"}}".to_string(),
+        ),
+        ("POST", ["api", "v1", "projects", _, "repositories"]) => {
+            (201, "{\"data\":{}}".to_string())
+        }
+        ("POST", ["api", "v1", "projects", _, "history-events"]) => (
+            201,
+            "{\"data\":{\"insertedCount\":0,\"skippedCount\":0}}".to_string(),
+        ),
+        ("POST", ["api", "v1", "projects", _, "bundles"]) => {
+            let slug = body["slug"].as_str().unwrap_or("unknown").to_string();
+            (
+                201,
+                format!("{{\"data\":{{\"id\":\"rb-{slug}\",\"slug\":\"{slug}\"}}}}"),
+            )
+        }
+        ("POST", ["api", "v1", "bundles", bundle_id, "artifacts"]) => {
+            let slug = bundle_id.trim_start_matches("rb-");
+            let state = body["payload"]["state"].as_str().unwrap_or("unset");
+            let record = dir.join(format!("artifact-{slug}.states"));
+            let mut existing = fs::read_to_string(&record).unwrap_or_default();
+            existing.push_str(state);
+            existing.push('\n');
+            fs::write(&record, existing).unwrap();
+            (
+                201,
+                "{\"data\":{\"id\":\"art-1\",\"artifactHash\":\"fakehash\"}}".to_string(),
+            )
+        }
+        _ => (
+            404,
+            format!("{{\"errors\":{{\"detail\":\"unexpected endpoint {method} /{path}\"}}}}"),
+        ),
+    };
+    write!(
+        stream,
+        "HTTP/1.1 {status} Fake\r\ncontent-type: application/json\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{response}",
+        response.len()
+    )?;
+    stream.flush()
+}

--- a/tests/sync.rs
+++ b/tests/sync.rs
@@ -1015,3 +1015,70 @@ fn pull_fast_forwards_checkouts_after_fetch_advanced_the_artifact() {
 
     fs::remove_dir_all(root).unwrap();
 }
+
+#[test]
+fn archive_and_restore_sync_lifecycle_state_to_remote() {
+    let root = unique_temp_dir();
+    let backend = root.join("backend");
+    let workspace = root.join("workspace");
+    fs::create_dir_all(&workspace).unwrap();
+    init_repo(&backend, "backend");
+
+    knit(&workspace, ["init", "demo"]);
+    knit(
+        &workspace,
+        ["project", "add", "backend", backend.to_str().unwrap()],
+    );
+    let fake_dir = root.join("fake-knithub");
+    let base_url = spawn_fake_knithub_push_api(&fake_dir);
+    knit(&workspace, ["remote", "add", "hosted", &base_url]);
+    let env = [("KNIT_REMOTE_TOKEN", "test-token")];
+
+    knit(&workspace, ["bundle", "quick fix", "--repo", "backend"]);
+    knit_with_env(&workspace, ["bundle", "archive", "quick-fix"], &env);
+
+    let record = fake_dir.join("artifact-quick-fix.states");
+    let states = fs::read_to_string(&record).expect("archive should push the artifact");
+    assert_eq!(states.lines().last(), Some("archived"), "{states}");
+
+    knit_with_env(&workspace, ["bundle", "restore", "quick-fix"], &env);
+    let states = fs::read_to_string(&record).unwrap();
+    assert_eq!(states.lines().last(), Some("open"), "{states}");
+
+    fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
+fn sync_push_bundles_sweeps_open_and_archived_artifacts() {
+    let root = unique_temp_dir();
+    let backend = root.join("backend");
+    let workspace = root.join("workspace");
+    fs::create_dir_all(&workspace).unwrap();
+    init_repo(&backend, "backend");
+
+    knit(&workspace, ["init", "demo"]);
+    knit(
+        &workspace,
+        ["project", "add", "backend", backend.to_str().unwrap()],
+    );
+    let fake_dir = root.join("fake-knithub");
+    let base_url = spawn_fake_knithub_push_api(&fake_dir);
+    knit(&workspace, ["remote", "add", "hosted", &base_url]);
+    let env = [("KNIT_REMOTE_TOKEN", "test-token")];
+
+    knit(&workspace, ["bundle", "alpha work", "--repo", "backend"]);
+    knit(&workspace, ["bundle", "beta work", "--repo", "backend"]);
+    // No token in the environment here, so the archive's own remote sync
+    // warn-skips and the later sweep is what carries the state.
+    knit(&workspace, ["bundle", "archive", "beta-work"]);
+
+    let output = knit_with_env(&workspace, ["sync", "push", "--bundles"], &env);
+    assert!(output.contains("bundle artifact(s)"), "{output}");
+
+    let alpha = fs::read_to_string(fake_dir.join("artifact-alpha-work.states")).unwrap();
+    assert_eq!(alpha.lines().last(), Some("open"), "{alpha}");
+    let beta = fs::read_to_string(fake_dir.join("artifact-beta-work.states")).unwrap();
+    assert_eq!(beta.lines().last(), Some("archived"), "{beta}");
+
+    fs::remove_dir_all(root).unwrap();
+}


### PR DESCRIPTION
Generated by Knit. Cross-links will be refreshed after all review objects are created.

<!-- BEGIN KNIT BUNDLE -->
## Knit Bundle

This PR is part of Knit bundle `sync-bundle-archive-state-to-knithub`.

See the other review objects in this bundle:
- `knit`: https://github.com/marc-merino/knit/pull/119 (this PR)
- `knithub`: https://github.com/marc-merino/knithub/pull/107

Bundle id: `sync-bundle-archive-state-to-knithub`
Bundle title: Sync bundle archive state to KnitHub
<!-- END KNIT BUNDLE -->