### PR TITLE
fix history events missing projectId breaking pull (knit)

### DIFF
--- a/src/commands/remote/clone.rs
+++ b/src/commands/remote/clone.rs
@@ -217,8 +217,11 @@ fn clone_fetched_export(
     for bundle in &bundles {
         write_json(&bundle_path(&target_root, &bundle.id), bundle)?;
     }
-    let history_count =
-        crate::history::append_history_events(&target_root, &project.id, &export.history_events)?;
+    let history_count = crate::history::append_history_events(
+        &target_root,
+        &project.id,
+        &export.decoded_history_events(&project.id),
+    )?;
 
     let selected_bundle_id = select_active_bundle(&bundles, active_bundle)?;
     let mut remotes = BTreeMap::new();

--- a/src/commands/remote/history.rs
+++ b/src/commands/remote/history.rs
@@ -94,12 +94,13 @@ pub(super) fn fetch_project_history_events(
     token: &str,
     project_identifier: &str,
 ) -> Result<Vec<HistoryEvent>> {
-    request_json(
+    let raw: Vec<serde_json::Value> = request_json(
         remote,
         token,
         "GET",
         &format!("/projects/{project_identifier}/history-events"),
         None,
     )
-    .with_context(|| format!("failed to fetch history for project `{project_identifier}`"))
+    .with_context(|| format!("failed to fetch history for project `{project_identifier}`"))?;
+    Ok(super::decode_history_events(&raw, project_identifier))
 }

--- a/src/commands/remote/mod.rs
+++ b/src/commands/remote/mod.rs
@@ -84,13 +84,50 @@ struct RemoteProjectExport {
     knit_project: Option<KnitProject>,
     repositories: Vec<RemoteExportRepository>,
     bundles: Vec<RemoteExportBundle>,
+    /// Raw history events, decoded leniently via `decoded_history_events` —
+    /// servers have shipped events without `projectId`, and one malformed
+    /// record must never make the whole export unreadable.
     #[serde(default)]
-    history_events: Vec<HistoryEvent>,
+    history_events: Vec<Value>,
     /// Repos the server withheld from this export (private repos the caller
     /// cannot see). Lets clone/pull say "the export is incomplete for you"
     /// instead of silently presenting a partial project as the whole thing.
     #[serde(default)]
     omitted_repository_count: Option<u64>,
+}
+
+impl RemoteProjectExport {
+    fn decoded_history_events(&self, project_id: &str) -> Vec<HistoryEvent> {
+        decode_history_events(&self.history_events, project_id)
+    }
+}
+
+/// Decode remote history events, tolerating server-side shape drift: a
+/// missing `projectId` is filled from the project context (every history
+/// fetch is project-scoped), and an event that still fails to decode is
+/// skipped with a warning instead of failing the caller.
+fn decode_history_events(raw: &[Value], project_id: &str) -> Vec<HistoryEvent> {
+    let mut events = Vec::with_capacity(raw.len());
+    let mut skipped = 0usize;
+    for value in raw {
+        let mut value = value.clone();
+        if let Value::Object(fields) = &mut value {
+            fields
+                .entry("projectId")
+                .or_insert_with(|| Value::String(project_id.to_string()));
+        }
+        match serde_json::from_value::<HistoryEvent>(value) {
+            Ok(event) => events.push(event),
+            Err(_) => skipped += 1,
+        }
+    }
+    if skipped > 0 {
+        crate::human!(
+            "{} skipped {skipped} unreadable remote history event(s)",
+            crate::output::heading("history:")
+        );
+    }
+    events
 }
 
 #[derive(Debug, Deserialize)]
@@ -185,4 +222,43 @@ struct RemoteExportBundle {
 struct RemoteExportArtifact {
     artifact_hash: String,
     payload: Value,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::decode_history_events;
+    use serde_json::json;
+
+    #[test]
+    fn decode_history_events_fills_missing_project_id_and_skips_garbage() {
+        let raw = vec![
+            json!({
+                "schemaVersion": "knit.history.event.v1",
+                "eventId": "evt-complete",
+                "projectId": "demo",
+                "kind": "bundle.created",
+                "recordedAt": "2026-07-18T15:00:00Z",
+                "recordedBy": "cli",
+            }),
+            // A native server-side event shipped without projectId.
+            json!({
+                "schemaVersion": "knit.history.event.v1",
+                "eventId": "review-decision:abc",
+                "kind": "review.approved",
+                "bundleId": "some-bundle",
+                "recordedAt": "2026-07-18T15:53:42Z",
+                "recordedBy": "native",
+            }),
+            // Unreadable however repaired: skipped, never an error.
+            json!({"eventId": 42}),
+            json!("not an object"),
+        ];
+
+        let events = decode_history_events(&raw, "demo");
+
+        assert_eq!(events.len(), 2);
+        assert_eq!(events[0].event_id, "evt-complete");
+        assert_eq!(events[1].event_id, "review-decision:abc");
+        assert_eq!(events[1].project_id, "demo");
+    }
 }

--- a/src/commands/remote/pull.rs
+++ b/src/commands/remote/pull.rs
@@ -141,7 +141,11 @@ pub fn prepare_remote_pull(
             .and_then(|(remote, token)| fetch_project_export(remote, &token, &project_id));
         match attempt {
             Ok(export) => {
-                crate::history::append_history_events(&root, &project_id, &export.history_events)?;
+                crate::history::append_history_events(
+                    &root,
+                    &project_id,
+                    &export.decoded_history_events(&project_id),
+                )?;
                 reconcile_project_repositories(&root, &mut project, &export)?;
                 return Ok(Some(RemotePullContext { project, export }));
             }
@@ -659,7 +663,11 @@ pub fn fetch_bundles_from_remote(
                 fetch_project_export(remote, token, &project_id)?,
             ))
         })?;
-    crate::history::append_history_events(root, &project_id, &export.history_events)?;
+    crate::history::append_history_events(
+        root,
+        &project_id,
+        &export.decoded_history_events(&project_id),
+    )?;
 
     let Some(local_project) = load_project_if_present(root, &project_id)? else {
         bail!("No local project `{project_id}` found. Cannot localize bundles.");
@@ -856,8 +864,12 @@ fn pull_bundle_by_slug_classified(
             ))
         })
         .map_err(|error| (RemoteErrorKind::Http, error))?;
