### PR TITLE
force push bundle artifacts to sync remote (knit)

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -463,6 +463,13 @@ pub enum SyncCommand {
         /// Named sync remote(s). Repeat for several. Defaults to configured sync remotes.
         #[arg(long, value_name = "REMOTE")]
         remote: Vec<String>,
+        /// Force-push bundle artifacts, overwriting the remote ledger only when it
+        /// still matches the state fetched for the lease. Applies to bundle targets only.
+        #[arg(long)]
+        force_with_lease: bool,
+        /// Force-push bundle artifacts unconditionally. Prefer --force-with-lease.
+        #[arg(long, conflicts_with = "force_with_lease")]
+        force: bool,
     },
     /// Pull artifacts from the sync remotes. With no target flags, pulls bundle, history,
     /// and views for the resolved project/bundle.

--- a/src/commands/land/update.rs
+++ b/src/commands/land/update.rs
@@ -99,7 +99,11 @@ pub(super) fn run_branch_update(
         save_active_bundle(&active)?;
         // Mirror the pushed feature branches into the sync remote bundle
         // (default on; see `knit config set push-sync`).
-        crate::commands::remote::maybe_sync_bundle_to_remote(&[], false)?;
+        crate::commands::remote::maybe_sync_bundle_to_remote(
+            &[],
+            false,
+            crate::commands::push::PushForce::No,
+        )?;
     }
 
     Ok(())

