### PR TITLE
Remote fan-out and neutral naming (knit)

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -15,7 +15,7 @@ src/
     land/             landing plan/check/execute/update/validate/display
     merge/            local integration runs and reports
     publish/          publish workflow: scope/remote/sync/status phases plus PR body generation
-    remote/           KnitHub transport: client, facade, per-artifact push/pull/history, clone
+    remote/           sync-remote transport: client, facade, per-artifact push/pull/history, clone
     agents.rs         generated AGENTS.md guidance
     cherrypick.rs     move recorded commits between bundles
     clean.rs
@@ -86,7 +86,7 @@ Rust does not use classes in the TypeScript sense. The equivalent separation her
 - `commands/publish/` owns the user-facing publish workflow. It resolves a `providers::Forge` per repo from the repo's remote and calls through the trait; it does not hard-code a host.
 - `commands/land/` owns landing plan/run orchestration. It reads publication metadata and project landing templates, writes `.knit/land-plans/` and `.knit/land-runs/`, manages deployment checkouts under `.knit/land-worktrees/`, and appends `feature.landed` only after every step succeeds.
 - `commands/merge/` owns local bundle/ref integration into target branches or other bundles. It writes `.knit/merge-runs/`, uses managed branch checkouts under `.knit/merge-worktrees/`, rolls back failed non-manual runs to their pre-run SHAs, and records target-bundle merges as `git.observed`.
-- `commands/remote/` owns all KnitHub artifact transport. `facade.rs` selects artifact families and remotes; the per-artifact helpers in `push.rs`/`pull.rs`/`history.rs` own transport. Every door (`knit sync push/pull`, `knit push --remote`, `knit fetch`/`pull --bundles`, post-land auto-sync) routes through it.
+- `commands/remote/` owns all sync-remote artifact transport. `facade.rs` selects artifact families and remotes; the per-artifact helpers in `push.rs`/`pull.rs`/`history.rs` own transport. Every door (`knit sync push/pull`, `knit push --remote`, `knit fetch`/`pull --bundles`, post-land auto-sync) routes through it.
 - The runtime itself lives in the `crates/knit-runtime` workspace crate, kept version-control agnostic on purpose: it consumes a `RuntimeContext` (workspace root, bundle id, repos with source and checkout paths) plus the `runtime` config block, and knows nothing about ledgers, git, or bundle resolution. `commands/runtime/mod.rs` is the CLI adapter — it resolves the bundle/project, applies `stacks`/`stackRepo` narrowing and repo-id slugging, and calls the crate. Inside the crate, `plan.rs` picks each stack's compose file and mode (explicit `runtime.mode`, the `docker-compose.knit.yml` filename, or `${KNIT_*}` references select contract mode; everything else is transformed), `transform.rs` rewrites resolved compose JSON (paths into tracked repos to bundle worktrees, published ports to free ports, textual port references, shared-database stripping), `up.rs` orchestrates multi-stack starts with cross-stack port rewiring, and `state.rs` owns run state under `.knit/runtime-runs/<bundle>/` (recorded only after every stack starts; `down`/`status` resolve containers by compose project label so they survive missing state and torn-down worktrees). Docker is reached only through `docker compose` subprocesses, and a project command named `up`/`down`/`status` always wins over the runtime verbs. Transform heuristics must not grow: a stack the transform cannot lift commits a contract compose file instead. This boundary is what would let the runtime ship as its own binary or embed elsewhere later without a redesign.
 - `commands/doctor.rs` owns workspace validation and additive JSON migrations. `commands/schema.rs` prints bundled JSON Schemas for Knit artifacts.
 - `providers/` owns the `Forge` trait and its host adapters. `mod.rs` defines the trait, the canonical `PullRequest`/`CheckRun` types, host detection from a remote URL (`for_remote`/`for_repo`/`by_id`), a shared CLI runner, and the provider-agnostic publication helpers. Each adapter (`github.rs`/`gitlab.rs`/`forgejo.rs`) maps its CLI's JSON onto the canonical types. GitLab and Codeberg/Forgejo are detected from the remote host; every other remote defaults to GitHub. Provider modules expose small operations; command modules decide workflow policy.
@@ -100,7 +100,7 @@ Rust does not use classes in the TypeScript sense. The equivalent separation her
 
 Cheap pure behavior lives in small integration tests (`tests/ids.rs`, `tests/status.rs`, `tests/model.rs`).
 
-End-to-end git behavior is automated: `tests/common/` builds temporary toy repos and a workspace with an isolated `KNIT_HOME` (tests must never read the real `~/.config/knit` or reach a live KnitHub), and the flow tests (`tests/feature_flow.rs`, `tests/bundle.rs`, `tests/land.rs`, `tests/merge.rs`, `tests/publish.rs`, `tests/sync.rs`, `tests/project.rs`, `tests/config.rs`, `tests/cleanup.rs`) drive the real binary against them. [manual-test.md](manual-test.md) remains as a hands-on walkthrough.
+End-to-end git behavior is automated: `tests/common/` builds temporary toy repos and a workspace with an isolated `KNIT_HOME` (tests must never read the real `~/.config/knit` or reach a live sync remote), and the flow tests (`tests/feature_flow.rs`, `tests/bundle.rs`, `tests/land.rs`, `tests/merge.rs`, `tests/publish.rs`, `tests/sync.rs`, `tests/project.rs`, `tests/config.rs`, `tests/cleanup.rs`) drive the real binary against them. [manual-test.md](manual-test.md) remains as a hands-on walkthrough.
 
 ## Bundle Ledger
 
@@ -122,9 +122,9 @@ History events are pointers, not patches. They record the project, bundle, repo,
 
 This split enables related-work queries without duplicating Git. `knit related` first asks Git which commits touched a path, then joins those SHAs to Knit history to recover the bundle and cross-repo commit context. If a commit was made wholly outside Knit and never recorded into a bundle, Git can still report it for the path, but Knit history has no bundle context for it.
 
-## KnitHub Artifact Sync
+## Remote Artifact Sync
 
-Three kinds of Knit artifact move between the workspace and KnitHub remotes: bundle artifacts, project history events, and per-user saved views. Historically these were reached through eight overlapping doors: `knit push --remote`, `knit bundle push`, `knit fetch --bundles`, `knit pull --bundles`, `knit history push/pull/sync`, `knit view push/pull`, `knit land sync`, and the automatic push-sync-on-land driven by the `push-sync`/`sync-remote`/`sync-remotes` config keys. Several verbs did the same thing under different names, and the command surface gave no single place to learn "how do I move artifacts to KnitHub".
+Three kinds of Knit artifact move between the workspace and sync remotes: bundle artifacts, project history events, and per-user saved views. Historically these were reached through eight overlapping doors: `knit push --remote`, `knit bundle push`, `knit fetch --bundles`, `knit pull --bundles`, `knit history push/pull/sync`, `knit view push/pull`, `knit land sync`, and the automatic push-sync-on-land driven by the `push-sync`/`sync-remote`/`sync-remotes` config keys. Several verbs did the same thing under different names, and the command surface gave no single place to learn "how do I move artifacts to a remote".
 
 This is consolidated into one verb family. `knit sync` keeps its original meaning exactly — a local-only reconcile that records git commits made outside Knit — and gains two subcommands that are the one explicit way to move artifacts:
 

--- a/docs/change-group-schema.md
+++ b/docs/change-group-schema.md
@@ -162,7 +162,7 @@ The `baseBranch` field is the review target recorded by the provider. `knit land
 
 Project history events are metadata-only records derived from bundle ledgers. They include fields such as `eventId`, `projectId`, `kind`, `bundleId`, `repoId`, `branch`, `commit`, `beforeSha`, `afterSha`, `nodeId`, `nodeType`, `commitGroupId`, `occurredAt`, and `recordedAt`.
 
-Knit uses deterministic event ids so local JSONL history and KnitHub history can be merged idempotently. `knit related` joins Git path history to these events by commit SHA, then expands the result to the related bundle and commit-group context.
+Knit uses deterministic event ids so local JSONL history and remote history can be merged idempotently. `knit related` joins Git path history to these events by commit SHA, then expands the result to the related bundle and commit-group context.
 
 ## Merge Runs
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -178,7 +178,7 @@ Related in same scope:
 
 The file you queried lived in one repo; the answer tells you which commit in a
 *different* repo must be read alongside it. Pass `--pull` to refresh the
-history ledger from a KnitHub remote first.
+history ledger from a sync remote first.
 
 ## 10. Host it on KnitHub (optional)
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -209,7 +209,7 @@ knit check record functional --pass --detail "manual QA on staging"
 knit check status          # latest verdict per check, with freshness
 ```
 
-`knit check run <name>` executes the configured project command of that name (the same definition `knit run <name>` uses — define it with `knit project command set ci -- cargo test`) and records a `check.recorded` node: pass if every targeted repo exited 0, fail otherwise. A failing run is still recorded before the command errors, so the red verdict is on the ledger. `knit check record` is the door for verdicts computed elsewhere — another tool, a host CI run, a human — without making that tool a second source of truth: the record always lives in the bundle artifact and syncs to KnitHub with it.
+`knit check run <name>` executes the configured project command of that name (the same definition `knit run <name>` uses — define it with `knit project command set ci -- cargo test`) and records a `check.recorded` node: pass if every targeted repo exited 0, fail otherwise. A failing run is still recorded before the command errors, so the red verdict is on the ledger. `knit check record` is the door for verdicts computed elsewhere — another tool, a host CI run, a human — without making that tool a second source of truth: the record always lives in the bundle artifact and syncs to the remote with it.
 
 **Freshness.** A verdict is *fresh* while every repo currently tracked in the bundle still sits on the head SHA the verdict was pinned to. Any new commit, any repo added later, and the verdict reads *stale*. There is no way to assert "merge ready" directly — readiness is always derived: required checks green **and** fresh at the current heads. `knit check status` shows both dimensions:
 
@@ -272,7 +272,7 @@ knit bundle remove frontend --delete-branch    # also delete the local feature b
 knit bundle apply-view backend       # reshape the bundle to match a saved view
 ```
 
-`knit bundle remove` refuses to discard uncommitted or unpushed work unless `--force`; pass `--keep-worktree` to remove only the tracking entry and leave the worktree on disk. Views sync to KnitHub as the user's own config with `knit sync push --views` / `knit sync pull --views`, are uploaded alongside `knit project push`, and are restored by `knit clone`.
+`knit bundle remove` refuses to discard uncommitted or unpushed work unless `--force`; pass `--keep-worktree` to remove only the tracking entry and leave the worktree on disk. Views sync to the remote as the user's own config with `knit sync push --views` / `knit sync pull --views`, are uploaded alongside `knit project push`, and are restored by `knit clone`.
 
 Projects can define a default landing template. `knit land plan` expands it into the bundle-specific `.knit/land-plans/<bundle-id>.land.json`, where it can still be edited for that one bundle before `knit land apply`:
 
@@ -393,7 +393,7 @@ knit bundle delete documentation-quick-wins --force --worktrees --branches --for
 
 `--branches` uses `git branch -d`, so it refuses to delete branches with unmerged commits. `--force-branches` uses `git branch -D`. Knit only deletes local feature branches recorded by the bundle unless `--remote-branches` is also passed, which deletes the matching recorded feature branches from `origin` and removes local `origin/<branch>` tracking refs when present.
 
-`knit prune` scans workspace bundles and lists dead-work candidates: clean bundles with no recorded open PRs. Existing PR records are refreshed from GitHub before deciding, missing PR records are allowed, and dirty generated checkouts keep the bundle alive. Add `--no-refresh` for a cached/offline scan. `--worktrees` also removes orphaned `.knit/worktrees/<bundle>` directories that no longer have bundle artifacts when they contain no pending files. Pass `--force` (included in `--all`) to discard uncommitted work and remove dirty orphan worktree dirs too. `--all` is a cleanup preset for generated worktrees, local feature branches, forced local branch deletion, matching `origin` branches, and matching KnitHub remote bundle records. `knit bundle prune` is the longer namespaced form:
+`knit prune` scans workspace bundles and lists dead-work candidates: clean bundles with no recorded open PRs. Existing PR records are refreshed from GitHub before deciding, missing PR records are allowed, and dirty generated checkouts keep the bundle alive. Add `--no-refresh` for a cached/offline scan. `--worktrees` also removes orphaned `.knit/worktrees/<bundle>` directories that no longer have bundle artifacts when they contain no pending files. Pass `--force` (included in `--all`) to discard uncommitted work and remove dirty orphan worktree dirs too. `--all` is a cleanup preset for generated worktrees, local feature branches, forced local branch deletion, matching `origin` branches, and matching remote bundle records. `knit bundle prune` is the longer namespaced form:
 
 ```sh
 knit bundle prune
