### PR TITLE
runtime generated compose secrets and port visibility (knit)

### DIFF
--- a/crates/knit-runtime/src/eject.rs
+++ b/crates/knit-runtime/src/eject.rs
@@ -20,6 +20,7 @@
 //! stops applying to that repo.
 
 use crate::config::{ProjectRuntime, ProjectRuntimeDatabase, RuntimeMode};
+use crate::envfile;
 use crate::plan::{StackPlan, CONTRACT_COMPOSE_CANDIDATES};
 use crate::support::{self, env_var_suffix, out};
 use crate::transform;
@@ -57,7 +58,33 @@ pub(crate) fn run_eject(
         }
 
         let mut config = transform::resolve_compose_config(&plan.compose, &plan.repo.source_path)?;
+        let env_files = match transform::resolve_compose_config_no_env(
+            &plan.compose,
+            &plan.repo.source_path,
+        ) {
+            Ok(unresolved) => envfile::service_env_files(&unresolved),
+            Err(_) => {
+                println!(
+                    "{}",
+                    out::muted(
+                        "Env files: inlined (this docker compose lacks --no-env-resolution) — check the generated file for secrets before committing."
+                    )
+                );
+                Default::default()
+            }
+        };
         let summary = eject_compose(&mut config, &inputs)?;