-    crate::history::append_history_events(&root, &project_id, &export.history_events)
-        .map_err(other)?;
+    crate::history::append_history_events(
+        &root,
+        &project_id,
+        &export.decoded_history_events(&project_id),
+    )
+    .map_err(other)?;
     let local_project = load_project_if_present(&root, &project_id)
         .map_err(other)?
         .with_context(|| format!("No local Knit project named `{project_id}`."))

--- a/tests/clone.rs
+++ b/tests/clone.rs
@@ -514,3 +514,54 @@ fn walk_contains(root: &Path, needle: &str) -> Vec<std::path::PathBuf> {
     }
     hits
 }
+
+#[test]
+fn clone_survives_history_events_missing_project_id() {
+    let root = unique_temp_dir();
+    let (mut export, _source) = partial_export(&root);
+    // A native server-side event without projectId (real production shape)
+    // plus an unreadable one: the clone must succeed, repair the former, and
+    // skip the latter with a warning.
+    export["data"]["historyEvents"] = serde_json::json!([
+        {
+            "schemaVersion": "knit.history.event.v1",
+            "eventId": "review-decision:prod-shape",
+            "kind": "review.approved",
+            "bundleId": "feature-a",
+            "recordedAt": "2026-07-18T15:53:42Z",
+            "recordedBy": "native",
+        },
+        {"eventId": 42},
+    ]);
+    let base_url = spawn_fake_knithub_with_body(export.to_string());
+    let target = root.join("workspace");
+
+    let (_stdout, stderr, success) = knit_split_output(
+        &root,
+        &[
+            "clone",
+            "acme/demo",
+            target.to_str().unwrap(),
+            "--remote",
+            "hosted",
+            "--url",
+            &base_url,
+            "--token",
+            "secret-token",
+            "--no-worktree",
+        ],
+        &[],
+    );
+
+    assert!(success, "{stderr}");
+    // Without --json, human lines (including the skip warning) stay on stdout.
+    assert!(
+        _stdout.contains("skipped 1 unreadable remote history event"),
+        "stdout: {_stdout}\nstderr: {stderr}"
+    );
+    let history = std::fs::read_to_string(target.join(".knit/history/demo.history.jsonl")).unwrap();
+    assert!(history.contains("review-decision:prod-shape"), "{history}");
+    assert!(history.contains("\"projectId\":\"demo\""), "{history}");
+
+    fs::remove_dir_all(root).unwrap();
+}


### PR DESCRIPTION
<!-- BEGIN KNIT BUNDLE -->
## Knit Bundle

This PR is part of Knit bundle `fix-history-events-missing-projectid-breaking-pull`.

See the other review objects in this bundle:
- `knit`: https://github.com/marc-merino/knit/pull/126 (this PR)
- `knithub`: https://github.com/marc-merino/knithub/pull/113

Bundle id: `fix-history-events-missing-projectid-breaking-pull`
Bundle title: fix history events missing projectId breaking pull
<!-- END KNIT BUNDLE -->