@@ -414,9 +414,9 @@ knit bundle prune --untracked
 knit bundle prune --apply --untracked --worktrees
 ```
 
-Remote bundle cleanup uses the configured KnitHub sync remote and archives matching remote bundle records — it never deletes them, because a record whose local artifact is gone is often the last remaining trace of shipped work. Archiving rides the everyday `bundle:push` scope. True remote deletion stays a per-bundle decision via `knit bundle delete --remote-bundles`, which requires a `bundle:delete` token.
+Remote bundle cleanup uses the configured sync remote and archives matching remote bundle records — it never deletes them, because a record whose local artifact is gone is often the last remaining trace of shipped work. Archiving rides the everyday `bundle:push` scope. True remote deletion stays a per-bundle decision via `knit bundle delete --remote-bundles`, which requires a `bundle:delete` token.
 
-With `--remote-bundles`, prune also detects **remote orphans**: bundle records that exist on the sync remote but have no local artifact and whose recorded PRs are all merged or closed. Without this, a plain `knit bundle prune --apply` could delete a local artifact while leaving its KnitHub record behind, and no later prune could ever reach it again. These are listed under "Remote orphan bundle candidates" and deleted on `--apply`; their live PR state is refreshed from the host by URL during detection (the synced artifact can be stale), falling back to the recorded state when the lookup fails. Prune is also best-effort: an unreadable bundle file, a failed PR lookup, or an unverifiable checkout is reported as a warning and skipped (the bundle is kept to be safe) instead of aborting the whole scan.
+With `--remote-bundles`, prune also detects **remote orphans**: bundle records that exist on the sync remote but have no local artifact and whose recorded PRs are all merged or closed. Without this, a plain `knit bundle prune --apply` could delete a local artifact while leaving its remote record behind, and no later prune could ever reach it again. These are listed under "Remote orphan bundle candidates" and deleted on `--apply`; their live PR state is refreshed from the host by URL during detection (the synced artifact can be stale), falling back to the recorded state when the lookup fails. Prune is also best-effort: an unreadable bundle file, a failed PR lookup, or an unverifiable checkout is reported as a warning and skipped (the bundle is kept to be safe) instead of aborting the whole scan.
 
 So the common cleanup distinction is:
 
@@ -471,19 +471,19 @@ knit fetch --all
 `knit pull` is context-aware. With no target flags:
 
 - **At the workspace base** (the shared workspace fallback, e.g. several open bundles and no specific one resolved) it updates *everything*: every active-project repo's source checkout plus every open bundle, and prints a per-target report instead of refusing.
-- **For a specific resolved bundle** (inside a worktree, `--bundle <id>`, `KNIT_BUNDLE`, or a single-bundle workspace) it pulls that bundle's tracked repos and then its KnitHub artifact, as before.
+- **For a specific resolved bundle** (inside a worktree, `--bundle <id>`, `KNIT_BUNDLE`, or a single-bundle workspace) it pulls that bundle's tracked repos and then its remote artifact, as before.
 
 Target flags drive the aggregate, best-effort report directly and may be combined:
 
 - `--main` updates each active-project repo's *source checkout* on its current branch with `git pull --ff-only`.
-- `--bundles` updates every open bundle's feature checkouts from its KnitHub artifact.
+- `--bundles` updates every open bundle's feature checkouts from its remote artifact.
 
-Aggregate pulls run in parallel — git work on the same source repo is serialized, distinct repos run concurrently — and never abort on the first problem: a dirty tree or non-fast-forward is reported (`skipped`/`failed`) while the rest proceed.
+Aggregate pulls run in parallel — git work on the same source repo is serialized, distinct repos run concurrently — and never abort on the first problem: a dirty tree or non-fast-forward is reported (`skipped`/`failed`) while the rest proceed. The remote artifact side is just as tolerant: Knit walks the configured sync remotes in order and uses the first one that responds, reporting and skipping each unreachable remote. When no remote answers, the pull says so and the git work still runs — an offline sync remote never blocks updating checkouts. An explicit `--remote <name>` still fails hard, because you named the remote you wanted.
 
 ```sh
 knit pull                 # at the base: project main repos + every open bundle, reported
 knit pull --main          # update all project repos' current branch (fast-forward only)
-knit pull --bundles       # fast-forward every open bundle's checkouts from KnitHub
+knit pull --bundles       # fast-forward every open bundle's checkouts from the sync remote
 knit pull --main --bundles
 knit pull backend         # single-bundle: pull a specific tracked repo's base checkout
 knit pull --rebase frontend
@@ -522,11 +522,11 @@ When a bundle continues after its recorded reviews were merged or closed, pass `
 
 Hosted services that run Knit from bundle artifacts can set `KNIT_GITHUB_API_TRANSPORT=ipv4` (the historical `curl`/`curl-ipv4` values still work, as do `native`/`api`) to make GitHub artifact-mode publish and landing use Knit's built-in GitHub REST client instead of `gh pr ...` commands. The client resolves hostnames IPv4-first and requires `GH_TOKEN` or `GITHUB_TOKEN` in the environment; no external `curl` is needed. It is intended for non-interactive runtimes where provider CLI prompts, host credential stores, or default IPv6 routing can hang simple GitHub I/O. Local workspace commands keep using the normal provider CLIs unless this environment variable is set. `KNIT_GITHUB_API_BASE` overrides the API base URL (defaults to `https://api.github.com`), mainly for tests.
 
-When KnitHub sync remotes are configured, `knit publish create` and `knit push` also push the bundle artifact to those remotes so the host and KnitHub stay in sync. This is on by default; disable it globally with `knit config set push-sync false`, skip it for one command with `--no-remote`, or force one or more remotes with repeated `--remote <name>`. A missing implicit sync remote is skipped after the git branch push; explicitly requested remotes still have to exist.
+When sync remotes are configured, `knit publish create` and `knit push` also push the bundle artifact to those remotes so the host and sync remotes stay in sync. This is on by default; disable it globally with `knit config set push-sync false`, skip it for one command with `--no-remote`, or force one or more remotes with repeated `--remote <name>`. A missing implicit sync remote is skipped after the git branch push; explicitly requested remotes still have to exist.
 
-### Syncing artifacts with KnitHub
+### Syncing artifacts with sync remotes
 
-`knit sync` with no subcommand is a local-only reconcile: it records git commits made outside Knit as `git.observed` nodes and never touches the network. Its `push`/`pull` subcommands are the one verb family for moving Knit artifacts (bundles, project history, and saved views) between the workspace and KnitHub remotes:
+`knit sync` with no subcommand is a local-only reconcile: it records git commits made outside Knit as `git.observed` nodes and never touches the network. Its `push`/`pull` subcommands are the one verb family for moving Knit artifacts (bundles, project history, and saved views) between the workspace and sync remotes:
 
 ```sh
 knit sync push                 # push bundle + history + views + architecture for the resolved project/bundle
@@ -539,16 +539,16 @@ knit sync pull --history       # pull only project history events
 knit sync push --remote hosted    # use an explicit remote
 ```
 
-With no target flag (`--bundles`/`--history`/`--views`/`--architecture`/`--all`), `knit sync push`/`pull` move every routine artifact family. The knowledge-graph viz slice (produced by `urdir kg viz`, often several MB) is deliberately excluded from `--all` and bare invocations — push it with an explicit `knit sync push --kg` after regenerating it. Remotes default to the configured sync remotes (`knit config set sync-remotes ...`, then `sync-remote`), falling back to the sole configured remote; override with one or more `--remote <name>`.
+With no target flag (`--bundles`/`--history`/`--views`/`--architecture`/`--all`), `knit sync push`/`pull` move every routine artifact family. The knowledge-graph viz slice (produced by `urdir kg viz`, often several MB) is deliberately excluded from `--all` and bare invocations — push it with an explicit `knit sync push --kg` after regenerating it. By default every configured remote is a sync remote — the remotes list itself is the sync set, and names carry no special meaning. `knit config set sync-remotes ...` (or the legacy `sync-remote`) narrows that set when some remotes should stay out of routine sync; override per invocation with one or more `--remote <name>`. Push-style syncs fan out to every sync remote and keep going past a failing one, reporting each failure at the end. Pull-style syncs walk the sync remotes in priority order and use the first one that responds.
 
 The git-shaped verbs keep their git semantics but route through the same internal sync module: `knit push --remote <name>` still pushes branches and then the bundle artifact, and `knit fetch --bundles` / `knit pull --bundles` still pull recorded bundle state. Landing's automatic artifact sync (when `push-sync` is enabled) goes through the same module too. There is one implementation behind several differently shaped doors.
 
 