+        // The ejected file is committed: env values the repo's env files
+        // provide stay references, so secrets never land in git. Paths are
+        // expressed against ${KNIT_ROOT} where possible — the env file lives
+        // in the source checkout (typically untracked, so worktrees lack it)
+        // and the interpolation keeps the committed file per-user portable.
+        envfile::detach_env_files(&mut config, &env_files, &|path| match path
+            .strip_prefix(&inputs.root)
+        {
+            Ok(suffix) => join_var("KNIT_ROOT", suffix),
+            Err(_) => path.display().to_string(),
+        });
         let text = format!(
             "{}{}",
             header(&plan.compose, summary.database_service.as_deref()),

--- a/crates/knit-runtime/src/envfile.rs
+++ b/crates/knit-runtime/src/envfile.rs
@@ -1,0 +1,318 @@
+//! Env-file de-inlining for generated compose files. `docker compose config`
+//! resolves `env_file:` entries by copying every value — secrets included —
+//! into each service's `environment` map, so writing that resolved config to
+//! disk persists plaintext credentials in a generated artifact. This module
+//! puts the indirection back: values the referenced env files provide
+//! verbatim are dropped from the generated `environment` and the `env_file`
+//! references are re-attached, so secrets stay in the user's env files and
+//! only knit's rewrites (remapped ports, database rewiring) remain inline as
+//! explicit overrides — compose gives `environment` precedence over
+//! `env_file`, so the rewrites still win at `up` time.
+//!
+//! The references come from a second `docker compose config
+//! --no-env-resolution` pass; values are compared against a lenient dotenv
+//! parse. Both are conservative by construction: when the flag is missing or
+//! a value does not match byte-for-byte, the value stays inlined — behavior
+//! never changes, only where it is written down.
+
+use serde_json::{Map, Value};
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+/// One `env_file:` entry of a service, as emitted by `docker compose config
+/// --no-env-resolution` (paths already resolved absolute).
+#[derive(Debug, Clone)]
+pub(crate) struct EnvFileRef {
+    pub(crate) path: PathBuf,
+    pub(crate) required: bool,
+}
+
+/// Per-service `env_file` references from a config resolved with
+/// `--no-env-resolution`. Accepts every shape compose emits or accepts: a
+/// single string, a list of strings, or a list of `{path, required}` maps.
+pub(crate) fn service_env_files(config: &Value) -> BTreeMap<String, Vec<EnvFileRef>> {
+    let mut refs = BTreeMap::new();
+    let Some(services) = config.get("services").and_then(Value::as_object) else {
+        return refs;
+    };
+    for (name, service) in services {
+        let Some(entry) = service.get("env_file") else {
+            continue;
+        };
+        let parsed = parse_refs(entry);
+        if !parsed.is_empty() {
+            refs.insert(name.clone(), parsed);
+        }
+    }
+    refs
+}
+
+fn parse_refs(entry: &Value) -> Vec<EnvFileRef> {
+    match entry {
+        Value::String(path) => vec![EnvFileRef {
+            path: PathBuf::from(path),
+            required: true,
+        }],
+        Value::Array(items) => items.iter().flat_map(parse_refs).collect(),
+        Value::Object(map) => {
+            let Some(path) = map.get("path").and_then(Value::as_str) else {
+                return Vec::new();
+            };
+            vec![EnvFileRef {
+                path: PathBuf::from(path),
+                required: map.get("required").and_then(Value::as_bool).unwrap_or(true),
+            }]
+        }
+        _ => Vec::new(),
+    }
+}
+
+/// Drop inlined `environment` values the referenced env files provide
+/// verbatim and re-attach the `env_file` references. Values that differ —
+/// knit's port/database rewrites, shell overrides — stay inline and win over
+/// the env file. `express` renders each env-file path for the target file
+/// (absolute for run artifacts, `${KNIT_ROOT}`-relative for committed eject
+/// files). Returns how many values were de-inlined.
+pub(crate) fn detach_env_files(
+    config: &mut Value,
+    refs: &BTreeMap<String, Vec<EnvFileRef>>,
+    express: &dyn Fn(&Path) -> String,
+) -> usize {
+    let mut detached = 0;
+    let Some(services) = config
+        .get_mut("services")
+        .and_then(|services| services.as_object_mut())
+    else {
+        return 0;
+    };
+    for (name, service) in services.iter_mut() {
+        let Some(service_refs) = refs.get(name) else {
+            continue;
+        };
+        let Some(service) = service.as_object_mut() else {
+            continue;
+        };
+
+        // Later files override earlier ones, mirroring compose's precedence.
+        let mut provided: BTreeMap<String, String> = BTreeMap::new();
+        for reference in service_refs {
+            provided.extend(parse_env_file(&reference.path));
+        }
+
+        if let Some(environment) = service
+            .get_mut("environment")
+            .and_then(Value::as_object_mut)
+        {
+            let covered: Vec<String> = environment
+                .iter()
+                .filter(|(key, value)| {
+                    value
+                        .as_str()
+                        .is_some_and(|text| provided.get(*key).map(String::as_str) == Some(text))
+                })
+                .map(|(key, _)| key.clone())
+                .collect();
+            detached += covered.len();
+            for key in covered {
+                environment.remove(&key);
+            }
+            if environment.is_empty() {
+                service.remove("environment");
+            }
+        }
+
+        let entries: Vec<Value> = service_refs
+            .iter()
+            .map(|reference| {
+                let mut map = Map::new();
+                map.insert("path".to_string(), Value::String(express(&reference.path)));
+                map.insert("required".to_string(), Value::Bool(reference.required));
+                Value::Object(map)
+            })
+            .collect();
+        service.insert("env_file".to_string(), Value::Array(entries));
+    }
+    detached
+}
+
+/// Lenient dotenv parse, for equality checks only: blank lines and comments
+/// are skipped, an `export ` prefix is accepted, and one level of matching
+/// surrounding quotes is stripped. A line this parser reads differently from
+/// compose just fails the equality check and stays inlined — never wrong,
+/// only less tidy. Missing or unreadable files contribute nothing.
+fn parse_env_file(path: &Path) -> BTreeMap<String, String> {
+    let mut values = BTreeMap::new();
+    let Ok(text) = std::fs::read_to_string(path) else {
+        return values;
+    };
+    for line in text.lines() {
+        let line = line.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        let line = line.strip_prefix("export ").unwrap_or(line);
+        let Some((key, value)) = line.split_once('=') else {
+            continue;
+        };
+        let key = key.trim();
+        if key.is_empty() {
+            continue;
+        }
+        values.insert(
+            key.to_string(),
+            strip_matching_quotes(value.trim()).to_string(),
+        );
+    }
+    values
+}
+
+fn strip_matching_quotes(value: &str) -> &str {
+    for quote in ['"', '\''] {
+        if value.len() >= 2 && value.starts_with(quote) && value.ends_with(quote) {
+            return &value[1..value.len() - 1];
+        }
+    }
+    value
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn temp_env_file(name: &str, contents: &str) -> PathBuf {
+        let path =
+            std::env::temp_dir().join(format!("knit-envfile-test-{}-{name}", std::process::id()));
+        std::fs::write(&path, contents).unwrap();
+        path
+    }
+
+    #[test]
+    fn parses_every_env_file_shape() {
+        let config = json!({
+            "services": {
+                "string": {"env_file": ".env"},
+                "list": {"env_file": [".env", ".env.local"]},
+                "objects": {"env_file": [{"path": "/abs/.env", "required": false}]},
+                "none": {"image": "nginx"}
+            }
+        });
+        let refs = service_env_files(&config);
+        assert_eq!(refs["string"].len(), 1);
+        assert!(refs["string"][0].required);
+        assert_eq!(refs["list"].len(), 2);
+        assert_eq!(refs["objects"][0].path, PathBuf::from("/abs/.env"));
+        assert!(!refs["objects"][0].required);
+        assert!(!refs.contains_key("none"));
+    }
+
+    #[test]
+    fn dotenv_parse_is_lenient() {
+        let path = temp_env_file(
+            "lenient",
+            "# comment\n\nSECRET=hunter2\nexport EXPORTED=yes\nQUOTED=\"a b\"\nSINGLE='c d'\nSPACED = padded \nNOEQ\n",
+        );
+        let values = parse_env_file(&path);
+        assert_eq!(values["SECRET"], "hunter2");
+        assert_eq!(values["EXPORTED"], "yes");
+        assert_eq!(values["QUOTED"], "a b");
+        assert_eq!(values["SINGLE"], "c d");
+        assert_eq!(values["SPACED"], "padded");
+        assert!(!values.contains_key("NOEQ"));
+        std::fs::remove_file(path).unwrap();
+    }
+
+    #[test]
+    fn detach_strips_covered_values_and_keeps_overrides() {
+        let env_path = temp_env_file(
+            "detach",
+            "SECRET=hunter2\nFRONTEND_URL=http://localhost:3000\n",
+        );
+        // SECRET was inlined verbatim (env_file or `${SECRET:-}` interpolation
+        // — both read the same file); FRONTEND_URL was rewritten by the port
+        // transform; EXTRA never came from the env file.
+        let mut config = json!({
+            "services": {
+                "web": {
+                    "environment": {
+                        "SECRET": "hunter2",
+                        "FRONTEND_URL": "http://localhost:3010",
+                        "EXTRA": "inline"
+                    }
+                },
+                "plain": {"environment": {"SECRET": "hunter2"}}
+            }
+        });
+        let mut refs = BTreeMap::new();
+        refs.insert(
+            "web".to_string(),
+            vec![EnvFileRef {
+                path: env_path.clone(),
+                required: false,
+            }],
+        );
+
+        let detached = detach_env_files(&mut config, &refs, &|path| path.display().to_string());
+        assert_eq!(detached, 1);
+
+        let web = &config["services"]["web"];
+        assert!(web["environment"].get("SECRET").is_none());
+        assert_eq!(web["environment"]["FRONTEND_URL"], "http://localhost:3010");
+        assert_eq!(web["environment"]["EXTRA"], "inline");
+        assert_eq!(
+            web["env_file"],
+            json!([{"path": env_path.display().to_string(), "required": false}])
+        );
+        // No refs recorded for `plain`: untouched, even with a matching value.
+        assert_eq!(
+            config["services"]["plain"]["environment"]["SECRET"],
+            "hunter2"
+        );
+        assert!(config["services"]["plain"].get("env_file").is_none());
+        std::fs::remove_file(env_path).unwrap();
+    }
+
+    #[test]
+    fn detach_with_missing_optional_file_only_reattaches_the_reference() {
+        let mut config = json!({
+            "services": {"web": {"environment": {"SECRET": "hunter2"}}}
+        });
+        let mut refs = BTreeMap::new();
+        refs.insert(
+            "web".to_string(),
+            vec![EnvFileRef {
+                path: PathBuf::from("/nonexistent/.env"),
+                required: false,
+            }],
+        );
+        let detached = detach_env_files(&mut config, &refs, &|path| path.display().to_string());
+        assert_eq!(detached, 0);
+        assert_eq!(
+            config["services"]["web"]["environment"]["SECRET"],
+            "hunter2"
+        );
+        assert_eq!(
+            config["services"]["web"]["env_file"][0]["path"],
+            "/nonexistent/.env"
+        );
+    }
+
+    #[test]
+    fn detach_removes_environment_when_fully_covered() {
+        let env_path = temp_env_file("full", "ONLY=value\n");
+        let mut config = json!({
+            "services": {"web": {"environment": {"ONLY": "value"}}}
+        });
+        let mut refs = BTreeMap::new();
+        refs.insert(
+            "web".to_string(),
+            vec![EnvFileRef {
+                path: env_path.clone(),
+                required: true,
+            }],
+        );
+        detach_env_files(&mut config, &refs, &|path| path.display().to_string());
+        assert!(config["services"]["web"].get("environment").is_none());
+        std::fs::remove_file(env_path).unwrap();
+    }
+}

--- a/crates/knit-runtime/src/lib.rs
+++ b/crates/knit-runtime/src/lib.rs
@@ -12,6 +12,7 @@
 
 pub mod config;
 mod eject;
+mod envfile;
 mod plan;
 mod state;
 mod support;

--- a/crates/knit-runtime/src/state.rs
+++ b/crates/knit-runtime/src/state.rs
@@ -69,6 +69,24 @@ pub(crate) fn run_down(ctx: &RuntimeContext) -> Result<()> {
         out::heading("Runtime down:"),
         out::repo(&ctx.bundle_id)
     );
+
+    // The generated compose files carry resolved app configuration; a
+    // finished run has no reason to keep them around.
+    let run_dir = runtime_run_dir(&ctx.root, &ctx.bundle_id);
+    if run_dir.exists() {
+        match std::fs::remove_dir_all(&run_dir) {
+            Ok(()) => println!(
+                "{} {}",
+                out::muted("Removed:"),
+                out::path(run_dir.display())
+            ),
+            Err(error) => println!(
+                "{} could not remove {}: {error}",
+                out::warn("Warn:"),
+                run_dir.display()
+            ),
+        }
+    }
     Ok(())
 }
 
