### PR TITLE
Preserve merged history in remote cleanup and archive projection (knit)

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -414,7 +414,7 @@ knit bundle prune --untracked
 knit bundle prune --apply --untracked --worktrees
 ```
 
-Remote bundle cleanup uses the configured KnitHub sync remote, requires a token with `bundle:delete`, and marks matching remote bundle records deleted. Use explicit flags instead of `--all` when you want local/Git branch cleanup but want to preserve KnitHub bundle history.
+Remote bundle cleanup uses the configured KnitHub sync remote and archives matching remote bundle records — it never deletes them, because a record whose local artifact is gone is often the last remaining trace of shipped work. Archiving rides the everyday `bundle:push` scope. True remote deletion stays a per-bundle decision via `knit bundle delete --remote-bundles`, which requires a `bundle:delete` token.
 
 With `--remote-bundles`, prune also detects **remote orphans**: bundle records that exist on the sync remote but have no local artifact and whose recorded PRs are all merged or closed. Without this, a plain `knit bundle prune --apply` could delete a local artifact while leaving its KnitHub record behind, and no later prune could ever reach it again. These are listed under "Remote orphan bundle candidates" and deleted on `--apply`; their live PR state is refreshed from the host by URL during detection (the synced artifact can be stale), falling back to the recorded state when the lookup fails. Prune is also best-effort: an unreadable bundle file, a failed PR lookup, or an unverifiable checkout is reported as a warning and skipped (the bundle is kept to be safe) instead of aborting the whole scan.
 

--- a/src/commands/bundle/prune/mod.rs
+++ b/src/commands/bundle/prune/mod.rs
@@ -243,21 +243,25 @@ pub fn prune_merged_bundles(
         remove_orphan_worktree(&orphan, force)?;
         removed_orphans += 1;
     }
+    // Remote orphan records are archived, never deleted: a record whose local
+    // artifact is gone is the last remaining trace of shipped work, and the
+    // hosted dashboard is the durable archive of record. True deletion stays a
+    // per-bundle decision via `knit bundle delete --remote-bundles`.
     let mut removed_remote = 0usize;
     if let Some(config) = config.as_ref() {
         for orphan in remote_orphans {
-            match crate::commands::remote::delete_remote_bundle_by_id(config, &orphan.remote_id) {
+            match crate::commands::remote::archive_remote_bundle_by_id(config, &orphan.remote_id) {
                 Ok(slug) => {
                     println!(
                         "{}: {} {}",
                         out::node(&orphan.slug),
-                        out::movement("deleted remote bundle"),
+                        out::movement("archived remote bundle"),
                         out::muted(slug)
                     );
                     removed_remote += 1;
                 }
                 Err(err) => print_prune_warning(format!(
-                    "{}: failed to delete remote bundle record: {err:#}",
+                    "{}: failed to archive remote bundle record: {err:#}",
                     orphan.slug
                 )),
             }
@@ -275,7 +279,7 @@ pub fn prune_merged_bundles(
     if removed_remote > 0 {
         println!(
             "{} {} remote orphan record(s)",
-            out::heading("Removed:"),
+            out::heading("Archived:"),
             removed_remote
         );
     }

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -596,8 +596,8 @@ knit cherrypick --from feature-a --repo backend abc123
 - `knit bundle prune` refreshes GitHub PR states and lists clean dead-work bundles with no recorded open PRs. Landed and archived bundle artifacts are kept as history unless `--archived` is passed.
 - `knit bundle prune --no-refresh` performs the same scan using cached recorded PR states only.
 - `knit bundle prune --apply --worktrees --branches` is the short form for deleting dead bundle artifacts and their generated local state.
-- `knit bundle prune --apply --all` removes dead bundle artifacts, generated and orphaned worktrees, local feature branches, matching `origin` branches, and matching KnitHub remote bundle records.
-- Remote bundle cleanup uses the configured KnitHub sync remote and requires a token with `bundle:delete`.
+- `knit bundle prune --apply --all` removes dead bundle artifacts, generated and orphaned worktrees, local feature branches, and matching `origin` branches, and archives matching KnitHub remote bundle records.
+- Remote bundle cleanup uses the configured KnitHub sync remote. Orphaned remote records are archived (never deleted) with the everyday `bundle:push` scope; true remote deletion stays per-bundle via `knit bundle delete --remote-bundles` and a `bundle:delete` token.
 - `knit switch <bundle> --workspace` changes the shared workspace fallback bundle (the `--workspace` flag is required so the change is deliberate).
 - `knit project remove <project> --force` removes a reusable project template artifact.
 - `knit run <project-command>` runs a configured command inside the resolved bundle checkout.

--- a/src/commands/land/mod.rs
+++ b/src/commands/land/mod.rs
@@ -183,7 +183,14 @@ fn tag_landed_bundle(
     };
 
     if let Err(error) = crate::commands::tag::create_tag_on_active(
-        active, &name, &[], None, false, false, remote, no_remote,
+        active,
+        &name,
+        &[],
+        None,
+        false,
+        false,
+        remote,
+        no_remote,
     ) {
         println!(
             "{} land succeeded but tagging failed: {error:#}",
@@ -191,7 +198,10 @@ fn tag_landed_bundle(
         );
         advice::print(
             &active.root,
-            format!("retry the tag with `knit tag {name} --bundle {}`.", active.bundle.id),
+            format!(
+                "retry the tag with `knit tag {name} --bundle {}`.",
+                active.bundle.id
+            ),
         );
     }
 }

--- a/src/commands/remote/mod.rs
+++ b/src/commands/remote/mod.rs
@@ -19,10 +19,10 @@ pub use clone::clone_project_from_remote;
 pub use facade::{sync_pull, sync_push, SyncTargets};
 pub use history::pull_history_from_remote;
 pub use pull::{
-    delete_bundle_from_remote, delete_remote_bundle_by_id, fetch_bundles_from_remote,
-    list_remote_bundles, prepare_remote_pull, pull_bundle_remote_state, pull_remote_state,
-    pull_views_from_remote, remote_bundle_lifecycle, RemoteBundleOutcome, RemoteBundleRecord,
-    RemotePullContext,
+    archive_remote_bundle_by_id, delete_bundle_from_remote, delete_remote_bundle_by_id,
+    fetch_bundles_from_remote, list_remote_bundles, prepare_remote_pull, pull_bundle_remote_state,
+    pull_remote_state, pull_views_from_remote, remote_bundle_lifecycle, RemoteBundleOutcome,
+    RemoteBundleRecord, RemotePullContext,
 };
 pub use push::{
     add_remote, list_remotes, maybe_sync_bundle_to_remote, push_all_bundles_to_remote,

--- a/src/commands/remote/pull.rs
+++ b/src/commands/remote/pull.rs
@@ -538,6 +538,24 @@ pub fn list_remote_bundles(
 
 /// Delete a single bundle record from the sync remote by its remote id, returning the
 /// deleted bundle's slug.
+/// Archive a KnitHub bundle record in place. Used by prune's remote-orphan
+/// cleanup: a record whose local artifact is gone is finished history, not
+/// noise, so the remote keeps it (hidden from active views) instead of
+/// tombstoning it. Rides the everyday `bundle:push` scope.
+pub fn archive_remote_bundle_by_id(config: &KnitConfig, remote_id: &str) -> Result<String> {
+    let remote_name = resolve_sync_remote_name(config)?;
+    let remote = resolve_remote(config, &remote_name)?;
+    let token = resolve_token(&remote_name, remote)?;
+    let archived: RemoteBundle = request_json(
+        remote,
+        &token,
+        "PATCH",
+        &format!("/bundles/{remote_id}/archive"),
+        None,
+    )?;
+    Ok(archived.slug)
+}
+
 pub fn delete_remote_bundle_by_id(config: &KnitConfig, remote_id: &str) -> Result<String> {
     let remote_name = resolve_sync_remote_name(config)?;
     let remote = resolve_remote(config, &remote_name)?;

--- a/src/commands/tag.rs
+++ b/src/commands/tag.rs
@@ -62,7 +62,16 @@ pub fn create_tag(
     no_git: bool,
 ) -> Result<()> {
     let mut active = load_active_bundle_for_update()?;
-    create_tag_on_active(&mut active, name, selectors, note, no_push, no_git, &[], false)
+    create_tag_on_active(
+        &mut active,
+        name,
+        selectors,
+        note,
+        no_push,
+        no_git,
+        &[],
+        false,
+    )
 }
 
 /// The create/resume entry point for an already-resolved, write-locked bundle.
@@ -101,7 +110,9 @@ pub(crate) fn create_tag_on_active(
     }
 
     let indexes = resolve_repo_indexes(active, &expand_repo_selectors(selectors), false)?;
-    create_tag_set_on(active, name, &indexes, note, no_push, no_git, remote, no_remote)
+    create_tag_set_on(
+        active, name, &indexes, note, no_push, no_git, remote, no_remote,
+    )
 }
 
 /// The create core, operating on an already-loaded bundle.
@@ -204,7 +215,12 @@ fn resume_tag_set(
     let mut pushed_any = false;
 
     for pin in &node.commits {
-        let Some(repo) = active.bundle.repos.iter().find(|repo| repo.id == pin.repo_id) else {
+        let Some(repo) = active
+            .bundle
+            .repos
+            .iter()
+            .find(|repo| repo.id == pin.repo_id)
+        else {
             bail!(
                 "{}: pinned by tag `{}` but no longer tracked in this bundle.",
                 pin.repo_id,
@@ -213,7 +229,11 @@ fn resume_tag_set(
         };
         let path = PathBuf::from(&repo.path);
         if !path.exists() {
-            bail!("{}: original repo path does not exist: {}", repo.id, path.display());
+            bail!(
+                "{}: original repo path does not exist: {}",
+                repo.id,
+                path.display()
+            );
         }
 
         match ref_commit_sha(&path, &tag_ref(name))? {
@@ -255,7 +275,11 @@ fn resume_tag_set(
             None => {
                 git_output(
                     &path,
-                    [OsString::from("push"), OsString::from("origin"), OsString::from(tag_ref(name))],
+                    [
+                        OsString::from("push"),
+                        OsString::from("origin"),
+                        OsString::from(tag_ref(name)),
+                    ],
                 )
                 .with_context(|| format!("{}: failed to push tag", repo.id))?;
                 pushed_any = true;
@@ -301,7 +325,9 @@ pub fn list_tags() -> Result<()> {
         for line in output.lines() {
             let tag = line.trim();
             if !tag.is_empty() {
-                tags.entry(tag.to_string()).or_default().insert(repo_id.clone());
+                tags.entry(tag.to_string())
+                    .or_default()
+                    .insert(repo_id.clone());
             }
         }
     }
@@ -312,7 +338,11 @@ pub fn list_tags() -> Result<()> {
     }
 
     let width = tags.keys().map(|tag| tag.len()).max().unwrap_or(3).max(3);
-    println!("{}  {}", out::header_field("tag", width), out::heading("repos"));
+    println!(
+        "{}  {}",
+        out::header_field("tag", width),
+        out::heading("repos")
+    );
     for (tag, repos) in &tags {
         let missing: Vec<&str> = targets
             .iter()
@@ -341,7 +371,11 @@ pub fn show_tag(name: &str) -> Result<()> {
     let mut found_git = false;
     let mut subject: Option<String> = None;
 
-    println!("{} {}", out::heading("Tag:"), out::branch(local_tag_name(name)));
+    println!(
+        "{} {}",
+        out::heading("Tag:"),
+        out::branch(local_tag_name(name))
+    );
     for (repo_id, path) in &targets {
         if !path.exists() {
             println!("  {} {}", out::repo(repo_id), out::muted("(missing path)"));
@@ -359,7 +393,12 @@ pub fn show_tag(name: &str) -> Result<()> {
             if subject.is_none() {
                 subject = git_output_optional(
                     path,
-                    ["tag", "--list", "--format=%(subject)", &local_tag_name(name)],
+                    [
+                        "tag",
+                        "--list",
+                        "--format=%(subject)",
+                        &local_tag_name(name),
+                    ],
                 )?;
             }
         }
@@ -503,9 +542,7 @@ fn preflight_collisions(targets: &[TagTarget], name: &str) -> Result<()> {
         let handles: Vec<_> = targets
             .iter()
             .map(|target| {
-                scope.spawn(move || {
-                    (target.repo_id.clone(), preflight_collision(target, name))
-                })
+                scope.spawn(move || (target.repo_id.clone(), preflight_collision(target, name)))
             })
             .collect();
         handles
@@ -652,7 +689,10 @@ fn build_annotation(
         }
     }
 
-    let tagged: Vec<&str> = targets.iter().map(|target| target.repo_id.as_str()).collect();
+    let tagged: Vec<&str> = targets
+        .iter()
+        .map(|target| target.repo_id.as_str())
+        .collect();
     let untagged: Vec<&str> = active
         .bundle
         .repos

--- a/tests/cleanup.rs
+++ b/tests/cleanup.rs
@@ -763,3 +763,59 @@ fn bundle_prune_keeps_finished_bundles_unless_archived_flag() {
 
     fs::remove_dir_all(root).unwrap();
 }
+
+#[test]
+fn prune_archives_remote_orphan_records_instead_of_deleting() {
+    let root = unique_temp_dir();
+    let backend = root.join("backend");
+    let workspace = root.join("workspace");
+    fs::create_dir_all(&workspace).unwrap();
+    init_repo(&backend, "backend");
+
+    knit(&workspace, ["init", "demo"]);
+    knit(
+        &workspace,
+        ["project", "add", "backend", backend.to_str().unwrap()],
+    );
+
+    // Author a bundle with merged PRs, capture its artifact as the remote
+    // record's payload, then erase it locally: the classic orphan — the
+    // KnitHub record is the last remaining trace of this shipped work.
+    knit(&workspace, ["bundle", "shipped old", "--repo", "backend"]);
+    write_bundle_publications(&workspace, "shipped-old", "MERGED");
+    let artifact_path = workspace.join(".knit/bundles/shipped-old.bundle.json");
+    let payload = fs::read_to_string(&artifact_path).unwrap();
+    knit(
+        &workspace,
+        ["bundle", "delete", "shipped-old", "--force", "--worktrees"],
+    );
+    fs::remove_dir_all(workspace.join(".knit/deleted")).ok();
+
+    let fake_dir = root.join("fake-knithub");
+    let base_url = spawn_fake_knithub_push_api(&fake_dir);
+    let export = format!(
+        "{{\"data\":{{\"project\":{{\"slug\":\"demo\"}},\"knitProject\":null,\"repositories\":[],\"bundles\":[{{\"id\":\"rb-shipped-old\",\"slug\":\"shipped-old\",\"lifecycleState\":\"open\",\"currentArtifact\":{{\"artifactHash\":\"h1\",\"payload\":{payload}}}}}],\"historyEvents\":[]}}}}"
+    );
+    fs::write(fake_dir.join("export.json"), export).unwrap();
+    knit(&workspace, ["remote", "add", "hosted", &base_url]);
+    let env = [("KNIT_REMOTE_TOKEN", "test-token")];
+
+    let pruned = knit_with_env(
+        &workspace,
+        [
+            "bundle",
+            "prune",
+            "--no-refresh",
+            "--apply",
+            "--remote-bundles",
+        ],
+        &env,
+    );
+    assert!(pruned.contains("archived remote bundle"), "{pruned}");
+
+    // The record was archived — never deleted.
+    assert!(fake_dir.join("archived-rb-shipped-old").exists());
+    assert!(!fake_dir.join("deleted-rb-shipped-old").exists());
+
+    fs::remove_dir_all(root).unwrap();
+}

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1103,6 +1103,33 @@ fn handle_fake_knithub_push_request(
         .to_string();
     let segments: Vec<&str> = path.split('/').collect();
     let (status, response) = match (method.as_str(), segments.as_slice()) {
+        // Project export: served from `<dir>/export.json` when a test staged
+        // one, so prune's remote-orphan scan sees a configurable bundle list.
+        ("GET", ["api", "v1", "projects", _, "export"]) => {
+            match fs::read_to_string(dir.join("export.json")) {
+                Ok(body) => (200, body),
+                Err(_) => (
+                    404,
+                    "{\"errors\":{\"detail\":\"no export staged\"}}".to_string(),
+                ),
+            }
+        }
+        ("PATCH", ["api", "v1", "bundles", bundle_id, "archive"]) => {
+            fs::write(dir.join(format!("archived-{bundle_id}")), "").unwrap();
+            let slug = bundle_id.trim_start_matches("rb-");
+            (
+                200,
+                format!("{{\"data\":{{\"id\":\"{bundle_id}\",\"slug\":\"{slug}\"}}}}"),
+            )
+        }
+        ("DELETE", ["api", "v1", "bundles", bundle_id]) => {
+            fs::write(dir.join(format!("deleted-{bundle_id}")), "").unwrap();
+            let slug = bundle_id.trim_start_matches("rb-");
+            (
+                200,
+                format!("{{\"data\":{{\"id\":\"{bundle_id}\",\"slug\":\"{slug}\"}}}}"),
+            )
+        }
         (_, ["api", "v1", "projects", slug]) => (
             200,
             format!("{{\"data\":{{\"id\":\"proj-1\",\"slug\":\"{slug}\"}}}}"),

--- a/tests/tag.rs
+++ b/tests/tag.rs
@@ -74,7 +74,10 @@ fn tag_creates_annotated_tags_pins_origin_base_and_records_node() {
     }
 
     // The bare origin has the tag, peeling to the freshly fetched origin base.
-    let remote_pin = git(&backend_remote, ["rev-parse", "refs/tags/knit/v1-launch^{commit}"]);
+    let remote_pin = git(
+        &backend_remote,
+        ["rev-parse", "refs/tags/knit/v1-launch^{commit}"],
+    );
     let origin_main = git(&backend, ["rev-parse", "origin/main"]);
     assert_eq!(remote_pin.trim(), origin_main.trim());
 
@@ -184,8 +187,7 @@ fn tag_show_reports_shas_subject_and_provenance() {
 #[test]
 fn tag_refuses_existing_tags_and_invalid_names() {
     let root = unique_temp_dir();
-    let (workspace, _backend, frontend, _backend_remote, collaborator) =
-        setup_remote_bundle(&root);
+    let (workspace, _backend, frontend, _backend_remote, collaborator) = setup_remote_bundle(&root);
 
     // A colliding tag pushed by someone else: refused, and nothing is created
     // anywhere (a same-bundle rerun would be the resume path instead).
@@ -211,8 +213,13 @@ fn tag_no_push_then_rerun_resumes_and_pushes_once() {
 
     let first = knit(&workspace, ["tag", "v3", "--no-push"]);
     assert!(first.contains("tagged"), "{first}");
-    assert!(!git(&backend, ["tag", "--list", "knit/v3"]).trim().is_empty());
-    assert_eq!(git(&backend_remote, ["tag", "--list", "knit/v3"]).trim(), "");
+    assert!(!git(&backend, ["tag", "--list", "knit/v3"])
+        .trim()
+        .is_empty());
+    assert_eq!(
+        git(&backend_remote, ["tag", "--list", "knit/v3"]).trim(),
+        ""
+    );
 
     let rerun = knit(&workspace, ["tag", "v3"]);
     assert!(rerun.contains("pushed"), "{rerun}");
@@ -390,7 +397,9 @@ fn land_apply_tag_flag_records_named_tag() {
     assert_eq!(bundle["state"].as_str(), Some("archived"));
     assert_eq!(tag_nodes(&bundle, "rel-2").len(), 1);
     let backend = root.join("backend");
-    assert!(!git(&backend, ["tag", "--list", "knit/rel-2"]).trim().is_empty());
+    assert!(!git(&backend, ["tag", "--list", "knit/rel-2"])
+        .trim()
+        .is_empty());
 }
 
 #[cfg(unix)]
@@ -430,7 +439,10 @@ fn land_apply_no_tag_overrides_auto_tag_config() {
         &fake_gh_dir,
     );
     // Skipped tagging still leaves the manual-tag advice.
-    assert!(apply.contains("knit tag <name> --bundle venue-capacity"), "{apply}");
+    assert!(
+        apply.contains("knit tag <name> --bundle venue-capacity"),
+        "{apply}"
+    );
 
     let bundle = read_bundle(&workspace);
     let tagged: Vec<Value> = bundle["nodes"]
@@ -448,7 +460,14 @@ fn land_apply_from_artifact_rejects_tag_flags() {
     let root = unique_temp_dir();
     let output = knit_fails(
         &root,
-        ["land", "apply", "--from-artifact", "bundle.json", "--tag", "v1"],
+        [
+            "land",
+            "apply",
+            "--from-artifact",
+            "bundle.json",
+            "--tag",
+            "v1",
+        ],
     );
     assert!(output.contains("--tag/--no-tag"), "{output}");
 }
@@ -466,7 +485,10 @@ fn land_apply_advises_tag_command() {
         &fake_bin,
         &fake_gh_dir,
     );
-    assert!(apply.contains("knit tag <name> --bundle venue-capacity"), "{apply}");
+    assert!(
+        apply.contains("knit tag <name> --bundle venue-capacity"),
+        "{apply}"
+    );
 
     // Following the advice records the land run in the tag's provenance.
     let tagged = knit(&workspace, ["--bundle", "venue-capacity", "tag", "rel-1"]);


### PR DESCRIPTION
Generated by Knit. Cross-links will be refreshed after all review objects are created.

<!-- BEGIN KNIT BUNDLE -->
## Knit Bundle

This PR is part of Knit bundle `preserve-merged-history-in-remote-cleanup-and-archive-projection`.

See the other review objects in this bundle:
- `knit`: https://github.com/marc-merino/knit/pull/120 (this PR)
- `knithub`: https://github.com/marc-merino/knithub/pull/108

Bundle id: `preserve-merged-history-in-remote-cleanup-and-archive-projection`
Bundle title: Preserve merged history in remote cleanup and archive projection
<!-- END KNIT BUNDLE -->