-Remotes can be workspace-local or user-global. Workspace `.knit/config.json` remotes override global remotes of the same name; otherwise commands fall back to the user-level config at `$KNIT_HOME/config.json`, `$XDG_CONFIG_HOME/knit/config.json`, or `~/.config/knit/config.json`. This lets every workspace share the same hosted KnitHub remote unless a workspace deliberately points that name somewhere else:
+Remotes can be workspace-local or user-global. Workspace `.knit/config.json` remotes override global remotes of the same name; otherwise commands fall back to the user-level config at `$KNIT_HOME/config.json`, `$XDG_CONFIG_HOME/knit/config.json`, or `~/.config/knit/config.json`. This lets every workspace share the same hosted remote unless a workspace deliberately points that name somewhere else:
 
 ```sh
 knit remote add --global hosted https://<your-knit-api-url>
-export KNIT_REMOTE_HOSTED_TOKEN="<KnitHub API token>"
+export KNIT_REMOTE_HOSTED_TOKEN="<remote API token>"
 knit config set --global sync-remotes hosted
 knit config show
 knit remote show hosted
@@ -596,7 +596,7 @@ Bare `knit land` is safe: it creates or shows the default plan and stops. It nev
 
 `knit land apply` preflights referenced PRs, refuses draft/closed/missing PRs, writes a durable run file under `.knit/land-runs/`, then executes the plan step by step. Already-merged PRs are treated as satisfied and skipped (whether or not a prior run exists), and an open PR that conflicts with its base is rejected with guidance to run `knit land update` first. `deploy` steps support `deploymentMode: "command"` for real deployment commands and `deploymentMode: "push"` for deployments that are triggered by the PR merge itself. A command deployment can specify a `checkout` branch; Knit creates or refreshes a managed detached checkout under `.knit/land-worktrees/` before running the command. If a step fails, the run stops and records the exact step status, stdout/stderr for `run` and command `deploy` steps, and failure detail; generated bundle worktrees are left intact so `knit land resume` and `knit land rollback` can continue from the recorded run. `knit land resume` continues that run from pending or failed steps only; succeeded steps are not repeated.
 
-A failed run can leave some PRs merged and others not — merged PRs cannot be un-merged, so Knit offers compensation instead of reset. `knit land rollback` previews the merge steps the failed run completed (verifying each PR is live-MERGED), and `knit land rollback --apply` opens a provider-side revert PR for each of them, records a `pr.revert` node targeting the run, and marks the run rolled back so `knit land resume` refuses to continue it. Setting `onFailure: "rollback"` in the land plan (or in the project landing template, which `knit land plan` copies into generated plans) makes `knit land apply` perform this rollback automatically when a step fails; the default `onFailure: "resume"` keeps today's stop-and-resume behavior. A fully successful `knit land apply` appends a `feature.landed` node, archives the bundle with a `feature.archived` node, removes generated worktrees under `.knit/worktrees/<bundle>/`, and preserves local feature branches plus the bundle artifact; pass `--keep-worktrees` to archive without removing those checkouts. It then syncs the updated bundle artifact to configured KnitHub remotes when push-sync is enabled. Use repeated `--remote <name>` to force remotes, `--no-remote` to skip this sync, or `knit sync push --bundles` to push the landed artifact later.
+A failed run can leave some PRs merged and others not — merged PRs cannot be un-merged, so Knit offers compensation instead of reset. `knit land rollback` previews the merge steps the failed run completed (verifying each PR is live-MERGED), and `knit land rollback --apply` opens a provider-side revert PR for each of them, records a `pr.revert` node targeting the run, and marks the run rolled back so `knit land resume` refuses to continue it. Setting `onFailure: "rollback"` in the land plan (or in the project landing template, which `knit land plan` copies into generated plans) makes `knit land apply` perform this rollback automatically when a step fails; the default `onFailure: "resume"` keeps today's stop-and-resume behavior. A fully successful `knit land apply` appends a `feature.landed` node, archives the bundle with a `feature.archived` node, removes generated worktrees under `.knit/worktrees/<bundle>/`, and preserves local feature branches plus the bundle artifact; pass `--keep-worktrees` to archive without removing those checkouts. It then syncs the updated bundle artifact to configured sync remotes when push-sync is enabled. Use repeated `--remote <name>` to force remotes, `--no-remote` to skip this sync, or `knit sync push --bundles` to push the landed artifact later.
 
 `knit merge` is for local branch integration that is not a PR landing. It can merge a bundle or git ref into a target branch, or into another bundle's feature branches:
 
@@ -622,9 +622,9 @@ knit merge x-y-compat --into feature-y
 
 `knit sync` records commits that happened outside Knit as `git.observed` nodes and advances each affected repo's remembered `headSha`. `knit log` shows both Knit commit groups and observed git movement from the node ledger. Use `knit log -2` for the latest two log entries. `knit log -n 3` also works, and `knit log -n` defaults to the latest ten.
 
-Knit also keeps a project-wide history ledger under `.knit/history/<project>.history.jsonl` and syncs it with KnitHub when history APIs are available. This ledger is metadata only: it records bundle ids, repo ids, branch names, Knit node ids, timestamps, and Git commit SHAs. Git remains the source of truth for file contents, diffs, and file-level history.
+Knit also keeps a project-wide history ledger under `.knit/history/<project>.history.jsonl` and syncs it with sync remotes when history APIs are available. This ledger is metadata only: it records bundle ids, repo ids, branch names, Knit node ids, timestamps, and Git commit SHAs. Git remains the source of truth for file contents, diffs, and file-level history.
 
-Use `knit history list` to inspect the local project history and `knit history refresh` to rebuild it from local bundle artifacts. Exchange history events with a KnitHub remote through the shared sync verbs: `knit sync push --history` and `knit sync pull --history`.
+Use `knit history list` to inspect the local project history and `knit history refresh` to rebuild it from local bundle artifacts. Exchange history events with a sync remote through the shared sync verbs: `knit sync push --history` and `knit sync pull --history`.
 
 Use `knit related` before editing a file or area with possible cross-repo coupling. The command asks Git which commits touched the path, joins those SHAs to Knit history, then expands matching events to their bundle, commit group, and companion repo commits:
 
@@ -719,7 +719,7 @@ Sparse advice is enabled by default for new workspaces. It prints a `Next:` line
 - Worktree creation relies on `git worktree add` and inherits its constraints, including branch checkout conflicts.
 - `knit fetch` fetches the `origin` remote for each selected repo. Repos without `origin` are reported as failures.
 - `knit pull` coordinates ordinary git pulls but does not resolve merge/rebase conflicts across repos. If git stops for a conflict, resolve that repo's git state before retrying.
-- `knit push` pushes feature branches to `origin` and, when KnitHub sync remotes are configured and `push-sync` is enabled, the bundle artifact to those remotes; use `knit publish create` to publish review objects.
+- `knit push` pushes feature branches to `origin` and, when sync remotes are configured and `push-sync` is enabled, the bundle artifact to those remotes; use `knit publish create` to publish review objects.
 - `knit publish` detects the host from each repo's remote: GitLab uses `glab`, Codeberg/Forgejo uses `tea`, and every other remote defaults to GitHub's `gh`. The matching CLI must be installed and authenticated. Bitbucket and other hosts would need new adapters. The GitLab and Forgejo adapters target current `glab`/`tea` JSON; their field mapping may need tuning across CLI versions, and `tea` does not surface commit-status checks, so landing treats Forgejo PRs as having no required checks.
 - `knit publish create` is not perfectly transactional. Branch pushes, review creation, and body updates happen sequentially. If phase two fails after review objects are created, run `knit publish sync`.
 - `knit land` resolves the host adapter per repo from its remote. A merge lands into the recorded base branch. Remote merges cannot be automatically unmerged by Knit, so failed land runs are recorded in `.knit/land-runs/`; fix the failed step and use `knit land resume`, or use `knit land rollback` to open revert PRs for the steps that already merged.

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -28,7 +28,7 @@ points, not pins.
 |------|----------|----------|-------|
 | External `git` lookup | `src/git.rs:146,179,199`, `src/commands/git_passthrough.rs:42`, `src/commands/runtime.rs:458`, `src/commands/remote/clone.rs:491` | Medium | `Command::new("git")`. Rust resolves `git.exe` on `PATH`, so this works if Git for Windows is installed. Not a blocker, but Git is now a hard external dependency on Windows too. |
 | External forge CLIs | `src/providers/github.rs:14` (`gh`), `src/providers/gitlab.rs:9` (`glab`), `src/providers/forgejo.rs:9` (`tea`) | Fixed | `forge_cli_command` in `src/providers/mod.rs` probes `.exe`, bare name, then `.cmd`/`.bat` shims on Windows before spawning. `.ps1`-only installs remain unsupported. |
-| HTTP client | `src/providers/github.rs`, `src/commands/remote/client.rs` | Fixed | KnitHub and GitHub artifact-mode API calls use a built-in HTTP client (ureq, rustls). No external `curl` dependency; the GitHub transport resolves IPv4-first, and the temporary netrc credentials file is gone — tokens travel in an `Authorization` header. |
+| HTTP client | `src/providers/github.rs`, `src/commands/remote/client.rs` | Fixed | Sync-remote and GitHub artifact-mode API calls use a built-in HTTP client (ureq, rustls). No external `curl` dependency; the GitHub transport resolves IPv4-first, and the temporary netrc credentials file is gone — tokens travel in an `Authorization` header. |
 | Interactive shell spawn | `src/commands/init.rs:168-195` | Low | `start_shell_in` already branches: `default_shell()` returns `cmd` on Windows, `/bin/sh` otherwise, and honors `$SHELL`. `cmd` does not understand the `KNIT_*` env it is handed in any special way, but the spawn itself is portable. No `sh -c` wrapper is used. |
 | Project/deploy command spawn | `src/commands/run.rs:204`, `src/commands/land/execute.rs:358,435` | Medium | Project commands and land deploy steps are spawned as `Command::new(command[0]).args(command[1..])` — a direct exec, **not** `sh -c`. This is portable in principle, but project/land JSON authored on Unix often assumes a POSIX shell (e.g. `["sh","-c","..."]`, `&&`, globbing). Such commands will not run on Windows. This is a data/portability concern, not a code bug. Documented, intentionally not refactored. |
 | Path comparison semantics | `src/paths.rs:14` (`same_path`) | Medium | Used for repo dedup in `src/commands/track.rs:117,272`. Now case-folds path components on Windows so `C:\repo` and `c:\repo` dedupe correctly; stays exact/case-sensitive on Unix. Best-effort textual compare, not canonicalization. (Fixed in this branch.) |
@@ -81,7 +81,7 @@ producers are:
   string into `.knit/contexts.json`.
 - Recorded repo `path` fields in bundle artifacts (consumed by `same_path`).
 
-These artifacts **travel between machines and operating systems via KnitHub**
+These artifacts **travel between machines and operating systems via sync remotes**
 (push/pull/clone). A bundle authored on macOS stores `backend/src`; the same
 bundle authored on Windows would store `backend\src`. When that artifact is
 pulled onto the other OS:

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -44,12 +44,12 @@ pub enum Commands {
         #[command(subcommand)]
         command: ViewCommand,
     },
-    /// Manage KnitHub API remotes.
+    /// Manage sync remotes.
     Remote {
         #[command(subcommand)]
         command: RemoteCommand,
     },
-    /// Clone a KnitHub project export into a local Knit workspace.
+    /// Clone a remote project export into a local Knit workspace.
     Clone {
         /// Project to clone: `owner/slug`, a bare slug, or a project id. Use the
         /// `owner/slug` form (owner is a username or org slug) when a slug is not
@@ -57,13 +57,13 @@ pub enum Commands {
         project: String,
         /// Directory to create. Defaults to the project slug.
         target: Option<PathBuf>,
-        /// Named KnitHub remote. Defaults to the configured sync remote.
+        /// Named sync remote. Defaults to the configured sync remote.
         #[arg(long)]
         remote: Option<String>,
-        /// KnitHub base URL. Required when the remote is not configured.
+        /// Remote base URL. Required when the remote is not configured.
         #[arg(long)]
         url: Option<String>,
-        /// KnitHub token. Prefer KNIT_REMOTE_<NAME>_TOKEN or KNIT_REMOTE_TOKEN.
+        /// Remote token. Prefer KNIT_REMOTE_<NAME>_TOKEN or KNIT_REMOTE_TOKEN.
         #[arg(long)]
         token: Option<String>,
         /// Bundle to make active after clone. Defaults to the latest open exported bundle.
@@ -174,10 +174,10 @@ pub enum Commands {
         /// Fetch mode: --all (default), --git only, --knit only.
         #[arg(long, default_value = "all", value_name = "MODE")]
         mode: FetchMode,
-        /// Named KnitHub remote for knit fetch. Defaults to the configured sync remote.
+        /// Named sync remote for knit fetch. Defaults to the configured sync remote.
         #[arg(long, value_name = "REMOTE")]
         remote: Option<String>,
-        /// (Deprecated, use --git) Skip KnitHub remote sync.
+        /// (Deprecated, use --git) Skip sync remote sync.
         #[arg(long, hide = true)]
         no_remote: bool,
     },
@@ -202,13 +202,13 @@ pub enum Commands {
         /// Update the active project's repos (their source checkouts, current branch, fast-forward only).
         #[arg(long)]
         main: bool,
-        /// Update every open bundle's checkouts from its KnitHub artifact. Combine with --main.
+        /// Update every open bundle's checkouts from its remote artifact. Combine with --main.
         #[arg(long)]
         bundles: bool,
-        /// Also pull the current bundle artifact from a named KnitHub remote.
+        /// Also pull the current bundle artifact from a named sync remote.
         #[arg(long, value_name = "REMOTE")]
         remote: Option<String>,
-        /// Skip configured KnitHub remote sync for this pull.
+        /// Skip configured sync remote sync for this pull.
         #[arg(long)]
         no_remote: bool,
         /// Union-merge the bundle ledger when the local and remote artifacts
@@ -226,10 +226,10 @@ pub enum Commands {
         /// Set each feature branch's upstream to origin/<branch>.
         #[arg(long)]
         set_upstream: bool,
-        /// Also push the bundle artifact to these KnitHub remotes. Repeat to push to multiple remotes and override push-sync config.
+        /// Also push the bundle artifact to these sync remotes. Repeat to push to multiple remotes and override push-sync config.
         #[arg(long, value_name = "REMOTE")]
         remote: Vec<String>,
-        /// Skip the KnitHub bundle sync for this push.
+        /// Skip the remote bundle sync for this push.
         #[arg(long)]
         no_remote: bool,
     },
@@ -337,11 +337,11 @@ pub enum Commands {
         #[arg(long)]
         dry_run: bool,
     },
-    /// Reconcile local Knit state, or sync artifacts with KnitHub.
+    /// Reconcile local Knit state, or sync artifacts with the configured remotes.
     ///
     /// Bare `knit sync` records git commits made outside Knit into the bundle
     /// ledger (a local-only reconcile). The `push`/`pull` subcommands are the one
-    /// way to move bundle, history, and view artifacts to and from KnitHub.
+    /// way to move bundle, history, and view artifacts to and from the sync remotes.
     Sync {
         #[command(subcommand)]
         command: Option<SyncCommand>,
@@ -371,7 +371,7 @@ pub enum Commands {
         /// Pull Knit history from a remote before querying.
         #[arg(long)]
         pull: bool,
-        /// Named KnitHub remote used with --pull.
+        /// Named sync remote used with --pull.
         #[arg(long)]
         remote: Option<String>,
     },
@@ -443,22 +443,22 @@ pub enum Commands {
 
 #[derive(Subcommand)]
 pub enum SyncCommand {
-    /// Push artifacts to KnitHub. With no target flags, pushes bundle, history,
+    /// Push artifacts to the sync remotes. With no target flags, pushes bundle, history,
     /// views, and architecture for the resolved project/bundle; the
     /// knowledge-graph viz slice moves only with an explicit `--kg`.
     Push {
         #[command(flatten)]
         targets: SyncTargetArgs,
-        /// Named KnitHub remote(s). Repeat for several. Defaults to configured sync remotes.
+        /// Named sync remote(s). Repeat for several. Defaults to configured sync remotes.
         #[arg(long, value_name = "REMOTE")]
         remote: Vec<String>,
     },
-    /// Pull artifacts from KnitHub. With no target flags, pulls bundle, history,
+    /// Pull artifacts from the sync remotes. With no target flags, pulls bundle, history,
     /// and views for the resolved project/bundle.
     Pull {
         #[command(flatten)]
         targets: SyncTargetArgs,
-        /// Named KnitHub remote(s). Repeat for several. Defaults to configured sync remotes.
+        /// Named sync remote(s). Repeat for several. Defaults to configured sync remotes.
         #[arg(long, value_name = "REMOTE")]
         remote: Vec<String>,
     },
@@ -592,7 +592,7 @@ pub enum BundleCommand {
         /// Report every bundle's prune status, including ones that are kept.
         #[arg(long)]
         report: bool,
-        /// Remove all cleanup targets: worktrees, local branches, forced local branch deletion, origin branches, and KnitHub remote bundle records.
+        /// Remove all cleanup targets: worktrees, local branches, forced local branch deletion, origin branches, and remote bundle records.
         #[arg(long)]
         all: bool,
         /// Remove generated worktrees for each pruned bundle and orphaned worktree dirs.
@@ -610,7 +610,7 @@ pub enum BundleCommand {
         /// Delete matching feature branches from origin.
         #[arg(long = "remote-branches", requires = "branches")]
         remote_branches: bool,
-        /// Delete matching KnitHub remote bundle records.
+        /// Delete matching remote bundle records.
         #[arg(long = "remote-bundles")]
         remote_bundles: bool,
         /// Also prune finished (landed/archived) bundle artifacts. By default
@@ -698,11 +698,11 @@ pub enum ProjectCommand {
         #[arg(long)]
         force: bool,
     },
-    /// Push the project JSON shape and repositories to a KnitHub remote.
+    /// Push the project JSON shape and repositories to a sync remote.
     Push {
         /// Project name. Defaults to the active project.
         name: Option<String>,
-        /// Named KnitHub remote. Defaults to the configured sync remote.
+        /// Named sync remote. Defaults to the configured sync remote.
         #[arg(long)]
         remote: Option<String>,
     },
@@ -855,13 +855,13 @@ pub enum ViewCommand {
 
 #[derive(Subcommand)]
 pub enum RemoteCommand {
-    /// Add or replace a named KnitHub API remote.
+    /// Add or replace a named sync remote.
     Add {
         /// Remote name, for example `hosted`.
         name: String,
-        /// KnitHub base URL, for example `http://localhost:4000` or `https://host.example`.
+        /// Remote base URL, for example `http://localhost:4000` or `https://host.example`.
         url: String,
-        /// Optional KnitHub token. Prefer KNIT_REMOTE_<NAME>_TOKEN or KNIT_REMOTE_TOKEN for shared workspaces.
+        /// Optional remote token. Prefer KNIT_REMOTE_<NAME>_TOKEN or KNIT_REMOTE_TOKEN for shared workspaces.
         #[arg(long)]
         token: Option<String>,
         /// Store this remote in the user-level Knit config instead of the workspace.