@@ -125,12 +143,21 @@ pub(crate) fn run_status(ctx: &RuntimeContext) -> Result<()> {
     };
 
     for port in &state.ports {
-        println!(
-            "{} {} localhost:{}",
-            out::muted("Port:"),
-            port.service,
-            port.host
-        );
+        match port.source_host.filter(|source| *source != port.host) {
+            Some(source) => println!(
+                "{} {} localhost:{} {}",
+                out::muted("Port:"),
+                port.service,
+                port.host,
+                out::muted(format!("(source {source})"))
+            ),
+            None => println!(
+                "{} {} localhost:{}",
+                out::muted("Port:"),
+                port.service,
+                port.host
+            ),
+        }
     }
     if let Some(database) = &state.database {
         println!(
@@ -359,11 +386,13 @@ mod tests {
                 service: "db".into(),
                 host: 5446,
                 container: Some(5432),
+                source_host: None,
             },
             ServicePort {
                 service: "web-frontend".into(),
                 host: 5184,
                 container: Some(5173),
+                source_host: None,
             },
         ];
         assert_eq!(frontend_port(&ports), Some(5184));

--- a/crates/knit-runtime/src/support.rs
+++ b/crates/knit-runtime/src/support.rs
@@ -20,6 +20,7 @@ pub(crate) mod out {
         Bold,
         Dim,
         CyanBold,
+        Yellow,
     }
 
     pub fn heading(text: impl Display) -> String {
@@ -38,6 +39,10 @@ pub(crate) mod out {
         paint(text, Style::CyanBold)
     }
 
+    pub fn warn(text: impl Display) -> String {
+        paint(text, Style::Yellow)
+    }
+
     fn paint(text: impl Display, style: Style) -> String {
         let text = text.to_string();
         if !should_color() {
@@ -47,6 +52,7 @@ pub(crate) mod out {
             Style::Bold => "\x1b[1m",
             Style::Dim => "\x1b[2m",
             Style::CyanBold => "\x1b[1;36m",
+            Style::Yellow => "\x1b[33m",
         };
         format!("{code}{text}\x1b[0m")
     }

--- a/crates/knit-runtime/src/transform.rs
+++ b/crates/knit-runtime/src/transform.rs
@@ -17,6 +17,9 @@
 //!   `docker compose config` bakes onto each named volume and network, so the
 //!   result runs as an isolated compose project with its own (freshly named)
 //!   networks and volumes rather than binding the source stack's
+//! - keeps `env_file:` values as references instead of the copies `docker
+//!   compose config` inlines, so secrets stay in the repo's env files rather
+//!   than in the generated artifact (see the `envfile` module)
 //!
 //! The result is the same composed shape with different ports and the new
 //! code. Repos that need precise control can instead commit a compose file
@@ -34,6 +37,13 @@ pub struct ServicePort {
     pub host: u16,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub container: Option<u16>,
+    /// The host port the source stack published (transform mode) or the
+    /// configured allocation base (contract mode). Surfaced so users can see
+    /// which dev port each bundle port replaced — the transform rewrites
+    /// references declared in the compose file, but ports hardcoded in app
+    /// source keep pointing here.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source_host: Option<u16>,
 }
 
 /// Transform a resolved compose config (the JSON output of `docker compose
@@ -83,6 +93,7 @@ pub fn transform_compose(
                         service: service_name.clone(),
                         host: mapping.1,
                         container: mapping.2,
+                        source_host: Some(mapping.0),
                     });
                 }
             }