--- a/src/commands/publish/mod.rs
+++ b/src/commands/publish/mod.rs
@@ -131,7 +131,11 @@ pub fn create_publications(
 
     // Sync the bundle artifact to the configured sync remote alongside the
     // host review objects (default on; see `knit config set push-sync`).
-    crate::commands::remote::maybe_sync_bundle_to_remote(remote, no_remote)?;
+    crate::commands::remote::maybe_sync_bundle_to_remote(
+        remote,
+        no_remote,
+        crate::commands::push::PushForce::No,
+    )?;
 
     if !failures.is_empty() {
         bail!(

--- a/src/commands/push.rs
+++ b/src/commands/push.rs
@@ -39,6 +39,20 @@ impl PushForce {
             Self::Unconditional => Some("--force"),
         }
     }
+
+    /// Whether this mode forces at all. Shared by the git plane and the
+    /// bundle-artifact plane: the same flag pair covers both, so one
+    /// `knit push --force-with-lease` moves rewritten branches and the
+    /// rewritten ledger together.
+    pub fn is_force(self) -> bool {
+        !matches!(self, Self::No)
+    }
+
+    /// Whether the force is guarded by a lease: the overwrite must only be
+    /// accepted if the remote still holds the state this client last saw.
+    pub fn wants_lease(self) -> bool {
+        matches!(self, Self::WithLease)
+    }
 }
 
 pub fn push_repos(
@@ -97,7 +111,9 @@ pub fn push_repos(
 
     // After git branches are pushed, also sync the bundle artifact to the
     // configured sync remote (default on; see `knit config set push-sync`).
-    crate::commands::remote::maybe_sync_bundle_to_remote(remote, no_remote)?;
+    // The force mode carries over: a forced branch push implies the ledger
+    // rewrite must be forced onto the sync remote too.
+    crate::commands::remote::maybe_sync_bundle_to_remote(remote, no_remote, force)?;
 
     Ok(())
 }
@@ -178,4 +194,26 @@ fn read_upstream(cwd: &Path) -> Option<String> {
         ["rev-parse", "--abbrev-ref", "--symbolic-full-name", "@{u}"],
     )
     .ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::PushForce;
+
+    #[test]
+    fn from_flags_maps_the_flag_pair() {
+        assert_eq!(PushForce::from_flags(false, false), PushForce::No);
+        assert_eq!(PushForce::from_flags(true, false), PushForce::WithLease);
+        assert_eq!(PushForce::from_flags(false, true), PushForce::Unconditional);
+    }
+
+    #[test]
+    fn force_and_lease_predicates() {
+        assert!(!PushForce::No.is_force());
+        assert!(PushForce::WithLease.is_force());
+        assert!(PushForce::Unconditional.is_force());
+        assert!(PushForce::WithLease.wants_lease());
+        assert!(!PushForce::Unconditional.wants_lease());
+        assert!(!PushForce::No.wants_lease());
+    }
 }

--- a/src/commands/remote/facade.rs
+++ b/src/commands/remote/facade.rs
@@ -16,6 +16,7 @@ use super::push::{
     push_all_bundles_to_remote, push_architecture_to_remote, push_bundle_to_remote,
     push_kg_graph_to_remote, push_views_to_remote,
 };
+use crate::commands::push::PushForce;
 use crate::output as out;
 use anyhow::{bail, Result};
 
@@ -86,7 +87,19 @@ fn resolve_remotes(remote_overrides: &[String]) -> Result<Vec<String>> {
 /// `knit sync push` and `knit sync push --bundles/--history/--views` route here,
 /// as does `knit push --remote` (bundles only). Failures across remotes are
 /// collected so one bad remote does not silently swallow the others.
-pub fn sync_push(targets: SyncTargets, remote_overrides: &[String]) -> Result<()> {
+pub fn sync_push(
+    targets: SyncTargets,
+    remote_overrides: &[String],
+    force: PushForce,
+) -> Result<()> {
+    // Force is an artifact-ledger concept: it overwrites the remote bundle
+    // ledger, nothing else. A selection without a bundle component has no
+    // ledger to force, so passing the flag there is a mistake worth stopping.
+    if force.is_force() && !targets.bundles {
+        bail!(
+            "--force/--force-with-lease apply only to bundle artifacts. Add --bundles to the target selection."
+        );
+    }
     let remotes = resolve_remotes(remote_overrides)?;
     let multiple = remotes.len() > 1;
     let mut failures = Vec::new();
@@ -112,7 +125,7 @@ pub fn sync_push(targets: SyncTargets, remote_overrides: &[String]) -> Result<()
                 .map(|active| active.bundle.id);
             match &active_id {
                 Some(_) => {
-                    if let Err(error) = push_bundle_to_remote(remote, None) {
+                    if let Err(error) = push_bundle_to_remote(remote, None, force) {
                         failures.push(format!("{remote} bundle: {error:#}"));
                     }
                 }
@@ -122,7 +135,9 @@ pub fn sync_push(targets: SyncTargets, remote_overrides: &[String]) -> Result<()
                     }
                 }
             }
-            if let Err(error) = push_all_bundles_to_remote(remote, None, active_id.as_deref()) {
+            if let Err(error) =
+                push_all_bundles_to_remote(remote, None, active_id.as_deref(), force)
+            {
                 failures.push(format!("{remote} bundles: {error:#}"));
             }
         } else if targets.history {

--- a/src/commands/remote/push.rs
+++ b/src/commands/remote/push.rs
@@ -8,6 +8,7 @@ use super::client::{
     resolve_remote, resolve_sync_remote_names, resolve_token, token_from_env, workspace_config,
 };
 use super::{RemoteArtifact, RemoteBundle, RemoteProject};
+use crate::commands::push::PushForce;
 use crate::ids::slugify;
 use crate::model::{ChangeGroup, KnitConfig, KnitProject, KnitRemote, ProjectRepoEntry};
 use crate::output as out;
@@ -444,15 +445,20 @@ fn read_graph_artifact(path: &Path, label: &str, hint: &str) -> Result<Option<Va
     }
 }
 
-pub fn push_bundle_to_remote(remote_name: &str, project: Option<&str>) -> Result<()> {
+pub fn push_bundle_to_remote(
+    remote_name: &str,
+    project: Option<&str>,
+    force: PushForce,
+) -> Result<()> {
     let active = load_active_bundle()?;
-    push_active_bundle_to_remote(remote_name, project, &active)
+    push_active_bundle_to_remote(remote_name, project, &active, force)
 }
 
 fn push_active_bundle_to_remote(
     remote_name: &str,
     project: Option<&str>,
     active: &ActiveBundle,
+    force: PushForce,
 ) -> Result<()> {
     let config = load_effective_config(&active.root)?;
     let project_id = project
@@ -469,7 +475,7 @@ fn push_active_bundle_to_remote(
     }
 
     let pushed_bundle = upsert_bundle(remote, &token, &pushed_project.slug, &active.bundle)?;
-    let artifact = push_bundle_artifact(remote, &token, &pushed_bundle.id, &active.bundle)?;
+    let artifact = push_bundle_artifact(remote, &token, &pushed_bundle.id, &active.bundle, force)?;
     let history_result = super::history::push_project_history_events(
         remote,
         &token,
@@ -480,7 +486,11 @@ fn push_active_bundle_to_remote(
 
     println!(
         "{} {} -> {}",
-        out::movement("pushed"),
+        out::movement(if force.is_force() {
+            "pushed (forced)"
+        } else {
+            "pushed"
+        }),
         out::repo(&active.bundle.id),
         out::repo(&pushed_bundle.slug)
     );
@@ -514,8 +524,14 @@ fn push_active_bundle_to_remote(
 /// With no remote configured this is a silent no-op. The `push_sync` config
 /// disables implicit sync, but explicit `--remote` still forces it. `--no-remote`
 /// always skips. Sync failures are reported as warnings and never fail the git
-/// push that already succeeded.
-pub fn maybe_sync_bundle_to_remote(remote_overrides: &[String], no_remote: bool) -> Result<()> {
+/// push that already succeeded. A forced git push (`knit push --force*`)
+/// carries the same force mode into this artifact sync so branches and ledger
+/// move together.
+pub fn maybe_sync_bundle_to_remote(
+    remote_overrides: &[String],
+    no_remote: bool,
+    force: PushForce,
+) -> Result<()> {
     if no_remote {
         return Ok(());
     }
@@ -548,7 +564,7 @@ pub fn maybe_sync_bundle_to_remote(remote_overrides: &[String], no_remote: bool)
         if multiple {
             println!("{} {}", out::heading("Remote:"), out::repo(&remote_name));
         }
-        if let Err(error) = push_bundle_to_remote(&remote_name, None) {
+        if let Err(error) = push_bundle_to_remote(&remote_name, None, force) {
             println!(
                 "{} {error:#}",
                 out::warn(format!("remote sync skipped ({remote_name}):"))
@@ -615,7 +631,7 @@ fn sync_bundle_to_remote_names(config: &KnitConfig, remote_names: &[String]) -> 
         if multiple {
             println!("{} {}", out::heading("Remote:"), out::repo(remote_name));
         }
-        if let Err(error) = push_bundle_to_remote(remote_name, None) {
+        if let Err(error) = push_bundle_to_remote(remote_name, None, PushForce::No) {
             failures.push(format!("{remote_name}: {error:#}"));
         }
     }
@@ -645,7 +661,7 @@ fn sync_active_bundle_to_remote_names(
         if multiple {
             println!("{} {}", out::heading("Remote:"), out::repo(remote_name));
         }
-        if let Err(error) = push_active_bundle_to_remote(remote_name, None, active) {
+        if let Err(error) = push_active_bundle_to_remote(remote_name, None, active, PushForce::No) {
             failures.push(format!("{remote_name}: {error:#}"));
         }
     }
@@ -732,6 +748,80 @@ fn upsert_bundle(
 enum ArtifactPushOutcome {
     Pushed(RemoteArtifact),
     RemoteAhead,
+    /// A forced-with-lease push was refused: the remote's current artifact no
+    /// longer matches the hash fetched for the lease (someone pushed
+    /// meanwhile). Carries the hash the remote reported as current, when it
+    /// sent one.
+    LeaseMismatch {
+        current: Option<String>,
+    },
+}
+
+/// Add the artifact-plane force fields to a POST body, mirroring the sync
+/// remote's contract: `force: true` alone is an unconditional replace;
+/// `force: true` plus `expectedArtifactHash` is a compare-and-swap against the
+/// remote's current artifact. A lease force with no known remote artifact
+/// sends a plain body: there is nothing to overwrite, so the normal
+/// fast-forward check is the safest gate for that first push.
+fn apply_artifact_force_fields(payload: &mut Value, force: PushForce, lease: Option<&str>) {
+    let Some(fields) = payload.as_object_mut() else {
+        return;
+    };
+    match force {
+        PushForce::No => {}
+        PushForce::Unconditional => {
+            fields.insert("force".to_string(), Value::Bool(true));
+        }
+        PushForce::WithLease => {
+            if let Some(lease) = lease {
+                fields.insert("force".to_string(), Value::Bool(true));
+                fields.insert(
+                    "expectedArtifactHash".to_string(),
+                    Value::String(lease.to_string()),
+                );
+            }
+        }
+    }
+}
+
+/// Fetch the hash of the remote bundle's current artifact for a force lease.
+/// Uses the per-bundle artifact index, which the server returns newest-first;
+/// the newest record is the current artifact. `None` means the bundle has no
+/// artifact yet.
+fn fetch_current_artifact_hash(
+    remote: &KnitRemote,
+    token: &str,
+    bundle_id: &str,
+) -> Result<Option<String>> {
+    let artifacts: Vec<RemoteArtifact> = request_json(
+        remote,
+        token,
+        "GET",
+        &format!("/bundles/{bundle_id}/artifacts"),
+        None,
+    )?;
+    Ok(artifacts
+        .into_iter()
+        .next()
+        .map(|artifact| artifact.artifact_hash))
+}
+
+/// The error envelope a sync remote sends with a refused artifact push. Only
+/// the `kind` and lease details matter here; unknown shapes decode to `None`s
+/// and fall back to the plain fast-forward interpretation.
+#[derive(Debug, serde::Deserialize)]
+struct RemotePushErrorEnvelope {
+    #[serde(default)]
+    error: Option<RemotePushError>,
+}
+
+#[derive(Debug, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct RemotePushError {
+    #[serde(default)]
+    kind: Option<String>,
+    #[serde(default)]
+    current_artifact_hash: Option<String>,
 }
 
 fn push_bundle_artifact_outcome(
@@ -739,14 +829,21 @@ fn push_bundle_artifact_outcome(
     token: &str,
     bundle_id: &str,
     bundle: &ChangeGroup,
+    force: PushForce,
 ) -> Result<ArtifactPushOutcome> {
-    let payload = json!({
+    let lease = if force.wants_lease() {
+        fetch_current_artifact_hash(remote, token, bundle_id)?
+    } else {
+        None
+    };
+    let mut payload = json!({
         "kind": "bundle",
         "schema_version": bundle.schema_version,
         "producer": "knit",
         "producer_version": env!("CARGO_PKG_VERSION"),
         "payload": bundle
     });
+    apply_artifact_force_fields(&mut payload, force, lease.as_deref());
     let response = request(
         remote,
         token,
@@ -756,11 +853,33 @@ fn push_bundle_artifact_outcome(
     )?;
     // The remote refuses any artifact whose ledger would drop nodes the
     // current remote artifact records: another user (or another machine)
-    // pushed work this workspace has not seen yet.
+    // pushed work this workspace has not seen yet. Under a force lease the
+    // same status instead means the remote artifact changed since the lease
+    // hash was fetched.
     if response.status == 409 {
+        let envelope: RemotePushErrorEnvelope =
+            serde_json::from_str(&response.body).unwrap_or(RemotePushErrorEnvelope { error: None });
+        if let Some(error) = envelope.error {
+            if error.kind.as_deref() == Some("leaseMismatch") {
+                return Ok(ArtifactPushOutcome::LeaseMismatch {
+                    current: error.current_artifact_hash,
+                });
+            }
+        }
         return Ok(ArtifactPushOutcome::RemoteAhead);
     }
     decode_response(response).map(ArtifactPushOutcome::Pushed)
+}
+
+/// The per-bundle failure message for a refused force lease. Kept in one place
+/// so the single push and the sweep report the same thing.
+fn lease_mismatch_message(bundle_id: &str, current: Option<&str>) -> String {
+    let current = current
+        .map(|hash| format!(" (remote artifact is now {hash})"))
+        .unwrap_or_default();
+    format!(
+        "{bundle_id}: remote artifact changed since fetch{current}. Run `knit sync pull --bundles` to see the new state, then force-push again."
+    )
 }
 
 fn push_bundle_artifact(
@@ -768,13 +887,17 @@ fn push_bundle_artifact(
     token: &str,
     bundle_id: &str,
     bundle: &ChangeGroup,
+    force: PushForce,
 ) -> Result<RemoteArtifact> {
-    match push_bundle_artifact_outcome(remote, token, bundle_id, bundle)? {
+    match push_bundle_artifact_outcome(remote, token, bundle_id, bundle, force)? {
         ArtifactPushOutcome::Pushed(artifact) => Ok(artifact),
         ArtifactPushOutcome::RemoteAhead => bail!(
-            "{}: the remote has recorded bundle work this workspace does not include. Run `knit pull` to fast-forward (or `knit pull --merge` if the ledgers diverged), then push again.",
+            "{}: the remote has recorded bundle work this workspace does not include. Run `knit pull` to fast-forward (or `knit pull --merge` if the ledgers diverged), then push again, or overwrite the remote ledger with `knit sync push --bundles --force-with-lease`.",
             bundle.id
         ),
+        ArtifactPushOutcome::LeaseMismatch { current } => {
+            bail!("{}", lease_mismatch_message(&bundle.id, current.as_deref()))
+        }
     }
 }
 
@@ -787,6 +910,7 @@ pub fn push_all_bundles_to_remote(
     remote_name: &str,
     project: Option<&str>,
     exclude_bundle: Option<&str>,
+    force: PushForce,
 ) -> Result<()> {
     let cwd = std::env::current_dir().context("failed to read current directory")?;
     let root = find_knit_root(&cwd).context("No Knit workspace found.")?;
@@ -845,11 +969,23 @@ pub fn push_all_bundles_to_remote(
         };
         let outcome =
             upsert_bundle(remote, &token, &project_slug, &bundle).and_then(|remote_bundle| {
-                push_bundle_artifact_outcome(remote, &token, &remote_bundle.id, &bundle)
+                push_bundle_artifact_outcome(remote, &token, &remote_bundle.id, &bundle, force)
             });
         match outcome {
-            Ok(ArtifactPushOutcome::Pushed(_)) => pushed += 1,
+            Ok(ArtifactPushOutcome::Pushed(_)) => {
+                pushed += 1;
+                if force.is_force() {
+                    println!(
+                        "{} {}",
+                        out::movement("pushed (forced)"),
+                        out::repo(&bundle.id)
+                    );
+                }
+            }
             Ok(ArtifactPushOutcome::RemoteAhead) => remote_ahead.push(bundle.id.clone()),
+            Ok(ArtifactPushOutcome::LeaseMismatch { current }) => {
+                failures.push(lease_mismatch_message(&bundle.id, current.as_deref()));
+            }
             Err(error) => failures.push(format!("{}: {error:#}", bundle.id)),
         }
     }
@@ -857,7 +993,7 @@ pub fn push_all_bundles_to_remote(
     println!("{} {pushed} bundle artifact(s)", out::movement("pushed"));
     if !remote_ahead.is_empty() {
         println!(
-            "{} {}: the remote ledger is ahead; run `knit sync pull --bundles` to fast-forward, then push again",
+            "{} {}: the remote ledger is ahead; run `knit sync pull --bundles` to fast-forward, then push again, or overwrite the remote ledger with `knit sync push --bundles --force-with-lease`",
             out::warn("Skipped"),
             remote_ahead.join(", ")
         );
@@ -1016,4 +1152,58 @@ fn remote_listing(global: bool) -> Result<(KnitConfig, BTreeMap<String, String>)
     let effective = crate::store::merge_effective_config(global_config, workspace_config);
 
     Ok((effective, sources))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{apply_artifact_force_fields, lease_mismatch_message};
+    use crate::commands::push::PushForce;
+    use serde_json::json;
+
+    fn base_payload() -> serde_json::Value {
+        json!({"kind": "bundle", "payload": {}})
+    }
+
+    #[test]
+    fn no_force_leaves_the_payload_untouched() {
+        let mut payload = base_payload();
+        apply_artifact_force_fields(&mut payload, PushForce::No, None);
+        assert!(payload.get("force").is_none());
+        assert!(payload.get("expectedArtifactHash").is_none());
+    }
+
+    #[test]
+    fn unconditional_force_sends_force_without_a_lease() {
+        let mut payload = base_payload();
+        apply_artifact_force_fields(&mut payload, PushForce::Unconditional, None);
+        assert_eq!(payload["force"], json!(true));
+        assert!(payload.get("expectedArtifactHash").is_none());
+    }
+
+    #[test]
+    fn lease_force_sends_force_and_the_fetched_hash() {
+        let mut payload = base_payload();
+        apply_artifact_force_fields(&mut payload, PushForce::WithLease, Some("hash-1"));
+        assert_eq!(payload["force"], json!(true));
+        assert_eq!(payload["expectedArtifactHash"], json!("hash-1"));
+    }
+
+    #[test]
+    fn lease_force_without_a_remote_artifact_sends_a_plain_push() {
+        // Nothing to lease against: the plain fast-forward check is the
+        // safest gate for what is effectively a first push.
+        let mut payload = base_payload();
+        apply_artifact_force_fields(&mut payload, PushForce::WithLease, None);
+        assert!(payload.get("force").is_none());
+        assert!(payload.get("expectedArtifactHash").is_none());
+    }
+
+    #[test]
+    fn lease_mismatch_message_names_the_bundle_and_current_hash() {
+        let message = lease_mismatch_message("feature-a", Some("abc123"));
+        assert!(message.contains("feature-a: remote artifact changed since fetch"));
+        assert!(message.contains("abc123"));
+        let without = lease_mismatch_message("feature-a", None);
+        assert!(without.contains("remote artifact changed since fetch"));
+    }
 }

--- a/src/commands/tag.rs
+++ b/src/commands/tag.rs
@@ -196,7 +196,7 @@ pub(crate) fn create_tag_set_on(
     }
 
     push_tags(&targets, name)?;
-    super::remote::maybe_sync_bundle_to_remote(remote, no_remote)?;
+    super::remote::maybe_sync_bundle_to_remote(remote, no_remote, super::push::PushForce::No)?;
     Ok(())
 }
 
@@ -305,7 +305,7 @@ fn resume_tag_set(
     }
 
     if pushed_any {
-        super::remote::maybe_sync_bundle_to_remote(remote, no_remote)?;
+        super::remote::maybe_sync_bundle_to_remote(remote, no_remote, super::push::PushForce::No)?;
     }
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -530,7 +530,12 @@ pub fn run(cli: Cli) -> Result<()> {
         } => commands::cherrypick_from_bundle(&from_bundle, &targets, &repos, dry_run),
         Commands::Sync { command } => match command {
             None => commands::sync_bundle(),
-            Some(SyncCommand::Push { targets, remote }) => {
+            Some(SyncCommand::Push {
+                targets,
+                remote,
+                force_with_lease,
+                force,
+            }) => {
                 let targets = commands::remote::SyncTargets::resolve(
                     targets.bundles,
                     targets.history,
@@ -539,7 +544,11 @@ pub fn run(cli: Cli) -> Result<()> {
                     targets.kg,
                     targets.all,
                 );
-                commands::remote::sync_push(targets, &remote)
+                commands::remote::sync_push(
+                    targets,
+                    &remote,
+                    PushForce::from_flags(force_with_lease, force),
+                )
             }
             Some(SyncCommand::Pull { targets, remote }) => {
                 let targets = commands::remote::SyncTargets::resolve(

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1077,7 +1077,18 @@ fn respond_with_json(stream: &mut std::net::TcpStream, body: &str) -> std::io::R
 /// Spawn a fake KnitHub push API: enough routes for `knit sync push --bundles`
 /// and the archive/restore lifecycle sync. Every pushed bundle artifact's
 /// payload state is appended to `<dir>/artifact-<slug>.states`, one state per
-/// line, so tests can assert which lifecycle states reached the remote.
+/// line, so tests can assert which lifecycle states reached the remote. The
+/// full POSTed body of each artifact push is appended as one JSON line to
+/// `<dir>/artifact-<slug>.bodies`, so tests can assert the force/lease fields.
+///
+/// Behavior markers in `dir`:
+/// - `current-artifact-hash`: `GET /bundles/:id/artifacts` reports one artifact
+///   with this hash (absent: empty list, i.e. no current artifact)
+/// - `post-current-artifact-hash`: the hash the POST compare-and-swap checks a
+///   supplied `expectedArtifactHash` against (defaults to `current-artifact-hash`;
+///   set both differently to simulate a concurrent push between GET and POST)
+/// - `enforce-fast-forward`: POSTs without `force: true` are refused with a
+///   plain 409, like a remote whose ledger is ahead
 pub fn spawn_fake_knithub_push_api(dir: &Path) -> String {
     let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
     let base_url = format!("http://{}", listener.local_addr().unwrap());
@@ -1185,6 +1196,18 @@ fn handle_fake_knithub_push_request(
                 format!("{{\"data\":{{\"id\":\"rb-{slug}\",\"slug\":\"{slug}\"}}}}"),
             )
         }
+        ("GET", ["api", "v1", "bundles", _, "artifacts"]) => {
+            match fs::read_to_string(dir.join("current-artifact-hash")) {
+                Ok(hash) => (
+                    200,
+                    format!(
+                        "{{\"data\":[{{\"id\":\"art-0\",\"artifactHash\":\"{}\"}}]}}",
+                        hash.trim()
+                    ),
+                ),
+                Err(_) => (200, "{\"data\":[]}".to_string()),
+            }
+        }
         ("POST", ["api", "v1", "bundles", bundle_id, "artifacts"]) => {
             let slug = bundle_id.trim_start_matches("rb-");
             let state = body["payload"]["state"].as_str().unwrap_or("unset");
@@ -1193,10 +1216,45 @@ fn handle_fake_knithub_push_request(
             existing.push_str(state);
             existing.push('\n');
             fs::write(&record, existing).unwrap();
-            (
-                201,
-                "{\"data\":{\"id\":\"art-1\",\"artifactHash\":\"fakehash\"}}".to_string(),
-            )
+            let bodies = dir.join(format!("artifact-{slug}.bodies"));
+            let mut recorded = fs::read_to_string(&bodies).unwrap_or_default();
+            recorded.push_str(&serde_json::to_string(&body).unwrap());
+            recorded.push('\n');
+            fs::write(&bodies, recorded).unwrap();
+
+            let force = body["force"].as_bool().unwrap_or(false);
+            let expected = body["expectedArtifactHash"].as_str();
+            let server_hash = fs::read_to_string(dir.join("post-current-artifact-hash"))
+                .or_else(|_| fs::read_to_string(dir.join("current-artifact-hash")))
+                .ok()
+                .map(|hash| hash.trim().to_string());
+            let accepted =
+                "{\"data\":{\"id\":\"art-1\",\"artifactHash\":\"fakehash\"}}".to_string();
+            if let Some(expected) = expected {
+                // Compare-and-swap: accept only when the lease matches the
+                // hash this server currently holds.
+                if force && server_hash.as_deref() == Some(expected) {
+                    (201, accepted)
+                } else {
+                    let current = server_hash
+                        .map(|hash| format!("\"{hash}\""))
+                        .unwrap_or_else(|| "null".to_string());
+                    (
+                        409,
+                        format!(
+                            "{{\"error\":{{\"kind\":\"leaseMismatch\",\"message\":\"the bundle's current artifact is not the leased one\",\"currentArtifactHash\":{current}}}}}"
+                        ),
+                    )
+                }
+            } else if !force && dir.join("enforce-fast-forward").exists() {
+                (
+                    409,
+                    "{\"error\":{\"kind\":\"conflict\",\"message\":\"artifact is not a fast-forward of the current ledger\"}}"
+                        .to_string(),
+                )
+            } else {
+                (201, accepted)
+            }
         }
         _ => (
             404,

--- a/tests/sync.rs
+++ b/tests/sync.rs
@@ -1267,3 +1267,192 @@ fn sync_push_fans_out_to_every_configured_remote_by_default() {
 
     fs::remove_dir_all(root).unwrap();
 }
+
+/// The last artifact body the fake sync remote received for a bundle slug.
+fn last_artifact_body(dir: &std::path::Path, slug: &str) -> serde_json::Value {
+    let raw = fs::read_to_string(dir.join(format!("artifact-{slug}.bodies"))).unwrap();
+    serde_json::from_str(raw.lines().last().unwrap()).unwrap()
+}
+
+/// Scaffold a workspace with one project repo and a fake sync remote, ready
+/// for artifact force-push tests. Returns (root, workspace, fake_dir).
+fn force_push_scaffold(
+    with_bundles: &[&str],
+) -> (std::path::PathBuf, std::path::PathBuf, std::path::PathBuf) {
+    let root = unique_temp_dir();
+    let backend = root.join("backend");
+    let workspace = root.join("workspace");
+    fs::create_dir_all(&workspace).unwrap();
+    init_repo(&backend, "backend");
+
+    knit(&workspace, ["init", "demo"]);
+    knit(
+        &workspace,
+        ["project", "add", "backend", backend.to_str().unwrap()],
+    );
+    let fake_dir = root.join("fake-knithub");
+    let base_url = spawn_fake_knithub_push_api(&fake_dir);
+    knit(&workspace, ["remote", "add", "hosted", &base_url]);
+    for title in with_bundles {
+        knit(&workspace, ["bundle", title, "--repo", "backend"]);
+    }
+    (root, workspace, fake_dir)
+}
+
+#[test]
+fn sync_push_without_force_hits_409_and_hints_at_force_with_lease() {
+    let (root, workspace, fake_dir) = force_push_scaffold(&["quick fix"]);
+    let env = [("KNIT_REMOTE_TOKEN", "test-token")];
+    fs::write(fake_dir.join("enforce-fast-forward"), "").unwrap();
+
+    let failure = knit_fails_with_env(&workspace, ["sync", "push", "--bundles"], &env);
+    assert!(
+        failure.contains("knit sync push --bundles --force-with-lease"),
+        "{failure}"
+    );
+
+    fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
+fn sync_push_force_overwrites_remote_ledger_unconditionally() {
+    let (root, workspace, fake_dir) = force_push_scaffold(&["quick fix"]);
+    let env = [("KNIT_REMOTE_TOKEN", "test-token")];
+    // A remote whose ledger is ahead refuses every non-forced push.
+    fs::write(fake_dir.join("enforce-fast-forward"), "").unwrap();
+
+    let output = knit_with_env(&workspace, ["sync", "push", "--bundles", "--force"], &env);
+    assert!(output.contains("pushed (forced)"), "{output}");
+
+    let body = last_artifact_body(&fake_dir, "quick-fix");
+    assert_eq!(body["force"], serde_json::json!(true), "{body}");
+    assert!(body.get("expectedArtifactHash").is_none(), "{body}");
+    assert_eq!(body["kind"], serde_json::json!("bundle"), "{body}");
+
+    fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
+fn sync_push_force_with_lease_fetches_hash_and_cas_accepts() {
+    let (root, workspace, fake_dir) = force_push_scaffold(&["quick fix"]);
+    let env = [("KNIT_REMOTE_TOKEN", "test-token")];
+    fs::write(fake_dir.join("enforce-fast-forward"), "").unwrap();
+    fs::write(fake_dir.join("current-artifact-hash"), "lease-hash-1").unwrap();
+
+    let output = knit_with_env(
+        &workspace,
+        ["sync", "push", "--bundles", "--force-with-lease"],
+        &env,
+    );
+    assert!(output.contains("pushed (forced)"), "{output}");
+
+    let body = last_artifact_body(&fake_dir, "quick-fix");
+    assert_eq!(body["force"], serde_json::json!(true), "{body}");
+    assert_eq!(
+        body["expectedArtifactHash"],
+        serde_json::json!("lease-hash-1"),
+        "{body}"
+    );
+
+    fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
+fn sync_push_force_with_lease_mismatch_fails_each_bundle() {
+    // Two open bundles from the workspace root: no active bundle resolves and
+    // the project-wide sweep carries both, so the per-bundle lease failures
+    // are collected instead of aborting the run at the first one.
+    let (root, workspace, fake_dir) = force_push_scaffold(&["alpha work", "beta work"]);
+    let env = [("KNIT_REMOTE_TOKEN", "test-token")];
+    // The GET for the lease sees hash-a; by the time the POST lands the
+    // remote is on hash-b — a concurrent push in the window.
+    fs::write(fake_dir.join("current-artifact-hash"), "hash-a").unwrap();
+    fs::write(fake_dir.join("post-current-artifact-hash"), "hash-b").unwrap();
+
+    let failure = knit_fails_with_env(
+        &workspace,
+        ["sync", "push", "--bundles", "--force-with-lease"],
+        &env,
+    );
+    assert!(
+        failure.contains("alpha-work: remote artifact changed since fetch"),
+        "{failure}"
+    );
+    assert!(
+        failure.contains("beta-work: remote artifact changed since fetch"),
+        "{failure}"
+    );
+    assert!(failure.contains("hash-b"), "{failure}");
+
+    fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
+fn sync_push_force_flags_conflict() {
+    let root = unique_temp_dir();
+    let workspace = root.join("workspace");
+    fs::create_dir_all(&workspace).unwrap();
+
+    let failure = knit_fails(
+        &workspace,
+        ["sync", "push", "--bundles", "--force", "--force-with-lease"],
+    );
+    assert!(failure.contains("cannot be used with"), "{failure}");
+
+    fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
+fn sync_push_force_requires_a_bundle_target() {
+    let (root, workspace, _fake_dir) = force_push_scaffold(&["quick fix"]);
+    let env = [("KNIT_REMOTE_TOKEN", "test-token")];
+
+    let failure = knit_fails_with_env(&workspace, ["sync", "push", "--views", "--force"], &env);
+    assert!(
+        failure.contains("apply only to bundle artifacts"),
+        "{failure}"
+    );
+
+    fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
+fn push_force_with_lease_propagates_into_the_artifact_sync() {
+    let root = unique_temp_dir();
+    let (_backend_remote, backend, _collab) = init_remote_repo(&root, "backend");
+    let workspace = root.join("workspace");
+    fs::create_dir_all(&workspace).unwrap();
+
+    knit(&workspace, ["init", "demo"]);
+    knit(
+        &workspace,
+        ["project", "add", "backend", backend.to_str().unwrap()],
+    );
+    let fake_dir = root.join("fake-knithub");
+    let base_url = spawn_fake_knithub_push_api(&fake_dir);
+    knit(&workspace, ["remote", "add", "hosted", &base_url]);
+    let env = [("KNIT_REMOTE_TOKEN", "test-token")];
+
+    knit(&workspace, ["bundle", "quick fix", "--repo", "backend"]);
+
+    // A plain push sends a plain artifact body: no force fields.
+    knit_with_env(&workspace, ["push", "--set-upstream"], &env);
+    let body = last_artifact_body(&fake_dir, "quick-fix");
+    assert!(body.get("force").is_none(), "{body}");
+    assert!(body.get("expectedArtifactHash").is_none(), "{body}");
+
+    // A forced branch push carries the same force mode into the artifact
+    // sync: lease hash fetched from the sync remote, then compare-and-swap.
+    fs::write(fake_dir.join("current-artifact-hash"), "lease-hash-9").unwrap();
+    let output = knit_with_env(&workspace, ["push", "--force-with-lease"], &env);
+    assert!(output.contains("pushed (forced)"), "{output}");
+    let body = last_artifact_body(&fake_dir, "quick-fix");
+    assert_eq!(body["force"], serde_json::json!(true), "{body}");
+    assert_eq!(
+        body["expectedArtifactHash"],
+        serde_json::json!("lease-hash-9"),
+        "{body}"
+    );
+
+    fs::remove_dir_all(root).unwrap();
+}


### PR DESCRIPTION
<!-- BEGIN KNIT BUNDLE -->
## Knit Bundle

This PR is part of Knit bundle `force-push-bundle-artifacts-to-sync-remote`.

See the other review objects in this bundle:
- `knit`: https://github.com/marc-merino/knit/pull/127 (this PR)
- `knithub`: https://github.com/marc-merino/knithub/pull/114

Bundle id: `force-push-bundle-artifacts-to-sync-remote`
Bundle title: force push bundle artifacts to sync remote
<!-- END KNIT BUNDLE -->