@@ -970,10 +970,10 @@ pub enum PublishCommand {
         /// Set each feature branch's upstream to origin/<branch> while pushing.
         #[arg(long)]
         set_upstream: bool,
-        /// Also push the bundle artifact to these KnitHub remotes. Repeat to push to multiple remotes and override push-sync config.
+        /// Also push the bundle artifact to these sync remotes. Repeat to push to multiple remotes and override push-sync config.
         #[arg(long, value_name = "REMOTE")]
         remote: Vec<String>,
-        /// Skip the KnitHub bundle sync for this publish.
+        /// Skip the remote bundle sync for this publish.
         #[arg(long)]
         no_remote: bool,
         /// Limit publishing to repos hosted on this provider (github, gitlab, forgejo). Default: every repo's own host.
@@ -1096,10 +1096,10 @@ pub enum LandCommand {
         /// When omitted, the updated artifact is printed to stdout.
         #[arg(long)]
         out: Option<PathBuf>,
-        /// Also push the landed bundle artifact to these KnitHub remotes. Repeat to push to multiple remotes and override push-sync config.
+        /// Also push the landed bundle artifact to these sync remotes. Repeat to push to multiple remotes and override push-sync config.
         #[arg(long, value_name = "REMOTE")]
         remote: Vec<String>,
-        /// Skip the KnitHub bundle sync after landing.
+        /// Skip the remote bundle sync after landing.
         #[arg(long, conflicts_with = "remote")]
         no_remote: bool,
         /// After a successful land, record a cross-repo known-good tag of the resulting main. Optionally name it; defaults to the bundle slug.
@@ -1126,10 +1126,10 @@ pub enum LandCommand {
         /// Run file to resume. Defaults to the latest run.
         #[arg(long)]
         run: Option<PathBuf>,
-        /// Also push the landed bundle artifact to these KnitHub remotes. Repeat to push to multiple remotes and override push-sync config.
+        /// Also push the landed bundle artifact to these sync remotes. Repeat to push to multiple remotes and override push-sync config.
         #[arg(long, value_name = "REMOTE")]
         remote: Vec<String>,
-        /// Skip the KnitHub bundle sync after landing.
+        /// Skip the remote bundle sync after landing.
         #[arg(long, conflicts_with = "remote")]
         no_remote: bool,
     },

--- a/src/commands/agents.rs
+++ b/src/commands/agents.rs
@@ -471,7 +471,7 @@ knit related <repo-id>/path/inside/repo
 knit related --repo <repo-id> path/inside/repo --pull
 ```
 
-Use `--pull` when you want to refresh the local history ledger from KnitHub first. The command joins Git's file history with Knit history; Git remains the source of truth for file diffs, and Knit supplies the bundle/commit-group context.
+Use `--pull` when you want to refresh the local history ledger from the sync remote first. The command joins Git's file history with Knit history; Git remains the source of truth for file diffs, and Knit supplies the bundle/commit-group context.
 {teamwork_section}{runtime_section}{landing_section}
 {end}
 "#,

--- a/src/commands/bundle/lifecycle.rs
+++ b/src/commands/bundle/lifecycle.rs
@@ -49,7 +49,7 @@ pub fn archive_bundle(
     Ok(())
 }
 
-/// Mirror an archive/restore onto configured KnitHub remotes by pushing the
+/// Mirror an archive/restore onto configured sync remotes by pushing the
 /// updated artifact, so hosted dashboards flip lifecycle state together with
 /// the local ledger. Best-effort: the local transition already succeeded, so
 /// sync failures warn instead of failing the command. A workspace with no
@@ -58,7 +58,7 @@ fn sync_lifecycle_state_to_remote(active: &ActiveBundle) {
     if let Err(error) =
         crate::commands::remote::sync_active_bundle_to_remote_if_enabled(active, &[], false)
     {
-        println!("{} {error:#}", out::warn("KnitHub sync skipped:"));
+        println!("{} {error:#}", out::warn("remote sync skipped:"));
     }
 }
 

--- a/src/commands/bundle/prune/mod.rs
+++ b/src/commands/bundle/prune/mod.rs
@@ -1,5 +1,5 @@
 //! `knit prune` — find and delete dead-work bundles, orphan worktrees, and
-//! orphaned KnitHub remote bundle records.
+//! orphaned remote bundle records.
 //!
 //! A bundle is "dead work" when it has no open PRs, no uncommitted tracked
 //! changes in any checkout, and — for repos with no recorded review object —
@@ -198,7 +198,7 @@ pub fn prune_merged_bundles(
             println!(
                 "  {} {} ({})",
                 out::node(&orphan.slug),
-                out::muted("KnitHub record with no local bundle"),
+                out::muted("remote record with no local bundle"),
                 out::muted(orphan.reason)
             );
         }

--- a/src/commands/bundle/prune/orphans.rs
+++ b/src/commands/bundle/prune/orphans.rs
@@ -1,5 +1,5 @@
 //! Orphan cleanup targets: generated worktree directories whose bundle is
-//! gone, and KnitHub remote bundle records with no local artifact whose PRs
+//! gone, and remote bundle records with no local artifact whose PRs
 //! are all merged or closed (unreachable by the local bundle scan).
 
 use super::assess::{
@@ -23,7 +23,7 @@ pub(super) struct OrphanWorktree {
     pub(super) discards_pending: bool,
 }
 
-/// A bundle that exists on the KnitHub sync remote but has no local artifact and
+/// A bundle that exists on the sync remote but has no local artifact and
 /// whose recorded pull requests are all merged or closed, so prune can never reach
 /// it through the local `.knit/bundles/` scan.
 pub(super) struct RemoteOrphan {
@@ -32,7 +32,7 @@ pub(super) struct RemoteOrphan {
     pub(super) reason: &'static str,
 }
 
-/// Find KnitHub remote bundle records that have no local artifact and whose recorded
+/// Find remote bundle records that have no local artifact and whose recorded
 /// PRs are all merged or closed. These can never be reached by the local `.knit/bundles/`
 /// scan once their local artifact is gone, so prune would otherwise leave them forever.
 pub(super) fn remote_orphan_candidates(
@@ -45,16 +45,14 @@ pub(super) fn remote_orphan_candidates(
         return Vec::new();
     };
     let Some(project_id) = config.active_project.clone() else {
-        print_prune_warning(
-            "no active project configured; skipping KnitHub remote orphan detection",
-        );
+        print_prune_warning("no active project configured; skipping sync remote orphan detection");
         return Vec::new();
     };
     let records = match crate::commands::remote::list_remote_bundles(config, &project_id) {
         Ok(records) => records,
         Err(err) => {
             print_prune_warning(format!(
-                "could not list KnitHub remote bundles ({err:#}); skipping remote orphan detection"
+                "could not list remote bundles ({err:#}); skipping remote orphan detection"
             ));
             return Vec::new();
         }

--- a/src/commands/config.rs
+++ b/src/commands/config.rs
@@ -224,7 +224,7 @@ fn ensure_sync_remotes_exist(root: &std::path::Path, config: &KnitConfig) -> Res
 fn ensure_sync_remotes_in_config(config: &KnitConfig) -> Result<()> {
     for remote_name in configured_sync_remote_names(config) {
         if !config.remotes.contains_key(&remote_name) {
-            bail!("No KnitHub remote named `{remote_name}`. Run `knit remote add {remote_name} <url>` or `knit remote add --global {remote_name} <url>` first.");
+            bail!("No remote named `{remote_name}`. Run `knit remote add {remote_name} <url>` or `knit remote add --global {remote_name} <url>` first.");
         }
     }
     Ok(())

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -252,7 +252,7 @@ fn default_shell() -> std::ffi::OsString {
     }
 }
 
-/// Refuse to create a bundle whose slug already exists on the KnitHub sync
+/// Refuse to create a bundle whose slug already exists on the sync
 /// remote for this project: two users independently picking the same title
 /// would otherwise share one remote record and one `knit/<slug>` branch
 /// namespace across every repo. Best-effort by design — no workspace config,
@@ -277,7 +277,7 @@ fn ensure_no_remote_slug_collision(
     };
     match crate::commands::remote::remote_bundle_lifecycle(&config, &project_id, bundle_id) {
         Ok(Some(state)) => bail!(
-            "Bundle `{bundle_id}` already exists on the KnitHub sync remote for project `{project_id}` ({state}). Join the existing bundle with `knit fetch` and `knit --bundle {bundle_id} bundle worktree`, pick another title, or pass --force to create a local bundle with the same id anyway."
+            "Bundle `{bundle_id}` already exists on the sync remote for project `{project_id}` ({state}). Join the existing bundle with `knit fetch` and `knit --bundle {bundle_id} bundle worktree`, pick another title, or pass --force to create a local bundle with the same id anyway."
         ),
         // Offline, missing remote/token, or a server error must never block
         // local bundle creation; the push-time ledger gate still protects the
@@ -544,7 +544,7 @@ Push the bundle's feature branches after committing:
 knit --bundle feature-a push --set-upstream
 ```
 
-Push the bundle to one or more KnitHub remotes so it appears in hosted dashboards. `knit push --remote` pushes feature branches and the bundle artifact together; `knit sync push` is the artifact-only door and is the one verb family for moving bundles, history, and views to KnitHub:
+Push the bundle to one or more sync remotes so it appears in hosted dashboards. `knit push --remote` pushes feature branches and the bundle artifact together; `knit sync push` is the artifact-only door and is the one verb family for moving bundles, history, and views to the sync remotes:
 
 ```sh
 knit --bundle feature-a push --remote hosted
@@ -594,7 +594,7 @@ Land from a bundle artifact JSON (merge-only, no local workspace):
 knit land apply --from-artifact bundle.published.json --out bundle.landed.json
 ```
 
-Bare `knit land` creates or shows the default plan and stops. It never merges PRs, deploys, waits, or runs plan commands. `knit land apply` executes the plan and lands each recorded PR into its GitHub PR base branch, then executes any generated or edited deployment steps. On full success it archives the bundle and removes generated worktrees under `.knit/worktrees/<bundle>/` while preserving local feature branches and the bundle artifact; pass `--keep-worktrees` to keep those checkouts. When push-sync is enabled, a successful land also syncs the updated bundle artifact to configured KnitHub remotes; use `knit sync push --bundles` to push the landed artifact later. Project JSON can define a default `landing` template with merge priority and deployments, while `.knit/land-plans/<bundle>.land.json` remains the editable per-bundle plan. A PR with no required checks has passed Knit’s required-check gate. Do not use `gh pr merge` for Knit-owned bundles. Do not use `knit merge --into main` as a substitute for PR landing unless the user explicitly asks for direct branch integration instead of PR landing.
+Bare `knit land` creates or shows the default plan and stops. It never merges PRs, deploys, waits, or runs plan commands. `knit land apply` executes the plan and lands each recorded PR into its GitHub PR base branch, then executes any generated or edited deployment steps. On full success it archives the bundle and removes generated worktrees under `.knit/worktrees/<bundle>/` while preserving local feature branches and the bundle artifact; pass `--keep-worktrees` to keep those checkouts. When push-sync is enabled, a successful land also syncs the updated bundle artifact to configured sync remotes; use `knit sync push --bundles` to push the landed artifact later. Project JSON can define a default `landing` template with merge priority and deployments, while `.knit/land-plans/<bundle>.land.json` remains the editable per-bundle plan. A PR with no required checks has passed Knit’s required-check gate. Do not use `gh pr merge` for Knit-owned bundles. Do not use `knit merge --into main` as a substitute for PR landing unless the user explicitly asks for direct branch integration instead of PR landing.
 
 After a landed bundle's main state has been verified (deploy, CI, QA — whatever the user trusts), record it as a cross-repo known-good marker. Landing archives the bundle, so pass `--bundle` explicitly:
 
@@ -629,12 +629,12 @@ knit cherrypick --from feature-a --repo backend abc123
 - `knit bundle remove <repo>...` removes repos from the current bundle and tears down their worktrees (`--keep-worktree` to only untrack, `--delete-branch` to also drop the feature branch, `--force` to discard dirty/unpushed work).
 - `knit bundle apply-view <name>` reshapes the current bundle to match a saved view.
 - `knit view save <name> [--include <repo>]... [--exclude <repo>]...` saves a per-user bundle shape; `knit view default <name>` makes it the default for new bundles.
-- `knit view list`, `knit view show [name] [--repos]`, `knit view edit`, `knit view rm <name>` manage saved views; `knit sync push --views`/`knit sync pull --views` sync them to KnitHub.
+- `knit view list`, `knit view show [name] [--repos]`, `knit view edit`, `knit view rm <name>` manage saved views; `knit sync push --views`/`knit sync pull --views` sync them to the sync remotes.
 - `knit cherrypick --from <bundle> <selector>...` cherry-picks selected source bundle commits into the resolved bundle.
 - `knit bundle path` prints the resolved bundle file.
 - `knit bundle validate` checks the bundle artifact.
 - `knit bundle list` shows workspace bundles.
-- `knit bundle archive <bundle> [--reason "merged"]` marks a bundle done: it records an archive node and removes generated worktrees while preserving local feature branches (`--keep-worktrees` to leave them, `--force` to discard dirty checkouts). With push-sync remotes configured, archive and restore also push the updated artifact so KnitHub dashboards flip lifecycle state together with the local ledger.
+- `knit bundle archive <bundle> [--reason "merged"]` marks a bundle done: it records an archive node and removes generated worktrees while preserving local feature branches (`--keep-worktrees` to leave them, `--force` to discard dirty checkouts). With push-sync remotes configured, archive and restore also push the updated artifact so hosted dashboards flip lifecycle state together with the local ledger.
 - `knit bundle restore <bundle>` reopens an archived bundle; run `knit bundle worktree` afterwards to rematerialize checkouts.
 - `knit bundle delete <bundle> --force` moves the bundle artifact to `.knit/deleted/bundles/` and preserves git state.
 - `knit bundle delete <bundle> --force --worktrees --branches --force-branches` discards generated worktrees and local feature branches for that bundle.
@@ -642,8 +642,8 @@ knit cherrypick --from feature-a --repo backend abc123
 - `knit bundle prune` refreshes GitHub PR states and lists clean dead-work bundles with no recorded open PRs. Landed and archived bundle artifacts are kept as history unless `--archived` is passed.
 - `knit bundle prune --no-refresh` performs the same scan using cached recorded PR states only.
 - `knit bundle prune --apply --worktrees --branches` is the short form for deleting dead bundle artifacts and their generated local state.
-- `knit bundle prune --apply --all` removes dead bundle artifacts, generated and orphaned worktrees, local feature branches, and matching `origin` branches, and archives matching KnitHub remote bundle records.
-- Remote bundle cleanup uses the configured KnitHub sync remote. Orphaned remote records are archived (never deleted) with the everyday `bundle:push` scope; true remote deletion stays per-bundle via `knit bundle delete --remote-bundles` and a `bundle:delete` token.
+- `knit bundle prune --apply --all` removes dead bundle artifacts, generated and orphaned worktrees, local feature branches, and matching `origin` branches, and archives matching remote bundle records.
+- Remote bundle cleanup uses the configured sync remote. Orphaned remote records are archived (never deleted) with the everyday `bundle:push` scope; true remote deletion stays per-bundle via `knit bundle delete --remote-bundles` and a `bundle:delete` token.
 - `knit switch <bundle> --workspace` changes the shared workspace fallback bundle (the `--workspace` flag is required so the change is deliberate).
 - `knit project remove <project> --force` removes a reusable project template artifact.
 - `knit run <project-command>` runs a configured command inside the resolved bundle checkout.
@@ -662,14 +662,14 @@ knit cherrypick --from feature-a --repo backend abc123
 - `knit migrate --check` reports additive JSON migrations; `knit migrate` applies them.
 - `knit config set advice false` disables sparse `Next:` advice.
 - `knit config set auto-tag true` makes a successful `knit land apply` record a cross-repo known-good tag automatically.
-- `knit config set sync-remotes hosted` makes push-sync upload bundle artifacts to your configured KnitHub remote.
+- `knit config set sync-remotes hosted` makes push-sync upload bundle artifacts to your configured sync remote.
 - `knit show HEAD` explains the latest bundle ledger entry.
 - `knit sync` records Git commits made outside Knit (local reconcile, no network).
-- `knit sync push [--bundles|--history|--views|--all] [--remote <name>]...` is the one verb family for moving artifacts to KnitHub; with no target flag it pushes bundle, history, and views. Bundle push is project-wide: every local bundle artifact — open, landed, archived — is swept so remote lifecycle state converges on the local ledger.
-- `knit sync pull [--bundles|--history|--views|--all] [--remote <name>]...` pulls those same artifacts from KnitHub. Bundle pull is project-wide: open bundles created on other machines (and their recorded PRs) are localized into `.knit/bundles/`, and stale local artifacts fast-forward whatever their state; materialize checkouts for a discovered bundle with `knit --bundle <slug> bundle worktree`.
-- `knit pull --merge` union-merges the bundle ledger when the local and KnitHub artifacts have diverged (two users recorded work concurrently); diverged feature branches still need a git merge in the worktree afterwards.
+- `knit sync push [--bundles|--history|--views|--all] [--remote <name>]...` is the one verb family for moving artifacts to the sync remotes; with no target flag it pushes bundle, history, and views. Bundle push is project-wide: every local bundle artifact — open, landed, archived — is swept so remote lifecycle state converges on the local ledger.
+- `knit sync pull [--bundles|--history|--views|--all] [--remote <name>]...` pulls those same artifacts from the sync remotes. Bundle pull is project-wide: open bundles created on other machines (and their recorded PRs) are localized into `.knit/bundles/`, and stale local artifacts fast-forward whatever their state; materialize checkouts for a discovered bundle with `knit --bundle <slug> bundle worktree`.
+- `knit pull --merge` union-merges the bundle ledger when the local and remote artifacts have diverged (two users recorded work concurrently); diverged feature branches still need a git merge in the worktree afterwards.
 - `knit push --set-upstream` pushes every tracked feature branch in the resolved bundle to `origin` and sets upstream tracking.
-- `knit push --remote hosted` pushes the resolved bundle's branches and artifact to the configured KnitHub remote so it is visible in hosted dashboards.
+- `knit push --remote hosted` pushes the resolved bundle's branches and artifact to the configured sync remote so it is visible in hosted dashboards.
 - `knit git --all status --short` runs Git across tracked checkouts.
 - `knit clean --archived --worktrees` removes generated worktrees left behind by bundles archived with `--keep-worktrees`.
 

--- a/src/commands/land/update.rs
+++ b/src/commands/land/update.rs
@@ -97,7 +97,7 @@ pub(super) fn run_branch_update(
         push_update_targets(&targets, set_upstream)?;
         refresh_update_publications(&mut active, &targets)?;
         save_active_bundle(&active)?;
-        // Mirror the pushed feature branches into the KnitHub remote bundle
+        // Mirror the pushed feature branches into the sync remote bundle
         // (default on; see `knit config set push-sync`).
         crate::commands::remote::maybe_sync_bundle_to_remote(&[], false)?;
     }

--- a/src/commands/publish/mod.rs
+++ b/src/commands/publish/mod.rs
@@ -129,7 +129,7 @@ pub fn create_publications(
         );
     }
 
-    // Sync the bundle artifact to the configured KnitHub remote alongside the
+    // Sync the bundle artifact to the configured sync remote alongside the
     // host review objects (default on; see `knit config set push-sync`).
     crate::commands::remote::maybe_sync_bundle_to_remote(remote, no_remote)?;
 

--- a/src/commands/pull.rs
+++ b/src/commands/pull.rs
@@ -265,7 +265,7 @@ fn print_pull_summary(repo_id: &str, before: &str, after: &str) {
 /// Entry point for `knit pull`. Decides what to update from context and flags:
 /// - `--main` / `--bundles` (or both) run the aggregate, best-effort report.
 /// - With no target flags: inside a resolved bundle, pull that bundle's feature
-///   worktrees plus its KnitHub artifact; at the workspace base (the shared
+///   worktrees plus its remote artifact; at the workspace base (the shared
 ///   fallback) pull everything (project main repos + every open bundle).
 #[allow(clippy::too_many_arguments)]
 pub fn pull(
@@ -294,7 +294,7 @@ pub fn pull(
         }
     }
 
-    // A specific bundle is in context: pull its repos (and its KnitHub artifact).
+    // A specific bundle is in context: pull its repos (and its remote artifact).
     pull_repos(selectors, all, rebase, force, feature)?;
     pull_remote_state(remote, no_remote, merge)
 }
@@ -482,7 +482,7 @@ fn pull_one_bundle(
     materialize: bool,
 ) -> Outcome {
     let Some(context) = context else {
-        return Outcome::Skipped("no KnitHub remote configured".to_string());
+        return Outcome::Skipped("no sync remote available".to_string());
     };
     match pull_bundle_remote_state(root, context, bundle_id, merge, materialize) {
         Ok(RemoteBundleOutcome::Pulled(hash)) => Outcome::Synced(hash),

--- a/src/commands/push.rs
+++ b/src/commands/push.rs
@@ -68,7 +68,7 @@ pub fn push_repos(
     }
 
     // After git branches are pushed, also sync the bundle artifact to the
-    // configured KnitHub remote (default on; see `knit config set push-sync`).
+    // configured sync remote (default on; see `knit config set push-sync`).
     crate::commands::remote::maybe_sync_bundle_to_remote(remote, no_remote)?;
 
     Ok(())

--- a/src/commands/remote/client.rs
+++ b/src/commands/remote/client.rs
@@ -1,4 +1,4 @@
-//! KnitHub HTTP client: native HTTP request transport, remote/token/config
+//! Sync remote HTTP client: native HTTP request transport, remote/token/config
 //! resolution, project-export fetching, and localizing remote bundles onto the
 //! local project's repos.
 
@@ -55,16 +55,15 @@ pub(super) fn resolve_project_id(
 
 pub(super) fn resolve_remote<'a>(config: &'a KnitConfig, name: &str) -> Result<&'a KnitRemote> {
     let remote_name = slugify(name);
-    config
-        .remotes
-        .get(&remote_name)
-        .with_context(|| format!("No KnitHub remote named `{remote_name}`. Run `knit remote add {remote_name} <url>` first."))
+    config.remotes.get(&remote_name).with_context(|| {
+        format!("No remote named `{remote_name}`. Run `knit remote add {remote_name} <url>` first.")
+    })
 }
 
 pub(super) fn resolve_token(name: &str, remote: &KnitRemote) -> Result<String> {
     token_from_env(&slugify(name))
         .or_else(|| remote.token.clone())
-        .context("No KnitHub token configured. Set KNIT_REMOTE_<NAME>_TOKEN, KNIT_REMOTE_TOKEN, or `knit remote token <name> <token>`.")
+        .context("No remote token configured. Set KNIT_REMOTE_<NAME>_TOKEN, KNIT_REMOTE_TOKEN, or `knit remote token <name> <token>`.")
 }
 
 pub(super) fn token_from_env(name: &str) -> Option<String> {
@@ -87,10 +86,10 @@ pub(super) fn token_from_env(name: &str) -> Option<String> {
         .filter(|value| !value.trim().is_empty())
 }
 
-/// Return configured KnitHub sync remotes in priority order. `syncRemotes` is the
-/// multi-target form; `syncRemote` remains the legacy single-target form. If a
-/// config has exactly one remote and no explicit sync remote, that sole remote
-/// is the sync remote by convention.
+/// Return the sync remotes in priority order. By default the remotes list
+/// itself is the sync set: every configured remote participates, names carry no
+/// special meaning. An explicit `syncRemotes` (or legacy `syncRemote`) narrows
+/// that set for configs that want some remotes excluded from routine sync.
 pub fn configured_sync_remote_names(config: &KnitConfig) -> Vec<String> {
     let mut names = Vec::new();
     if !config.sync_remotes.is_empty() {
@@ -103,12 +102,51 @@ pub fn configured_sync_remote_names(config: &KnitConfig) -> Vec<String> {
             push_unique_remote_name(&mut names, name);
         }
     }
-    if names.is_empty() && config.remotes.len() == 1 {
-        if let Some(name) = config.remotes.keys().next() {
+    if names.is_empty() {
+        for name in config.remotes.keys() {
             push_unique_remote_name(&mut names, name);
         }
     }
     names
+}
+
+/// Run `attempt` against each configured sync remote in priority order and
+/// return the first success. An unreachable remote is reported and skipped; the
+/// last candidate's error (or an explicit override's error) propagates, so the
+/// call only fails when no remote could serve it. Read paths (pull, fetch,
+/// history) use this; push paths fan out over every remote instead.
+pub(super) fn with_first_available_remote<T>(
+    config: &KnitConfig,
+    remote_override: Option<&str>,
+    attempt: impl Fn(&str, &KnitRemote, &str) -> Result<T>,
+) -> Result<T> {
+    let candidates: Vec<String> = match remote_override {
+        Some(name) => vec![slugify(name)],
+        None => configured_sync_remote_names(config),
+    };
+    if candidates.is_empty() {
+        bail!("No sync remote configured. Run `knit remote add <name> <url>` first.");
+    }
+    let explicit = remote_override.is_some();
+    let last = candidates.len() - 1;
+    for (index, remote_name) in candidates.iter().enumerate() {
+        let result = resolve_remote(config, remote_name)
+            .and_then(|remote| Ok((remote, resolve_token(remote_name, remote)?)))
+            .and_then(|(remote, token)| attempt(remote_name, remote, &token));
+        match result {
+            Ok(value) => return Ok(value),
+            Err(error) => {
+                if explicit || index == last {
+                    return Err(error);
+                }
+                println!(
+                    "{} {error:#}",
+                    crate::output::warn(format!("remote {remote_name} unavailable, trying next:"))
+                );
+            }
+        }
+    }
+    unreachable!("candidates checked non-empty above")
 }
 
 pub(super) fn explicit_remote_names(remote_overrides: &[String]) -> Vec<String> {
@@ -137,11 +175,12 @@ fn push_unique_remote_name(names: &mut Vec<String>, name: &str) {
     }
 }
 
-/// Resolve the primary KnitHub sync remote, preferring `syncRemotes[0]`, then
-/// legacy `syncRemote`, then the sole configured remote.
+/// Resolve the primary sync remote: the first name `configured_sync_remote_names`
+/// returns. Callers that can address only one remote (per-record deletes,
+/// archive-by-id) use this; fan-out callers iterate the full list instead.
 pub(super) fn resolve_sync_remote_name(config: &KnitConfig) -> Result<String> {
     configured_sync_remote_names(config).into_iter().next().context(
-        "No KnitHub sync remote configured. Run `knit remote add <name> <url>`, `knit config set sync-remote <name>`, or use explicit prune flags instead of --all.",
+        "No sync remote configured. Run `knit remote add <name> <url>`, `knit config set sync-remote <name>`, or use explicit prune flags instead of --all.",
     )
 }
 
@@ -173,7 +212,7 @@ pub(super) fn fetch_project_export(
 /// Split an `owner/slug` clone reference into its parts. A bare identifier (no
 /// `/`) resolves by slug alone, preserving the historical behavior used by
 /// local project ids. Each segment is slugified so it is URL-safe and matches
-/// how KnitHub stores usernames, org slugs, and project slugs.
+/// how the hosted server stores usernames, org slugs, and project slugs.
 pub(super) fn split_project_identifier(identifier: &str) -> (Option<String>, String) {
     match identifier.split_once('/') {
         Some((owner, slug)) if !owner.trim().is_empty() && !slug.trim().is_empty() => {
@@ -404,13 +443,13 @@ pub(super) fn request_json<T: DeserializeOwned>(
 pub(super) fn decode_response<T: DeserializeOwned>(response: HttpResponse) -> Result<T> {
     if !(200..300).contains(&response.status) {
         bail!(
-            "KnitHub remote returned HTTP {}: {}",
+            "Sync remote returned HTTP {}: {}",
             response.status,
             response.body.trim()
         );
     }
     let envelope: ApiEnvelope<T> =
-        serde_json::from_str(&response.body).context("failed to parse KnitHub response")?;
+        serde_json::from_str(&response.body).context("failed to parse remote response")?;
     Ok(envelope.data)
 }
 
@@ -443,13 +482,13 @@ pub(super) fn request(
         // as an HttpResponse so callers keep their status-based error paths.
         Err(ureq::Error::Status(_, response)) => response,
         Err(ureq::Error::Transport(transport)) => {
-            bail!("KnitHub request failed for {url}: {transport}")
+            bail!("Remote request failed for {url}: {transport}")
         }
     };
     let status = response.status();
     let body = response
         .into_string()
-        .context("failed to read KnitHub response body")?;
+        .context("failed to read remote response body")?;
     Ok(HttpResponse { status, body })
 }
 

--- a/src/commands/remote/clone.rs
+++ b/src/commands/remote/clone.rs
@@ -1,4 +1,4 @@
-//! `knit clone` — import a KnitHub project export into a fresh local workspace:
+//! `knit clone` — import a remote project export into a fresh local workspace:
 //! clone its repositories, write the project and bundle artifacts, and
 //! optionally materialize the active bundle.
 
@@ -180,7 +180,7 @@ fn resolve_remote_for_clone(
         .as_ref()
         .and_then(|config| configured_sync_remote_names(config).into_iter().next());
     let remote_name = requested_name.or(configured_name).with_context(|| {
-        "No KnitHub remote selected. Pass `--remote <name>` with `--url <url>`, or configure a sync remote first."
+        "No remote selected. Pass `--remote <name>` with `--url <url>`, or configure a sync remote first."
     })?;
     let configured = config
         .as_ref()
@@ -195,7 +195,7 @@ fn resolve_remote_for_clone(
         .or(env_url)
         .or_else(|| configured.as_ref().map(|remote| remote.url.clone()))
         .with_context(|| {
-            format!("No KnitHub URL configured for remote `{remote_name}`. Pass --url, set KNIT_REMOTE_URL, or run `knit remote add {remote_name} <url>`.")
+            format!("No URL configured for remote `{remote_name}`. Pass --url, set KNIT_REMOTE_URL, or run `knit remote add {remote_name} <url>`.")
         })?;
     let stored_token = token
         .map(ToString::to_string)
@@ -208,7 +208,7 @@ fn resolve_remote_for_clone(
         .map(ToString::to_string)
         .or_else(|| token_from_env(&remote_name))
         .or_else(|| remote.token.clone())
-        .context("No KnitHub token configured. Set KNIT_REMOTE_<NAME>_TOKEN or KNIT_REMOTE_TOKEN, pass --token, or configure a stored remote token.")?;
+        .context("No remote token configured. Set KNIT_REMOTE_<NAME>_TOKEN or KNIT_REMOTE_TOKEN, pass --token, or configure a stored remote token.")?;
 
     Ok((remote_name, remote, stored_token, resolved_token))
 }

--- a/src/commands/remote/facade.rs
+++ b/src/commands/remote/facade.rs
@@ -1,4 +1,4 @@
-//! The single internal entry point for explicit artifact sync with KnitHub.
+//! The single internal entry point for explicit artifact sync with the configured remotes.
 //!
 //! `knit sync push` / `knit sync pull` (and the git-shaped `knit push --remote`,
 //! `knit fetch --knit`, `knit pull --remote`, plus landing's automatic sync) all
@@ -75,13 +75,13 @@ fn resolve_remotes(remote_overrides: &[String]) -> Result<Vec<String>> {
     let remotes = resolve_sync_remote_names(&config, remote_overrides);
     if remotes.is_empty() {
         bail!(
-            "No KnitHub remote configured. Run `knit remote add --global <name> <url>`, `knit remote add <name> <url>`, or `knit config set sync-remotes <name>[,<name>...]` first."
+            "No sync remote configured. Run `knit remote add --global <name> <url>`, `knit remote add <name> <url>`, or `knit config set sync-remotes <name>[,<name>...]` first."
         );
     }
     Ok(remotes)
 }
 
-/// Push selected artifact families to KnitHub for the resolved project/bundle.
+/// Push selected artifact families to the sync remotes for the resolved project/bundle.
 ///
 /// `knit sync push` and `knit sync push --bundles/--history/--views` route here,
 /// as does `knit push --remote` (bundles only). Failures across remotes are
@@ -150,7 +150,7 @@ pub fn sync_push(targets: SyncTargets, remote_overrides: &[String]) -> Result<()
     finish(failures, "push")
 }
 
-/// Pull selected artifact families from KnitHub for the resolved project/bundle.
+/// Pull selected artifact families from the sync remotes for the resolved project/bundle.
 ///
 /// `knit sync pull` and `knit sync pull --bundles/--history/--views` route here,
 /// as does `knit pull --remote`/`knit fetch --knit` (bundles only). Bundle pull
@@ -214,7 +214,7 @@ fn finish(failures: Vec<String>, verb: &str) -> Result<()> {
         Ok(())
     } else {
         bail!(
-            "KnitHub {verb} failed for {} target(s):\n{}",
+            "Sync {verb} failed for {} target(s):\n{}",
             failures.len(),
             failures.join("\n")
         )

--- a/src/commands/remote/history.rs
+++ b/src/commands/remote/history.rs
@@ -2,7 +2,7 @@
 
 use super::client::{
     effective_workspace_config, load_project_if_present, request_json, resolve_project_id,
-    resolve_remote, resolve_sync_remote_name, resolve_token,
+    resolve_remote, resolve_token, with_first_available_remote,
 };
 use crate::history::{append_history_events, load_history_events, refresh_project_history};
 use crate::model::{HistoryEvent, KnitRemote};
@@ -53,13 +53,9 @@ pub fn push_history_to_remote(project: Option<&str>, remote_name: &str) -> Resul
 pub fn pull_history_from_remote(project: Option<&str>, remote_name: Option<&str>) -> Result<()> {
     let (root, config) = effective_workspace_config()?;
     let project_id = resolve_project_id(&root, &config, project)?;
-    let remote_name = match remote_name {
-        Some(remote_name) => crate::ids::slugify(remote_name),
-        None => resolve_sync_remote_name(&config)?,
-    };
-    let remote = resolve_remote(&config, &remote_name)?;
-    let token = resolve_token(&remote_name, remote)?;
-    let events = fetch_project_history_events(remote, &token, &project_id)?;
+    let events = with_first_available_remote(&config, remote_name, |_, remote, token| {
+        fetch_project_history_events(remote, token, &project_id)
+    })?;
     let appended = append_history_events(&root, &project_id, &events)?;
     println!(
         "{} {} {}",

--- a/src/commands/remote/mod.rs
+++ b/src/commands/remote/mod.rs
@@ -1,9 +1,9 @@
-//! `knit remote` and KnitHub sync. This root holds the shared remote response
+//! `knit remote` and sync-remote transport. This root holds the shared remote response
 //! DTOs; the work is split across submodules:
 //!
 //! - [`client`] HTTP transport, remote/token resolution, and bundle localization
 //! - [`push`] remote config CRUD plus pushing projects/bundles and sync-on-push
-//! - [`clone`] cloning a KnitHub project export into a fresh workspace
+//! - [`clone`] cloning a remote project export into a fresh workspace
 //! - [`pull`] pulling/fetching recorded bundle state and remote bundle cleanup
 //! - [`history`] project history event sync
 

--- a/src/commands/remote/pull.rs
+++ b/src/commands/remote/pull.rs
@@ -1,4 +1,4 @@
-//! Pull recorded bundle state from a KnitHub remote (one bundle or workspace
+//! Pull recorded bundle state from a sync remote (one bundle or workspace
 //! wide), list/fetch remote bundles, and delete remote bundle records.
 
 use super::client::{
@@ -6,6 +6,7 @@ use super::client::{
     ensure_remote_bundle_fast_forward, fast_forward_feature_checkouts, fetch_project_export,
     load_project_if_present, localize_bundle, prepare_feature_branches, request_json,
     resolve_project_id, resolve_remote, resolve_sync_remote_name, resolve_token,
+    with_first_available_remote,
 };
 use super::clone::{
     clone_export_repositories, export_repo_local_id, project_repo_entry_from_export,
@@ -27,7 +28,7 @@ use std::collections::BTreeSet;
 use std::fs;
 use std::path::Path;
 
-/// Pull the current user's saved views for a project from the KnitHub remote,
+/// Pull the current user's saved views for a project from the sync remote,
 /// replacing the local views artifact.
 pub fn pull_views_from_remote(name: Option<&str>, remote_name: &str) -> Result<()> {
     let (root, config) = effective_workspace_config()?;
@@ -88,7 +89,7 @@ pub enum RemoteBundleOutcome {
     Skipped(String),
 }
 
-/// A bundle as it exists on the configured KnitHub sync remote, with its current
+/// A bundle as it exists on the configured sync remote, with its current
 /// artifact payload decoded into a `ChangeGroup` when one is present.
 pub struct RemoteBundleRecord {
     pub remote_id: String,
@@ -97,11 +98,14 @@ pub struct RemoteBundleRecord {
     pub payload: Option<ChangeGroup>,
 }
 
-/// Resolve the configured KnitHub remote and fetch the project export a single
-/// time. Returns `None` when the pull opts out (`--no-remote`) or no remote is
-/// configured, so callers can skip the artifact step without it being an error.
-/// Remote resolution matches the primary push-sync remote: explicit override,
-/// then `syncRemotes[0]`/`sync_remote`, then the sole configured remote.
+/// Resolve a sync remote and fetch the project export a single time. Returns
+/// `None` when the pull opts out (`--no-remote`), no remote is configured, or
+/// no configured remote is reachable, so callers can skip the artifact step
+/// without it being an error — the git side of a pull never depends on a
+/// remote answering. Implicit resolution walks the configured sync remotes in
+/// order and uses the first one that responds; each unreachable remote is
+/// reported and skipped. An explicit `--remote` override still fails hard,
+/// because the caller named exactly the remote they wanted.
 pub fn prepare_remote_pull(
     remote_override: Option<&str>,
     skip_remote: bool,
@@ -110,38 +114,50 @@ pub fn prepare_remote_pull(
         return Ok(None);
     }
     let (root, config) = effective_workspace_config()?;
-    let Some(remote_name) = remote_override
-        .map(crate::ids::slugify)
-        .or_else(|| configured_sync_remote_names(&config).into_iter().next())
-    else {
+    let candidates: Vec<String> = match remote_override {
+        Some(name) => vec![crate::ids::slugify(name)],
+        None => configured_sync_remote_names(&config),
+    };
+    if candidates.is_empty() {
         return Ok(None);
-    };
-    let remote = match resolve_remote(&config, &remote_name) {
-        Ok(remote) => remote,
-        Err(error) => {
-            // An explicitly requested remote that is missing is an error; an
-            // implicit fallback that is missing is simply skipped.
-            if remote_override.is_some() {
-                return Err(error);
-            }
-            return Ok(None);
-        }
-    };
-    let token = resolve_token(&remote_name, remote)?;
+    }
+    let explicit = remote_override.is_some();
     let project_id = config
         .active_project
         .clone()
         .context("No active project selected for remote pull. Run `knit init <name>`.")?;
     let mut project = load_project_if_present(&root, &project_id)?
         .with_context(|| format!("No local Knit project named `{project_id}`."))?;
-    let export = fetch_project_export(remote, &token, &project_id)?;
-    crate::history::append_history_events(&root, &project_id, &export.history_events)?;
-    reconcile_project_repositories(&root, &mut project, &export)?;
-    Ok(Some(RemotePullContext { project, export }))
+    for remote_name in candidates {
+        let attempt = resolve_remote(&config, &remote_name)
+            .and_then(|remote| Ok((remote, resolve_token(&remote_name, remote)?)))
+            .and_then(|(remote, token)| fetch_project_export(remote, &token, &project_id));
+        match attempt {
+            Ok(export) => {
+                crate::history::append_history_events(&root, &project_id, &export.history_events)?;
+                reconcile_project_repositories(&root, &mut project, &export)?;
+                return Ok(Some(RemotePullContext { project, export }));
+            }
+            Err(error) => {
+                if explicit {
+                    return Err(error);
+                }
+                println!(
+                    "{} {error:#}",
+                    out::warn(format!("remote {remote_name} unavailable, skipping:"))
+                );
+            }
+        }
+    }
+    println!(
+        "{}",
+        out::warn("No sync remote reachable; continuing without remote sync.")
+    );
+    Ok(None)
 }
 
 /// Reconcile the local project's tracked repositories with the remote export so
-/// that repositories added or removed on KnitHub flow into an existing
+/// that repositories added or removed on the remote flow into an existing
 /// workspace, not just a fresh `knit clone`. Removals drop the project repo
 /// entry (the checkout on disk is left in place); additions clone the repo into
 /// the workspace and record it. A degenerate export with no repositories is
@@ -478,7 +494,7 @@ pub fn pull_remote_state(remote_name: Option<&str>, skip_remote: bool, merge: bo
         ),
         RemoteBundleOutcome::Skipped(reason) => println!(
             "{} {}",
-            out::warn("KnitHub pull skipped:"),
+            out::warn("remote pull skipped:"),
             out::muted(reason)
         ),
     }
@@ -495,17 +511,26 @@ pub fn remote_bundle_lifecycle(
     project_id: &str,
     bundle_id: &str,
 ) -> Result<Option<String>> {
-    let Some(remote_name) = configured_sync_remote_names(config).into_iter().next() else {
-        return Ok(None);
-    };
-    let remote = resolve_remote(config, &remote_name)?;
-    let token = resolve_token(&remote_name, remote)?;
-    let export = fetch_project_export(remote, &token, project_id)?;
-    Ok(export
-        .bundles
-        .into_iter()
-        .find(|bundle| bundle.slug == bundle_id && bundle.lifecycle_state != "deleted")
-        .map(|bundle| bundle.lifecycle_state))
+    let mut last_error: Option<anyhow::Error> = None;
+    for remote_name in configured_sync_remote_names(config) {
+        let attempt = resolve_remote(config, &remote_name)
+            .and_then(|remote| Ok((remote, resolve_token(&remote_name, remote)?)))
+            .and_then(|(remote, token)| fetch_project_export(remote, &token, project_id));
+        match attempt {
+            Ok(export) => {
+                return Ok(export
+                    .bundles
+                    .into_iter()
+                    .find(|bundle| bundle.slug == bundle_id && bundle.lifecycle_state != "deleted")
+                    .map(|bundle| bundle.lifecycle_state));
+            }
+            Err(error) => last_error = Some(error),
+        }
+    }
+    match last_error {
+        Some(error) => Err(error),
+        None => Ok(None),
+    }
 }
 
 /// List the bundle records the sync remote holds for `project_id`, decoding each
@@ -514,10 +539,9 @@ pub fn list_remote_bundles(
     config: &KnitConfig,
     project_id: &str,
 ) -> Result<Vec<RemoteBundleRecord>> {
-    let remote_name = resolve_sync_remote_name(config)?;
-    let remote = resolve_remote(config, &remote_name)?;
-    let token = resolve_token(&remote_name, remote)?;
-    let export = fetch_project_export(remote, &token, project_id)?;
+    let export = with_first_available_remote(config, None, |_, remote, token| {
+        fetch_project_export(remote, token, project_id)
+    })?;
     Ok(export
         .bundles
         .into_iter()
@@ -538,7 +562,7 @@ pub fn list_remote_bundles(
 
 /// Delete a single bundle record from the sync remote by its remote id, returning the
 /// deleted bundle's slug.
-/// Archive a KnitHub bundle record in place. Used by prune's remote-orphan
+/// Archive a remote bundle record in place. Used by prune's remote-orphan
 /// cleanup: a record whose local artifact is gone is finished history, not
 /// noise, so the remote keeps it (hidden from active views) instead of
 /// tombstoning it. Rides the everyday `bundle:push` scope.
@@ -616,21 +640,18 @@ pub fn fetch_bundles_from_remote(
     config: &KnitConfig,
     remote_name: Option<&str>,
 ) -> Result<()> {
-    let remote_name = remote_name
-        .map(crate::ids::slugify)
-        .or_else(|| configured_sync_remote_names(config).into_iter().next())
-        .with_context(|| {
-            "No remote configured for bundle fetch. Configure a remote with `knit remote add` or set sync-remotes."
-        })?;
-    let remote = resolve_remote(config, &remote_name)?;
-    let token = resolve_token(&remote_name, remote)?;
-
     let project_id = config
         .active_project
         .clone()
         .context("Bundle fetch requires active_project. Set with `knit init <name>`.")?;
 
-    let export = fetch_project_export(remote, &token, &project_id)?;
+    let (remote_name, export) =
+        with_first_available_remote(config, remote_name, |name, remote, token| {
+            Ok((
+                name.to_string(),
+                fetch_project_export(remote, token, &project_id)?,
+            ))
+        })?;
     crate::history::append_history_events(root, &project_id, &export.history_events)?;
 
     let Some(local_project) = load_project_if_present(root, &project_id)? else {

--- a/src/commands/remote/push.rs
+++ b/src/commands/remote/push.rs
@@ -1,12 +1,11 @@
 //! Remote configuration commands (add/list/show/remove/token) and pushing the
-//! local project and bundle artifact to a KnitHub remote, including the implicit
+//! local project and bundle artifact to a sync remote, including the implicit
 //! sync-on-push.
 
 use super::client::{
     configured_sync_remote_names, decode_response, effective_workspace_config,
     load_project_if_present, normalize_base_url, request, request_json, resolve_project_id,
-    resolve_remote, resolve_sync_remote_name, resolve_sync_remote_names, resolve_token,
-    token_from_env, workspace_config,
+    resolve_remote, resolve_sync_remote_names, resolve_token, token_from_env, workspace_config,
 };
 use super::{RemoteArtifact, RemoteBundle, RemoteProject};
 use crate::ids::slugify;
@@ -74,7 +73,7 @@ fn warn_workspace_scoped_token(remote_name: &str) {
 pub fn list_remotes(global: bool) -> Result<()> {
     let (config, sources) = remote_listing(global)?;
     if config.remotes.is_empty() {
-        println!("{}", out::muted("No KnitHub remotes configured."));
+        println!("{}", out::muted("No remotes configured."));
         return Ok(());
     }
 
@@ -113,7 +112,7 @@ pub fn show_remote(name: &str, global: bool) -> Result<()> {
     let remote = config
         .remotes
         .get(&remote_name)
-        .with_context(|| format!("No KnitHub remote named `{remote_name}`."))?;
+        .with_context(|| format!("No remote named `{remote_name}`."))?;
     let sync_remotes = configured_sync_remote_names(&config);
     println!("{} {}", out::heading("Remote:"), out::repo(&remote_name));
     println!("{} {}", out::heading("URL:"), remote.url);
@@ -157,7 +156,7 @@ pub fn remove_remote(name: &str, global: bool) -> Result<()> {
     };
     let remote_name = slugify(name);
     if config.remotes.remove(&remote_name).is_none() {
-        bail!("No KnitHub remote named `{remote_name}`.");
+        bail!("No remote named `{remote_name}`.");
     }
     config
         .sync_remotes
@@ -197,7 +196,7 @@ pub fn set_remote_token(name: &str, token: Option<&str>, clear: bool, global: bo
     let remote = config
         .remotes
         .get_mut(&remote_name)
-        .with_context(|| format!("No KnitHub remote named `{remote_name}`."))?;
+        .with_context(|| format!("No remote named `{remote_name}`."))?;
 
     if clear {
         remote.token = None;
@@ -222,15 +221,50 @@ pub fn set_remote_token(name: &str, token: Option<&str>, clear: bool, global: bo
 pub fn push_project_to_remote(name: Option<&str>, remote_name: Option<&str>) -> Result<()> {
     let (root, config) = effective_workspace_config()?;
     let project_id = resolve_project_id(&root, &config, name)?;
-    let remote_name = match remote_name {
-        Some(remote_name) => slugify(remote_name),
-        None => resolve_sync_remote_name(&config)?,
+    let remote_names = match remote_name {
+        Some(remote_name) => vec![slugify(remote_name)],
+        None => configured_sync_remote_names(&config),
     };
-    let remote = resolve_remote(&config, &remote_name)?;
-    let token = resolve_token(&remote_name, remote)?;
+    if remote_names.is_empty() {
+        bail!("No sync remote configured. Run `knit remote add <name> <url>` first.");
+    }
     let project = load_project_if_present(&root, &project_id)?;
-    let pushed = upsert_project(remote, &token, &project_id, project.as_ref())?;
-    let repo_count = match project.as_ref() {
+    let multiple = remote_names.len() > 1;
+    let mut failures = Vec::new();
+    for remote_name in &remote_names {
+        if multiple {
+            println!("{} {}", out::heading("Remote:"), out::repo(remote_name));
+        }
+        if let Err(error) =
+            push_project_to_one_remote(&config, remote_name, &root, &project_id, project.as_ref())
+        {
+            println!(
+                "{} {error:#}",
+                out::warn(format!("push failed ({remote_name}):"))
+            );
+            failures.push(remote_name.clone());
+        }
+    }
+    if failures.len() == remote_names.len() {
+        bail!(
+            "project push failed for every remote: {}",
+            failures.join(", ")
+        );
+    }
+    Ok(())
+}
+
+fn push_project_to_one_remote(
+    config: &KnitConfig,
+    remote_name: &str,
+    root: &Path,
+    project_id: &str,
+    project: Option<&KnitProject>,
+) -> Result<()> {
+    let remote = resolve_remote(config, remote_name)?;
+    let token = resolve_token(remote_name, remote)?;
+    let pushed = upsert_project(remote, &token, project_id, project)?;
+    let repo_count = match project {
         Some(project) => push_repositories(remote, &token, &pushed.slug, &project.repos)?,
         None => 0,
     };
@@ -245,7 +279,7 @@ pub fn push_project_to_remote(name: Option<&str>, remote_name: Option<&str>) -> 
 
     // Best-effort: also upload the user's saved views for this project. A server
     // without the views endpoint must not fail the project push.
-    if let Err(error) = upload_views(remote, &token, &root, &pushed.slug) {
+    if let Err(error) = upload_views(remote, &token, root, &pushed.slug) {
         println!("{} {error:#}", out::warn("views not synced:"));
     }
     Ok(())
@@ -271,7 +305,7 @@ fn upload_views(remote: &KnitRemote, token: &str, root: &Path, project_slug: &st
     Ok(())
 }
 
-/// Push the current user's saved views for a project to the KnitHub remote.
+/// Push the current user's saved views for a project to the sync remote.
 pub fn push_views_to_remote(name: Option<&str>, remote_name: &str) -> Result<()> {
     let (root, config) = effective_workspace_config()?;
     let project_id = resolve_project_id(&root, &config, name)?;
@@ -299,7 +333,7 @@ pub fn push_views_to_remote(name: Option<&str>, remote_name: &str) -> Result<()>
 }
 
 /// Push the project architecture artifact (repo-level rollup produced by
-/// `urdir kg architecture`) to a KnitHub remote. Reads the conventional
+/// `urdir kg architecture`) to a sync remote. Reads the conventional
 /// `.urdir/kg/<slug>/architecture.json`; a missing file is a soft skip with a
 /// hint, not an error, so `knit sync push` (everything) stays safe.
 pub fn push_architecture_to_remote(name: Option<&str>, remote_name: &str) -> Result<()> {
@@ -347,7 +381,7 @@ pub fn push_architecture_to_remote(name: Option<&str>, remote_name: &str) -> Res
 }
 
 /// Push the knowledge-graph viz slice (produced by `urdir kg viz`) to a
-/// KnitHub remote. Reads `.urdir/kg/<slug>/viz.json`; missing file is a soft
+/// sync remote. Reads `.urdir/kg/<slug>/viz.json`; missing file is a soft
 /// skip with a hint.
 pub fn push_kg_graph_to_remote(name: Option<&str>, remote_name: &str) -> Result<()> {
     let (root, config) = effective_workspace_config()?;
@@ -472,7 +506,7 @@ fn push_active_bundle_to_remote(
     Ok(())
 }
 
-/// Push the resolved bundle artifact to configured KnitHub remote(s) alongside a
+/// Push the resolved bundle artifact to configured sync remote(s) alongside a
 /// git push, when enabled.
 ///
 /// Resolution order for remotes: repeated explicit `--remote`, then
@@ -507,7 +541,7 @@ pub fn maybe_sync_bundle_to_remote(remote_overrides: &[String], no_remote: bool)
             }
             println!(
                 "{} {error:#}",
-                out::warn(format!("KnitHub sync skipped ({remote_name}):"))
+                out::warn(format!("remote sync skipped ({remote_name}):"))
             );
             continue;
         }
@@ -517,14 +551,14 @@ pub fn maybe_sync_bundle_to_remote(remote_overrides: &[String], no_remote: bool)
         if let Err(error) = push_bundle_to_remote(&remote_name, None) {
             println!(
                 "{} {error:#}",
-                out::warn(format!("KnitHub sync skipped ({remote_name}):"))
+                out::warn(format!("remote sync skipped ({remote_name}):"))
             );
         }
     }
     Ok(())
 }
 
-/// Push the resolved bundle artifact to KnitHub when push-sync is enabled.
+/// Push the resolved bundle artifact to the sync remotes when push-sync is enabled.
 ///
 /// Unlike `maybe_sync_bundle_to_remote`, sync failures are returned to the
 /// caller. This is used after landing so a stale remote lifecycle state is
@@ -589,7 +623,7 @@ fn sync_bundle_to_remote_names(config: &KnitConfig, remote_names: &[String]) -> 
         Ok(())
     } else {
         bail!(
-            "KnitHub sync failed for {} remote(s):\n{}",
+            "Sync failed for {} remote(s):\n{}",
             failures.len(),
             failures.join("\n")
         )
@@ -619,7 +653,7 @@ fn sync_active_bundle_to_remote_names(
         Ok(())
     } else {
         bail!(
-            "KnitHub sync failed for {} remote(s):\n{}",
+            "Sync failed for {} remote(s):\n{}",
             failures.len(),
             failures.join("\n")
         )
@@ -738,14 +772,14 @@ fn push_bundle_artifact(
     match push_bundle_artifact_outcome(remote, token, bundle_id, bundle)? {
         ArtifactPushOutcome::Pushed(artifact) => Ok(artifact),
         ArtifactPushOutcome::RemoteAhead => bail!(
-            "{}: the KnitHub remote has recorded bundle work this workspace does not include. Run `knit pull` to fast-forward (or `knit pull --merge` if the ledgers diverged), then push again.",
+            "{}: the remote has recorded bundle work this workspace does not include. Run `knit pull` to fast-forward (or `knit pull --merge` if the ledgers diverged), then push again.",
             bundle.id
         ),
     }
 }
 
 /// Push every local bundle artifact — open, landed, and archived alike — to a
-/// KnitHub remote so the remote's lifecycle state converges on the local
+/// sync remote so the remote's lifecycle state converges on the local
 /// ledger. Bundles whose remote ledger is ahead of this workspace are skipped
 /// with a warning (catching up is `knit sync pull`'s job); other per-bundle
 /// failures are collected and fail the sweep at the end.

--- a/src/commands/tag.rs
+++ b/src/commands/tag.rs
@@ -77,7 +77,7 @@ pub fn create_tag(
 /// The create/resume entry point for an already-resolved, write-locked bundle.
 /// `knit tag` loads the bundle then calls this; `knit land apply` reuses it to
 /// tag the state it just landed without re-resolving the archived bundle.
-/// `remote`/`no_remote` control the KnitHub artifact sync after a push, so a
+/// `remote`/`no_remote` control the remote artifact sync after a push, so a
 /// land run's explicit `--no-remote` carries into its tag.
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn create_tag_on_active(

--- a/src/history.rs
+++ b/src/history.rs
@@ -270,7 +270,7 @@ fn history_event(
         occurred_at: Some(occurred_at.to_string()),
         recorded_at: now_iso(),
         recorded_by: "knit".to_string(),
-        // The node title travels with the event so consumers (KnitHub) can
+        // The node title travels with the event so consumers (hosted dashboards) can
         // name titled nodes — a tag's name, a check's name — without parsing
         // the message text.
         metadata: title.map(|title| serde_json::json!({ "title": title })),

--- a/src/model/config.rs
+++ b/src/model/config.rs
@@ -25,7 +25,7 @@ pub struct KnitConfig {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub auto_tag: Option<bool>,
     /// When true (default), git-pushing commands also push the bundle artifact to
-    /// the configured KnitHub remote. Set false to never sync on push.
+    /// the configured sync remote. Set false to never sync on push.
     #[serde(default = "default_push_sync")]
     pub push_sync: bool,
     #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]

--- a/src/model/view.rs
+++ b/src/model/view.rs
@@ -2,7 +2,7 @@
 //! include/exclude deltas on top of the project's `includeByDefault` repo set.
 //!
 //! Views are user-local config, stored at `.knit/views/<project-id>.views.json`
-//! and synced to KnitHub as the user's own configuration. They never live inside
+//! and synced to the sync remotes as the user's own configuration. They never live inside
 //! the shared project artifact.
 
 use super::SCHEMA_VERSION;

--- a/tests/bundle.rs
+++ b/tests/bundle.rs
@@ -313,7 +313,7 @@ fn bundle_creation_refuses_slug_taken_on_sync_remote() {
     let env = [("KNIT_REMOTE_TOKEN", "test-token")];
 
     let refused = knit_fails_with_env(&workspace, ["bundle", "payment flow"], &env);
-    assert!(refused.contains("already exists on the KnitHub sync remote"));
+    assert!(refused.contains("already exists on the sync remote"));
     assert!(!workspace
         .join(".knit/bundles/payment-flow.bundle.json")
         .exists());

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -308,6 +308,22 @@ pub fn isolated_knit_home() -> String {
         .to_string()
 }
 
+/// Ambient identity overrides (exported by editor/agent harnesses such as a
+/// T3 Code session) would silently override the per-repo `git config` identity
+/// every fixture sets and inject actor attribution, breaking actor/author
+/// assertions. Test-provided env is applied after, so a test can still set any
+/// of these deliberately.
+fn scrub_ambient_git_identity(command: &mut Command) {
+    command
+        .env_remove("GIT_AUTHOR_NAME")
+        .env_remove("GIT_AUTHOR_EMAIL")
+        .env_remove("GIT_COMMITTER_NAME")
+        .env_remove("GIT_COMMITTER_EMAIL")
+        .env_remove("T3_ACTOR_SESSION")
+        .env_remove("T3_ACTOR_LABEL")
+        .env_remove("T3_ACTOR_EMAIL");
+}
+
 // KNIT_BUNDLE and KNIT_SESSION are removed everywhere: the test process may
 // itself run inside a knit bundle / agent session (dogfooding), and inherited
 // bundle targeting or ledger attribution would break hermetic assertions.
@@ -324,6 +340,7 @@ where
         .env("KNIT_HOME", isolated_knit_home())
         .env_remove("KNIT_BUNDLE")
         .env_remove("KNIT_SESSION");
+    scrub_ambient_git_identity(&mut command);
     run(command)
 }
 
@@ -339,6 +356,7 @@ where
         .env("KNIT_HOME", isolated_knit_home())
         .env_remove("KNIT_BUNDLE")
         .env_remove("KNIT_SESSION");
+    scrub_ambient_git_identity(&mut command);
     // Test-provided env wins, so a test can still point KNIT_HOME at its own dir.
     for (key, value) in env {
         command.env(key, value);
@@ -358,6 +376,7 @@ where
         .env("KNIT_HOME", isolated_knit_home())
         .env_remove("KNIT_BUNDLE")
         .env_remove("KNIT_SESSION");
+    scrub_ambient_git_identity(&mut command);
     let output = command.output().unwrap();
     assert!(!output.status.success());
     format!(
@@ -379,6 +398,7 @@ where
         .env("KNIT_HOME", isolated_knit_home())
         .env_remove("KNIT_BUNDLE")
         .env_remove("KNIT_SESSION");
+    scrub_ambient_git_identity(&mut command);
     for (key, value) in env {
         command.env(key, value);
     }
@@ -424,6 +444,7 @@ where
         .env_remove("KNIT_SESSION")
         .env("PATH", path)
         .env("GH_FAKE_DIR", fake_gh_dir);
+    scrub_ambient_git_identity(&mut command);
     for (key, value) in env {
         command.env(key, value);
     }
@@ -468,6 +489,7 @@ where
         .env_remove("KNIT_SESSION")
         .env("PATH", path)
         .env("GH_FAKE_DIR", fake_gh_dir);
+    scrub_ambient_git_identity(&mut command);
     for (key, value) in env {
         command.env(key, value);
     }
@@ -487,6 +509,7 @@ where
 {
     let mut command = Command::new("git");
     command.args(args).current_dir(cwd);
+    scrub_ambient_git_identity(&mut command);
     run(command)
 }
 
@@ -497,6 +520,7 @@ where
 {
     let mut command = Command::new("git");
     command.args(args).current_dir(cwd);
+    scrub_ambient_git_identity(&mut command);
     command.stdout(Stdio::null()).stderr(Stdio::null());
     command.status().unwrap().success()
 }
@@ -982,6 +1006,15 @@ fn handle_fake_github_request(stream: &mut std::net::TcpStream, dir: &Path) -> s
     )?;
     stream.flush()
 }
+/// Reserve a local port and immediately release it, yielding a base URL that
+/// refuses connections — an unreachable sync remote for resilience tests.
+pub fn unreachable_remote_url() -> String {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    let base_url = format!("http://{}", listener.local_addr().unwrap());
+    drop(listener);
+    base_url
+}
+
 /// Spawn a minimal fake KnitHub API that answers every request with a project
 /// export containing a single bundle record. Enough for creation-time slug
 /// collision checks against the sync remote.

--- a/tests/config.rs
+++ b/tests/config.rs
@@ -174,15 +174,15 @@ fn clone_resolves_url_and_token_from_global_config_outside_a_workspace() {
     // The fix: clone must consult the global config outside a workspace, so it
     // never reports a missing URL or token; it should reach the network step.
     assert!(
-        !output.contains("No KnitHub URL configured"),
+        !output.contains("No URL configured"),
         "global URL should be used outside a workspace: {output}"
     );
     assert!(
-        !output.contains("No KnitHub token configured"),
+        !output.contains("No remote token configured"),
         "global token should be used outside a workspace: {output}"
     );
     assert!(
-        output.contains("KnitHub request failed"),
+        output.contains("Remote request failed"),
         "clone should fail at the request step, not resolution: {output}"
     );
 
@@ -227,10 +227,7 @@ fn config_can_target_multiple_knithub_sync_remotes() {
     assert_eq!(list.matches("sync").count(), 2, "{list}");
 
     let missing = knit_fails(&workspace, ["config", "set", "sync-remotes", "missing"]);
-    assert!(
-        missing.contains("No KnitHub remote named `missing`"),
-        "{missing}"
-    );
+    assert!(missing.contains("No remote named `missing`"), "{missing}");
 
     knit(&workspace, ["remote", "remove", "local"]);
     let config: Value =
@@ -280,6 +277,35 @@ fn workspace_scoped_tokens_warn_about_shared_config() {
         &env,
     );
     assert!(!global_store.contains("warning:"));
+
+    fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
+fn every_configured_remote_is_a_sync_remote_by_default() {
+    let root = unique_temp_dir();
+    let workspace = root.join("workspace");
+    fs::create_dir_all(&workspace).unwrap();
+
+    knit(&workspace, ["bundle", "default sync set"]);
+    knit(
+        &workspace,
+        ["remote", "add", "alpha", "http://localhost:4000"],
+    );
+    knit(
+        &workspace,
+        ["remote", "add", "beta", "https://beta.example.invalid"],
+    );
+
+    // No sync-remotes config: the remotes list itself is the sync set.
+    let list = knit(&workspace, ["remote", "list"]);
+    assert!(!list.contains("not sync"), "{list}");
+    assert_eq!(list.matches("sync").count(), 2, "{list}");
+
+    // An explicit sync-remotes narrows the set.
+    knit(&workspace, ["config", "set", "sync-remotes", "beta"]);
+    let list = knit(&workspace, ["remote", "list"]);
+    assert!(list.contains("not sync"), "{list}");
 
     fs::remove_dir_all(root).unwrap();
 }

--- a/tests/land.rs
+++ b/tests/land.rs
@@ -235,7 +235,7 @@ fn land_plan_and_apply_merges_recorded_publications_with_fake_gh() {
         &workspace,
         ["--bundle", "venue-capacity", "sync", "push", "--bundles"],
     );
-    assert!(sync_error.contains("No KnitHub remote configured"));
+    assert!(sync_error.contains("No sync remote configured"));
 
     let revert_plan = knit_with_fake_gh(
         &workspace,

--- a/tests/project.rs
+++ b/tests/project.rs
@@ -24,7 +24,7 @@ fn init_can_generate_agents_tutorial() {
     assert!(agents.contains("knit bundle prune --apply --worktrees --branches"));
     assert!(agents.contains("knit bundle prune --apply --all"));
     assert!(agents.contains("--remote-branches"));
-    assert!(agents.contains("matching KnitHub remote bundle records"));
+    assert!(agents.contains("matching remote bundle records"));
     assert!(agents.contains("archived (never deleted) with the everyday `bundle:push` scope"));
     assert!(agents.contains("knit project remove <project> --force"));
     assert!(agents.contains("knit --bundle feature-a commit"));

--- a/tests/sync.rs
+++ b/tests/sync.rs
@@ -135,7 +135,7 @@ fn pull_bundles_without_remote_reports_each_bundle_skipped() {
     assert!(report.contains("Bundles:"));
     assert!(report.contains("feature-one"));
     assert!(report.contains("feature-two"));
-    assert!(report.contains("no KnitHub remote configured"));
+    assert!(report.contains("no sync remote available"));
     // --bundles alone does not touch project main repos.
     assert!(!report.contains("Main repos:"));
 
@@ -261,7 +261,7 @@ fn push_skips_missing_implicit_knithub_remote_after_git_branch_push() {
 
     let push = knit(&workspace, ["push", "backend"]);
     assert!(push.contains("backend"), "{push}");
-    assert!(push.contains("KnitHub sync skipped (svartal):"), "{push}");
+    assert!(push.contains("remote sync skipped (svartal):"), "{push}");
     assert_eq!(
         git(&remote, ["rev-parse", "refs/heads/knit/stale-remote"]),
         sha
@@ -1079,6 +1079,132 @@ fn sync_push_bundles_sweeps_open_and_archived_artifacts() {
     assert_eq!(alpha.lines().last(), Some("open"), "{alpha}");
     let beta = fs::read_to_string(fake_dir.join("artifact-beta-work.states")).unwrap();
     assert_eq!(beta.lines().last(), Some("archived"), "{beta}");
+
+    fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
+fn pull_walks_sync_remotes_past_unreachable_one() {
+    let root = unique_temp_dir();
+    let backend = root.join("backend");
+    let workspace = root.join("workspace");
+    fs::create_dir_all(&workspace).unwrap();
+    init_repo(&backend, "backend");
+
+    knit(&workspace, ["init", "demo"]);
+    knit(
+        &workspace,
+        ["project", "add", "backend", backend.to_str().unwrap()],
+    );
+    knit(&workspace, ["bundle", "feature one", "--repo", "backend"]);
+
+    // With no sync-remotes config, every configured remote is a sync remote.
+    // `dead` sorts first and refuses connections; `live` serves a valid export.
+    let dead_url = unreachable_remote_url();
+    let live_url = spawn_fake_knithub_with_body(
+        "{\"data\":{\"project\":{\"slug\":\"demo\"},\"knitProject\":null,\"repositories\":[],\"bundles\":[],\"historyEvents\":[]}}".to_string(),
+    );
+    knit(&workspace, ["remote", "add", "dead", &dead_url]);
+    knit(&workspace, ["remote", "add", "live", &live_url]);
+    let env = [("KNIT_REMOTE_TOKEN", "test-token")];
+
+    let report = knit_with_env(&workspace, ["pull", "--main", "--bundles"], &env);
+    assert!(report.contains("remote dead unavailable"), "{report}");
+    assert!(report.contains("Main repos:"), "{report}");
+    assert!(report.contains("feature-one"), "{report}");
+
+    fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
+fn pull_continues_when_every_sync_remote_is_unreachable() {
+    let root = unique_temp_dir();
+    let backend = root.join("backend");
+    let workspace = root.join("workspace");
+    fs::create_dir_all(&workspace).unwrap();
+    init_repo(&backend, "backend");
+
+    knit(&workspace, ["init", "demo"]);
+    knit(
+        &workspace,
+        ["project", "add", "backend", backend.to_str().unwrap()],
+    );
+    knit(&workspace, ["bundle", "feature one", "--repo", "backend"]);
+    knit(
+        &workspace,
+        ["remote", "add", "dead", &unreachable_remote_url()],
+    );
+    let env = [("KNIT_REMOTE_TOKEN", "test-token")];
+
+    // The offline remote is reported, and the git side still runs.
+    let report = knit_with_env(&workspace, ["pull", "--main", "--bundles"], &env);
+    assert!(report.contains("No sync remote reachable"), "{report}");
+    assert!(report.contains("Main repos:"), "{report}");
+    assert!(report.contains("no sync remote available"), "{report}");
+
+    fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
+fn pull_with_explicit_remote_still_fails_hard() {
+    let root = unique_temp_dir();
+    let backend = root.join("backend");
+    let workspace = root.join("workspace");
+    fs::create_dir_all(&workspace).unwrap();
+    init_repo(&backend, "backend");
+
+    knit(&workspace, ["init", "demo"]);
+    knit(
+        &workspace,
+        ["project", "add", "backend", backend.to_str().unwrap()],
+    );
+    knit(&workspace, ["bundle", "feature one", "--repo", "backend"]);
+    knit(
+        &workspace,
+        ["remote", "add", "dead", &unreachable_remote_url()],
+    );
+    let env = [("KNIT_REMOTE_TOKEN", "test-token")];
+
+    let failure = knit_fails_with_env(
+        &workspace,
+        ["pull", "--main", "--bundles", "--remote", "dead"],
+        &env,
+    );
+    assert!(failure.contains("Remote request failed"), "{failure}");
+
+    fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
+fn sync_push_fans_out_to_every_configured_remote_by_default() {
+    let root = unique_temp_dir();
+    let backend = root.join("backend");
+    let workspace = root.join("workspace");
+    fs::create_dir_all(&workspace).unwrap();
+    init_repo(&backend, "backend");
+
+    knit(&workspace, ["init", "demo"]);
+    knit(
+        &workspace,
+        ["project", "add", "backend", backend.to_str().unwrap()],
+    );
+    let fake_a = root.join("fake-a");
+    let fake_b = root.join("fake-b");
+    let url_a = spawn_fake_knithub_push_api(&fake_a);
+    let url_b = spawn_fake_knithub_push_api(&fake_b);
+    knit(&workspace, ["remote", "add", "alpha", &url_a]);
+    knit(&workspace, ["remote", "add", "beta", &url_b]);
+    let env = [("KNIT_REMOTE_TOKEN", "test-token")];
+
+    knit(&workspace, ["bundle", "quick fix", "--repo", "backend"]);
+    let output = knit_with_env(&workspace, ["sync", "push", "--bundles"], &env);
+    assert!(output.contains("alpha"), "{output}");
+    assert!(output.contains("beta"), "{output}");
+
+    let alpha = fs::read_to_string(fake_a.join("artifact-quick-fix.states")).unwrap();
+    assert_eq!(alpha.lines().last(), Some("open"), "{alpha}");
+    let beta = fs::read_to_string(fake_b.join("artifact-quick-fix.states")).unwrap();
+    assert_eq!(beta.lines().last(), Some("open"), "{beta}");
 
     fs::remove_dir_all(root).unwrap();
 }


### PR DESCRIPTION
Generated by Knit. Cross-links will be refreshed after all review objects are created.

<!-- BEGIN KNIT BUNDLE -->
## Knit Bundle

This PR is part of Knit bundle `remote-fan-out-and-neutral-naming`.

See the other review objects in this bundle:
- `knit`: https://github.com/marc-merino/knit/pull/123 (this PR)

Bundle id: `remote-fan-out-and-neutral-naming`
Bundle title: Remote fan-out and neutral naming
<!-- END KNIT BUNDLE -->