@@ -529,12 +540,36 @@ fn relative_between(base: &Path, target: &Path) -> Option<String> {
 /// Resolve the compose file via `docker compose config --format json`,
 /// anchored at the source repo so relative paths resolve in source-space.
 pub fn resolve_compose_config(compose_file: &Path, project_directory: &Path) -> Result<Value> {
-    let output = std::process::Command::new("docker")
+    run_compose_config(compose_file, project_directory, false)
+}
+
+/// Like [`resolve_compose_config`], but with `--no-env-resolution`, so
+/// `env_file:` entries survive as references instead of being copied into
+/// each service's environment. Fails on compose releases predating the flag;
+/// callers fall back to the fully resolved shape.
+pub fn resolve_compose_config_no_env(
+    compose_file: &Path,
+    project_directory: &Path,
+) -> Result<Value> {
+    run_compose_config(compose_file, project_directory, true)
+}
+
+fn run_compose_config(
+    compose_file: &Path,
+    project_directory: &Path,
+    no_env_resolution: bool,
+) -> Result<Value> {
+    let mut command = std::process::Command::new("docker");
+    command
         .args(["compose", "-f"])
         .arg(compose_file)
         .arg("--project-directory")
         .arg(project_directory)
-        .args(["config", "--format", "json"])
+        .args(["config", "--format", "json"]);
+    if no_env_resolution {
+        command.arg("--no-env-resolution");
+    }
+    let output = command
         .output()
         .context("failed to run docker compose config")?;
     if !output.status.success() {
@@ -712,6 +747,14 @@ mod tests {
         assert_eq!(by_service["frontend"].1, Some(5173));
         assert_ne!(by_service["backend"].0, 4000);
         assert_ne!(by_service["frontend"].0, 5173);
+        // The source port each allocation replaced is recorded.
+        let sources: std::collections::BTreeMap<_, _> = ports
+            .iter()
+            .map(|port| (port.service.clone(), port.source_host))
+            .collect();
+        assert_eq!(sources["db"], Some(5436));
+        assert_eq!(sources["backend"], Some(4000));
+        assert_eq!(sources["frontend"], Some(5173));
 
         // Environment references to old host ports are rewritten, including
         // cross-service references; container-side ports stay.

--- a/crates/knit-runtime/src/up.rs
+++ b/crates/knit-runtime/src/up.rs
@@ -4,6 +4,7 @@
 //! environment contract, and database resolution.
 
 use crate::config::{DatabaseMode, ProjectRuntime, ProjectRuntimeDatabase, RuntimeMode};
+use crate::envfile;
 use crate::plan::StackPlan;
 use crate::state::{
     compose_project_name, frontend_port, runtime_run_dir, RuntimeRunState, RuntimeStackState,
@@ -29,6 +30,11 @@ enum Prepared {
     Transform {
         config: Value,
         port_map: Vec<(u16, u16)>,
+        /// Per-service `env_file` references from the `--no-env-resolution`
+        /// pass, used to keep env-file values (secrets included) out of the
+        /// generated file. `None` when the local compose lacks the flag —
+        /// values then stay inlined, as before.
+        env_files: Option<BTreeMap<String, Vec<envfile::EnvFileRef>>>,
     },
     Contract {
         profiles: Vec<String>,
@@ -107,6 +113,13 @@ pub(crate) fn run_up_stacks(
             RuntimeMode::Transform => {
                 let source_dir = plan.repo.source_path.clone();
                 let mut config = transform::resolve_compose_config(&plan.compose, &source_dir)?;
+                // A second, unresolved pass records which environment values
+                // come from env files, so the generated file can reference
+                // them in place instead of carrying copies.
+                let env_files =
+                    transform::resolve_compose_config_no_env(&plan.compose, &source_dir)
+                        .map(|unresolved| envfile::service_env_files(&unresolved))
+                        .ok();
                 // Shared database: strip the db service BEFORE port
                 // reallocation, so references to the shared dev port are
                 // never rewritten away from it.
@@ -166,7 +179,11 @@ pub(crate) fn run_up_stacks(
                 ready.push(Ready {
                     ports,
                     database,
-                    prepared: Prepared::Transform { config, port_map },
+                    prepared: Prepared::Transform {
+                        config,
+                        port_map,
+                        env_files,
+                    },
                 });
             }
             RuntimeMode::Contract => {
@@ -213,6 +230,7 @@ pub(crate) fn run_up_stacks(
                         service: service.clone(),
                         host: *port,
                         container: None,
+                        source_host: bases.get(service).copied(),
                     })
                     .collect();
                 if resolved.mode == DatabaseMode::Bundle {
@@ -220,6 +238,7 @@ pub(crate) fn run_up_stacks(
                         service: "db".to_string(),
                         host: resolved.host_port,
                         container: Some(5432),
+                        source_host: None,
                     });
                 }
                 let database = Some(StateDatabase {
@@ -250,7 +269,10 @@ pub(crate) fn run_up_stacks(
             })
             .collect();
         for (index, entry) in ready.iter_mut().enumerate() {
-            let Prepared::Transform { config, port_map } = &mut entry.prepared else {
+            let Prepared::Transform {
+                config, port_map, ..
+            } = &mut entry.prepared
+            else {
                 continue;
             };
             let own: BTreeSet<u16> = port_map.iter().map(|(old, _)| *old).collect();
@@ -286,9 +308,35 @@ pub(crate) fn run_up_stacks(
         out::repo(&ctx.bundle_id)
     );
     let mut stack_states: Vec<RuntimeStackState> = Vec::new();
-    for (plan, entry) in plans.iter().zip(&ready) {
-        let compose_file: PathBuf = match &entry.prepared {
-            Prepared::Transform { config, .. } => {
+    let mut any_transform_remap = false;
+    for (plan, entry) in plans.iter().zip(ready.iter_mut()) {
+        let mut env_notes: Vec<String> = Vec::new();
+        let compose_file: PathBuf = match &mut entry.prepared {
+            Prepared::Transform {
+                config, env_files, ..
+            } => {
+                // Env-file values are referenced in place, not copied: the
+                // resolved config would otherwise persist secrets from the
+                // repo's env files inside this generated artifact.
+                match env_files {
+                    Some(refs) => {
+                        envfile::detach_env_files(config, refs, &|path| path.display().to_string());
+                        let mut seen = BTreeSet::new();
+                        for reference in refs.values().flatten() {
+                            if seen.insert(reference.path.clone()) {
+                                env_notes.push(format!(
+                                    "{} {} {}",
+                                    out::muted("Env file:"),
+                                    out::path(reference.path.display()),
+                                    out::muted("(referenced, not copied)")
+                                ));
+                            }
+                        }
+                    }
+                    None => env_notes.push(out::muted(
+                        "Env files: inlined (this docker compose lacks --no-env-resolution)",
+                    )),
+                }
                 // JSON is valid YAML, so the generated file stays a compose file.
                 let generated = if multi {
                     run_dir.join(format!("docker-compose.{}.yml", plan.repo.id))
@@ -297,6 +345,14 @@ pub(crate) fn run_up_stacks(
                 };
                 fs::write(&generated, serde_json::to_string_pretty(config)?)
                     .context("failed to write generated compose file")?;
+                // Values the detach could not prove came from an env file
+                // (and knit's own rewrites of env-file values) may still be
+                // sensitive: keep the artifact owner-only.
+                #[cfg(unix)]
+                {
+                    use std::os::unix::fs::PermissionsExt;
+                    let _ = fs::set_permissions(&generated, fs::Permissions::from_mode(0o600));
+                }
                 generated
             }
             Prepared::Contract { .. } => plan.compose.clone(),
@@ -314,13 +370,30 @@ pub(crate) fn run_up_stacks(
             out::muted("Compose:"),
             out::path(compose_file.display())
         );
+        for note in &env_notes {
+            println!("{note}");
+        }
         for port in &entry.ports {
-            println!(
-                "{} {} localhost:{}",
-                out::muted("Port:"),
-                port.service,
-                port.host
-            );
+            match port.source_host.filter(|source| *source != port.host) {
+                Some(source) => {
+                    if plan.mode == RuntimeMode::Transform {
+                        any_transform_remap = true;
+                    }
+                    println!(
+                        "{} {} localhost:{} {}",
+                        out::muted("Port:"),
+                        port.service,
+                        port.host,
+                        out::muted(format!("(source {source})"))
+                    );
+                }
+                None => println!(
+                    "{} {} localhost:{}",
+                    out::muted("Port:"),
+                    port.service,
+                    port.host
+                ),
+            }
         }
         let (profiles, env) = match &entry.prepared {
             Prepared::Contract { profiles, env } => (profiles.clone(), env.clone()),
@@ -340,6 +413,14 @@ pub(crate) fn run_up_stacks(
             env,
             database: entry.database.clone(),
         });
+    }
+    if any_transform_remap {
+        println!(
+            "{}",
+            out::muted(
+                "Note: port references declared in the compose files were rewritten to the bundle ports; ports hardcoded in app source still point at the source ports."
+            )
+        );
     }
     let all_ports: Vec<ServicePort> = stack_states
         .iter()
@@ -383,6 +464,36 @@ pub(crate) fn run_up_stacks(
                 "docker compose exited with status {status}. Clean up partial containers with `knit run down`.{hint}"
             );
         }
+    }
+
+    // App code that hardcodes a source port fails silently against a dead
+    // port — or reaches the dev stack when it is still running. Surface the
+    // source ports something is actually listening on.
+    let mut busy: BTreeMap<u16, String> = BTreeMap::new();
+    for stack in &stack_states {
+        if stack.mode != RuntimeMode::Transform {
+            continue;
+        }
+        for port in &stack.ports {
+            let Some(source) = port.source_host.filter(|source| *source != port.host) else {
+                continue;
+            };
+            if !busy.contains_key(&source)
+                && TcpStream::connect_timeout(
+                    &std::net::SocketAddr::from(([127, 0, 0, 1], source)),
+                    Duration::from_millis(250),
+                )
+                .is_ok()
+            {
+                busy.insert(source, port.service.clone());
+            }
+        }
+    }
+    for (source, service) in &busy {
+        println!(
+            "{} source port {source} ({service}) is in use by another process — app code that hardcodes it reaches that stack, not this bundle",
+            out::warn("Warn:")
+        );
     }
 
     // Recorded only after every stack starts so a failed `up` does not leave

--- a/src/commands/clean.rs
+++ b/src/commands/clean.rs
@@ -131,7 +131,32 @@ pub(crate) fn clean_worktrees_for_bundle(active: &mut ActiveBundle, force: bool)
     }
 
     remove_bundle_worktree_container(&active.root, &active.bundle.id);
+    remove_runtime_run_dir(&active.root, &active.bundle.id);
     Ok(removed)
+}
+
+/// Remove the bundle's `.knit/runtime-runs/<bundle>/` artifacts (generated
+/// compose files and run state). They describe stacks built from the
+/// worktrees being torn down, and the generated files carry resolved app
+/// configuration; `knit run down` still works without them by resolving
+/// containers via compose project labels.
+fn remove_runtime_run_dir(root: &Path, bundle_id: &str) {
+    let run_dir = root.join(".knit/runtime-runs").join(bundle_id);
+    if !run_dir.exists() {
+        return;
+    }
+    match std::fs::remove_dir_all(&run_dir) {
+        Ok(()) => println!(
+            "{} {}",
+            out::movement("removed"),
+            out::path(run_dir.display())
+        ),
+        Err(error) => println!(
+            "{} could not remove {}: {error:#}",
+            out::warn("Warn:"),
+            run_dir.display()
+        ),
+    }
 }
 
 /// Tear down a single repo's generated worktree, clearing its recorded


### PR DESCRIPTION
/Hardens the transform-mode runtime after the first lift of a real multi-repo stack surfaced three gaps. No behavior change for running stacks — only what gets written to disk and shown to the user.

## 1. Secrets stay out of generated compose files

`docker compose config` inlines `env_file:` values — secrets included — into every service's environment, and the transform wrote that resolved config into `.knit/runtime-runs/<bundle>/`. In a real stack this persists credentials from the repo's `.env` in plaintext, duplicated across services, surviving `knit run down`.

Fix (new `envfile` module):
- A second `docker compose config --no-env-resolution` pass records which env values come from env files.
- Values the env files provide verbatim are dropped from the generated file and the `env_file:` references are re-attached (source-checkout paths). This also catches secrets pulled in through `${VAR:-}` interpolation in the environment section.
- Values knit rewrote (remapped ports, database rewiring) stay inline and win over the env file via compose precedence — verified in a container: a rewritten URL overrides the env-file value while secrets still arrive via `env_file`.
- Conservative by construction: on an older compose without the flag, or any value the lenient dotenv parse cannot match byte-for-byte, the value stays inlined (with a note). Never wrong, only less tidy.
- The same detach applies to `knit run eject` — the ejected file is committed, so inlined secrets would have landed in git. Paths become `${KNIT_ROOT}`-relative there when possible.
- Generated files are written `0600`; `knit run down` and worktree teardown (archive / delete / clean) now remove `.knit/runtime-runs/<bundle>/`.

## 2. Port remaps are visible

`ServicePort` records `sourceHost`; `knit run up`/`status` print `Port: api localhost:18061 (source 18051)` plus a one-line note that only compose-declared references were rewritten — ports hardcoded in app source still point at the source stack. That failure mode was silent.

## 3. Live source ports warn

After a transform up, knit probes the remapped source ports. If something still listens there (usually the dev stack), it warns — app code hardcoding that port would silently talk to the dev stack instead of the bundle.

## Verification

- `cargo test`: all green except 2 `bundle.rs` + 1 `project.rs` failures that reproduce identically on `main` (pre-existing, unrelated).
- End-to-end with a two-stack docker sandbox: secret absent from the generated file but present in the container env; cross-stack rewritten URL override wins; `0600` perms; source-port display, note, and live-port warning all shown; run dir removed on `down` and on `archive`; ejected file free of secrets with `env_file` re-attached.
- Accepted against a real multi-repo compose stack with a shared dev database.
