### PR TITLE
archive remote bundle records on local delete (knit)

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -414,7 +414,7 @@ knit bundle restore feature-x                    # reopen; `knit bundle worktree
 
 Archiving refuses to discard dirty generated worktrees unless `--force` is passed.
 
-`knit bundle delete <bundle> --force` moves the bundle JSON artifact to `.knit/deleted/bundles/` and clears the active bundle if needed. By default it preserves git state. Add `--worktrees` to remove Knit-generated worktrees for that bundle before moving the artifact. Add `--branches` to delete the local `knit/<bundle>` feature branches after those generated worktrees are removed:
+`knit bundle delete <bundle> --force` moves the bundle JSON artifact to `.knit/deleted/bundles/` and clears the active bundle if needed. By default it preserves git state. With push-sync remotes configured, it also archives the bundle's record on each sync remote so hosted dashboards stop counting the deleted work as open; that mirror is best-effort (offline deletes warn and continue) and a later `knit bundle prune --remote-bundles` catches anything it missed. Add `--worktrees` to remove Knit-generated worktrees for that bundle before moving the artifact. Add `--branches` to delete the local `knit/<bundle>` feature branches after those generated worktrees are removed:
 
 ```sh
 knit bundle delete documentation-quick-wins --force
@@ -447,9 +447,9 @@ knit bundle prune --untracked
 knit bundle prune --apply --untracked --worktrees
 ```
 
-Remote bundle cleanup uses the configured sync remote and archives matching remote bundle records — it never deletes them, because a record whose local artifact is gone is often the last remaining trace of shipped work. Archiving rides the everyday `bundle:push` scope. True remote deletion stays a per-bundle decision via `knit bundle delete --remote-bundles`, which requires a `bundle:delete` token.
+Remote bundle cleanup archives matching remote bundle records — it never deletes them, because a record whose local artifact is gone is often the last remaining trace of shipped work. Archiving rides the everyday `bundle:push` scope. True remote deletion stays an explicit decision via `knit bundle prune --apply --remote-bundles`, which requires a `bundle:delete` token.
 
-With `--remote-bundles`, prune also detects **remote orphans**: bundle records that exist on the sync remote but have no local artifact and whose recorded PRs are all merged or closed. Without this, a plain `knit bundle prune --apply` could delete a local artifact while leaving its remote record behind, and no later prune could ever reach it again. These are listed under "Remote orphan bundle candidates" and deleted on `--apply`; their live PR state is refreshed from the host by URL during detection (the synced artifact can be stale), falling back to the recorded state when the lookup fails. Prune is also best-effort: an unreadable bundle file, a failed PR lookup, or an unverifiable checkout is reported as a warning and skipped (the bundle is kept to be safe) instead of aborting the whole scan.
+With `--remote-bundles`, prune also detects **remote orphans**: bundle records that exist on the sync remote but have no local artifact and are dead work — their artifact sits in the local `.knit/deleted/bundles/` quarantine (a locally deleted bundle is dead even with no recorded PRs), or every recorded PR is merged or closed. Without this, a delete that could not reach the remote (offline, or made before delete-time archiving existed) would leave its record behind forever, and no later prune could reach it through the local bundle scan. These are listed under "Remote orphan bundle candidates" and archived on `--apply`; records already archived on the remote are skipped. Live PR state is refreshed from the host by URL during detection (the synced artifact can be stale), falling back to the recorded state when the lookup fails. Prune is also best-effort: an unreadable bundle file, a failed PR lookup, or an unverifiable checkout is reported as a warning and skipped (the bundle is kept to be safe) instead of aborting the whole scan.
 
 So the common cleanup distinction is:
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -431,13 +431,16 @@ knit bundle delete documentation-quick-wins --force --worktrees --branches --for
 ```sh
 knit bundle prune
 knit bundle prune --no-refresh
-knit bundle prune --apply --worktrees --branches
+knit bundle prune --apply
 knit bundle prune --apply --all
+knit bundle prune --apply --delete --worktrees --branches
 ```
 
-Landed and archived bundles are finished work, not dead work: their artifacts are the audit record of what shipped, so prune keeps them (and says how many it kept) unless `--archived` opts them into the scan. `--all` deliberately does not imply `--archived`.
+On `--apply`, dead bundles are **archived, not deleted**: finished work — a bundle whose PRs all merged, even outside `knit land` — becomes history, exactly like `knit bundle archive`. The archive node records why the bundle was dead (for example "recorded PRs are merged"), generated worktrees are removed, local feature branches are preserved, and with push-sync remotes configured the terminal state is pushed so hosted dashboards flip together with the local ledger. This is what keeps the remote from accumulating bundles that read "open" after their work merged. The explicit `--branches`/`--remote-branches` cleanups still apply in either mode. Pass `--delete` to discard the artifacts to `.knit/deleted/bundles/` instead of archiving them.
 
-A bundle whose only uncommitted work is untracked files is otherwise dead work, so prune does not delete it by default; instead it lists it under "Blocked by untracked files". Pass `--untracked` to treat those bundles as dead-work candidates — combine with `--worktrees` (or `--all`) on `--apply` so the untracked files are discarded with the generated checkout. Bundles with tracked, uncommitted changes are still preserved even with `--untracked`.
+Landed and archived bundles are finished work, not dead work: their artifacts are the audit record of what shipped, so prune keeps them (and says how many it kept) unless `--archived` opts them into the scan. `--archived` requires `--delete` because pruning finished bundles discards history artifacts. `--all` deliberately implies neither.
+
+A bundle whose only uncommitted work is untracked files is otherwise dead work, so prune does not touch it by default; instead it lists it under "Blocked by untracked files". Pass `--untracked` to treat those bundles as dead-work candidates — the untracked files are discarded with the generated checkout on `--apply`. Bundles with tracked, uncommitted changes are still preserved even with `--untracked`.
 
 `--report` prints every scanned bundle and why it is prunable or kept (open PRs, merged PRs, tracked changes, or untracked-only files), not just the deletable candidates:
 
@@ -447,7 +450,7 @@ knit bundle prune --untracked
 knit bundle prune --apply --untracked --worktrees
 ```
 
-Remote bundle cleanup archives matching remote bundle records — it never deletes them, because a record whose local artifact is gone is often the last remaining trace of shipped work. Archiving rides the everyday `bundle:push` scope. True remote deletion stays an explicit decision via `knit bundle prune --apply --remote-bundles`, which requires a `bundle:delete` token.
+Remote bundle cleanup archives matching remote bundle records — it never deletes them, because a record whose local artifact is gone is often the last remaining trace of shipped work. Archiving rides the everyday `bundle:push` scope. True remote deletion stays an explicit decision via `knit bundle prune --apply --delete --remote-bundles`, which requires a `bundle:delete` token.
 
 With `--remote-bundles`, prune also detects **remote orphans**: bundle records that exist on the sync remote but have no local artifact and are dead work — their artifact sits in the local `.knit/deleted/bundles/` quarantine (a locally deleted bundle is dead even with no recorded PRs), or every recorded PR is merged or closed. Without this, a delete that could not reach the remote (offline, or made before delete-time archiving existed) would leave its record behind forever, and no later prune could reach it through the local bundle scan. These are listed under "Remote orphan bundle candidates" and archived on `--apply`; records already archived on the remote are skipped. Live PR state is refreshed from the host by URL during detection (the synced artifact can be stale), falling back to the recorded state when the lookup fails. Prune is also best-effort: an unreadable bundle file, a failed PR lookup, or an unverifiable checkout is reported as a warning and skipped (the bundle is kept to be safe) instead of aborting the whole scan.
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -650,11 +650,14 @@ pub enum BundleCommand {
         #[arg(long)]
         deleted: bool,
     },
-    /// Delete dead bundles whose PRs are merged, closed, missing, or absent.
+    /// Archive dead bundles whose PRs are merged, closed, missing, or absent (--delete discards them instead).
     Prune {
         /// Apply pruning after listing candidate bundles.
         #[arg(long)]
         apply: bool,
+        /// Discard dead bundle artifacts to .knit/deleted/bundles/ instead of archiving them as finished history.
+        #[arg(long)]
+        delete: bool,
         /// Refresh recorded PR states from GitHub before deciding. This is the default.
         #[arg(long, conflicts_with = "no_refresh")]
         refresh: bool,
@@ -685,12 +688,12 @@ pub enum BundleCommand {
         /// Delete matching feature branches from origin.
         #[arg(long = "remote-branches", requires = "branches")]
         remote_branches: bool,
-        /// Delete matching remote bundle records.
+        /// Scan the sync remote and archive orphaned bundle records; with --delete, remote records matching pruned bundles are deleted.
         #[arg(long = "remote-bundles")]
         remote_bundles: bool,
-        /// Also prune finished (landed/archived) bundle artifacts. By default
-        /// finished bundles are history and only open dead work is pruned.
-        #[arg(long)]
+        /// Also prune finished (landed/archived) bundle artifacts. Requires
+        /// --delete because it discards history artifacts.
+        #[arg(long, requires = "delete")]
         archived: bool,
     },
     /// Mark a bundle done: archive its artifact and remove generated worktrees, keeping branches.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -712,7 +712,7 @@ pub enum BundleCommand {
         /// Bundle id to restore.
         bundle: String,
     },
-    /// Move a bundle JSON artifact to .knit/deleted/bundles/.
+    /// Move a bundle JSON artifact to .knit/deleted/bundles/ and archive its record on the sync remotes.
     Delete {
         /// Bundle id to delete.
         bundle: String,

--- a/src/commands/bundle/lifecycle.rs
+++ b/src/commands/bundle/lifecycle.rs
@@ -138,6 +138,34 @@ pub fn restore_bundle(bundle_id: &str) -> Result<()> {
     Ok(())
 }
 
+/// Archive a dead bundle found by `prune`: finished or abandoned work becomes
+/// history instead of discarded state. Records the dead reason on the archive
+/// node, removes generated worktrees, honors prune's explicit branch-cleanup
+/// flags, and mirrors the terminal state to the sync remotes through the
+/// archive lifecycle sync.
+pub fn archive_dead_bundle(
+    bundle_id: &str,
+    reason: &str,
+    branches: bool,
+    force_branches: bool,
+    remote_branches: bool,
+) -> Result<()> {
+    archive_bundle(bundle_id, Some(reason), false, true)?;
+    if branches || remote_branches {
+        let root = current_root()?;
+        let bundle_id = crate::ids::slugify(bundle_id);
+        let path = stored_bundle_path(&root, &bundle_id);
+        let bundle = load_existing_bundle(&path, &bundle_id)?;
+        if branches {
+            delete_local_feature_branches(&bundle, force_branches)?;
+        }
+        if remote_branches {
+            delete_remote_feature_branches(&bundle)?;
+        }
+    }
+    Ok(())
+}
+
 pub fn delete_bundle(
     bundle_id: &str,
     force: bool,

--- a/src/commands/bundle/lifecycle.rs
+++ b/src/commands/bundle/lifecycle.rs
@@ -203,7 +203,40 @@ pub fn delete_bundle(
         out::node(&bundle_id),
         out::path(deleted_path.display())
     );
+    if !remote_bundles {
+        archive_remote_record_for_deleted(&root, config, &bundle);
+    }
     Ok(())
+}
+
+/// Mirror a local delete onto the configured sync remotes by archiving the
+/// matching bundle record, so hosted dashboards stop showing deleted work as
+/// open. Best-effort like the archive/restore lifecycle sync: the local delete
+/// already succeeded, so remote failures warn instead of failing the command.
+/// A workspace without push-sync remotes is a silent no-op, and explicit
+/// `--remote-bundles` already deleted the record outright.
+fn archive_remote_record_for_deleted(
+    root: &Path,
+    config: Option<&crate::model::KnitConfig>,
+    bundle: &ChangeGroup,
+) {
+    let loaded_config;
+    let config = match config {
+        Some(config) => config,
+        None => match crate::store::load_effective_config(root) {
+            Ok(config) => {
+                loaded_config = config;
+                &loaded_config
+            }
+            Err(_) => return,
+        },
+    };
+    if !config.push_sync {
+        return;
+    }
+    if let Err(error) = crate::commands::remote::archive_deleted_bundle_on_remotes(config, bundle) {
+        println!("{} {error:#}", out::warn("remote archive skipped:"));
+    }
 }
 
 /// Delete one repo's local feature branch in its original checkout. Uses

--- a/src/commands/bundle/mod.rs
+++ b/src/commands/bundle/mod.rs
@@ -10,7 +10,7 @@ mod validate;
 pub(crate) use lifecycle::{
     archive_active_bundle, clear_workspace_active_if_matches, delete_repo_feature_branch,
 };
-pub use lifecycle::{archive_bundle, delete_bundle, restore_bundle};
+pub use lifecycle::{archive_bundle, archive_dead_bundle, delete_bundle, restore_bundle};
 pub use prune::prune_merged_bundles;
 
 use crate::model::{BundleState, ChangeGroup};

--- a/src/commands/bundle/prune/mod.rs
+++ b/src/commands/bundle/prune/mod.rs
@@ -1,5 +1,7 @@
-//! `knit prune` — find and delete dead-work bundles, orphan worktrees, and
-//! orphaned remote bundle records.
+//! `knit prune` — find dead-work bundles, orphan worktrees, and orphaned
+//! remote bundle records. Dead bundles are archived as finished history by
+//! default (which also mirrors the terminal state to the sync remotes);
+//! `--delete` discards their artifacts instead.
 //!
 //! A bundle is "dead work" when it has no open PRs, no uncommitted tracked
 //! changes in any checkout, and — for repos with no recorded review object —
@@ -10,7 +12,7 @@
 mod assess;
 mod orphans;
 
-use super::{bundle_json_paths, current_root, delete_bundle};
+use super::{archive_dead_bundle, bundle_json_paths, current_root, delete_bundle};
 use crate::output as out;
 use anyhow::{bail, Result};
 use assess::{assess_bundles, PruneAssessment, PruneCache};
@@ -29,6 +31,7 @@ pub(super) fn print_prune_warning(message: impl std::fmt::Display) {
 
 pub fn prune_merged_bundles(
     apply: bool,
+    delete: bool,
     refresh: bool,
     untracked: bool,
     report: bool,
@@ -49,6 +52,11 @@ pub fn prune_merged_bundles(
     if branches && !worktrees {
         bail!(
             "Pruning local branches requires --worktrees so generated checkouts are removed first."
+        );
+    }
+    if include_finished && !delete {
+        bail!(
+            "Pruning finished (landed/archived) bundles discards history artifacts; add --delete."
         );
     }
 
@@ -209,7 +217,7 @@ pub fn prune_merged_bundles(
         println!(
             "{}",
             out::warn(format!(
-                "Run `{}` to delete these bundle artifacts.",
+                "Run `{}` to archive these dead bundles as finished history (add --delete to discard their artifacts instead).",
                 suggested_prune_apply_command(
                     untracked,
                     worktrees,
@@ -226,16 +234,26 @@ pub fn prune_merged_bundles(
 
     let mut pruned = 0usize;
     for candidate in candidates {
-        delete_bundle(
-            &candidate.id,
-            true,
-            worktrees,
-            branches,
-            force_branches,
-            remote_branches,
-            remote_bundles,
-            config.as_ref(),
-        )?;
+        if delete {
+            delete_bundle(
+                &candidate.id,
+                true,
+                worktrees,
+                branches,
+                force_branches,
+                remote_branches,
+                remote_bundles,
+                config.as_ref(),
+            )?;
+        } else {
+            archive_dead_bundle(
+                &candidate.id,
+                &candidate.reason,
+                branches,
+                force_branches,
+                remote_branches,
+            )?;
+        }
         pruned += 1;
     }
     let mut removed_orphans = 0usize;
@@ -245,8 +263,8 @@ pub fn prune_merged_bundles(
     }
     // Remote orphan records are archived, never deleted: a record whose local
     // artifact is gone is the last remaining trace of shipped work, and the
-    // hosted dashboard is the durable archive of record. True deletion stays a
-    // per-bundle decision via `knit bundle delete --remote-bundles`.
+    // hosted dashboard is the durable archive of record. True deletion stays
+    // an explicit decision via `--delete --remote-bundles`.
     let mut removed_remote = 0usize;
     if let Some(config) = config.as_ref() {
         for orphan in remote_orphans {
@@ -268,7 +286,15 @@ pub fn prune_merged_bundles(
         }
     }
 
-    println!("{} {} bundle(s)", out::heading("Pruned:"), pruned);
+    if delete {
+        println!("{} {} bundle(s)", out::heading("Pruned:"), pruned);
+    } else {
+        println!(
+            "{} {} dead bundle(s) as finished history",
+            out::heading("Archived:"),
+            pruned
+        );
+    }
     if removed_orphans > 0 {
         println!(
             "{} {} orphan worktree dir(s)",

--- a/src/commands/bundle/prune/orphans.rs
+++ b/src/commands/bundle/prune/orphans.rs
@@ -1,6 +1,7 @@
 //! Orphan cleanup targets: generated worktree directories whose bundle is
-//! gone, and remote bundle records with no local artifact whose PRs
-//! are all merged or closed (unreachable by the local bundle scan).
+//! gone, and remote bundle records with no local artifact that are dead work
+//! (deleted locally, or every recorded PR merged or closed) and so are
+//! unreachable by the local bundle scan.
 
 use super::assess::{
     path_pending_changes, publication_state_is_closed, publication_state_is_merged, PruneCache,
@@ -23,9 +24,10 @@ pub(super) struct OrphanWorktree {
     pub(super) discards_pending: bool,
 }
 
-/// A bundle that exists on the sync remote but has no local artifact and
-/// whose recorded pull requests are all merged or closed, so prune can never reach
-/// it through the local `.knit/bundles/` scan.
+/// A bundle that exists on the sync remote but has no local artifact and is
+/// dead work — its artifact sits in the local delete quarantine, or every
+/// recorded pull request is merged or closed — so prune can never reach it
+/// through the local `.knit/bundles/` scan.
 pub(super) struct RemoteOrphan {
     pub(super) remote_id: String,
     pub(super) slug: String,
@@ -59,20 +61,36 @@ pub(super) fn remote_orphan_candidates(
     };
     let mut orphans = Vec::new();
     let cache = PruneCache::new();
-    let jobs: Vec<RemoteOrphanJob> = records
-        .into_iter()
-        .filter_map(|record| {
-            if record.lifecycle_state == "deleted" || local_ids.contains(&record.slug) {
-                return None;
-            }
-            let payload = record.payload?;
-            Some(RemoteOrphanJob {
+    let mut jobs: Vec<RemoteOrphanJob> = Vec::new();
+    for record in records {
+        // Archived and tombstoned records are already terminal on the remote;
+        // re-archiving them would only churn the record and the network.
+        if record.lifecycle_state == "deleted"
+            || record.lifecycle_state == "archived"
+            || local_ids.contains(&record.slug)
+        {
+            continue;
+        }
+        // An artifact in the local delete quarantine is proof the work was
+        // deliberately discarded here, so the record is dead even when it has
+        // no recorded PRs (which the classifier below keeps as possible WIP).
+        if deleted_artifact_exists(root, &record.slug) {
+            orphans.push(RemoteOrphan {
                 remote_id: record.remote_id,
                 slug: record.slug,
-                payload,
-            })
-        })
-        .collect();
+                reason: "local bundle was deleted",
+            });
+            continue;
+        }
+        let Some(payload) = record.payload else {
+            continue;
+        };
+        jobs.push(RemoteOrphanJob {
+            remote_id: record.remote_id,
+            slug: record.slug,
+            payload,
+        });
+    }
 
     let results: Vec<(String, Option<RemoteOrphan>)> = std::thread::scope(|scope| {
         let handles: Vec<_> = jobs
@@ -183,6 +201,14 @@ fn refresh_remote_publication_state(
         },
         None => publication.state.clone(),
     }
+}
+
+/// True when the bundle's artifact sits in `.knit/deleted/bundles/`, the
+/// quarantine `knit bundle delete` moves artifacts into.
+fn deleted_artifact_exists(root: &Path, slug: &str) -> bool {
+    root.join(".knit/deleted/bundles")
+        .join(format!("{slug}.bundle.json"))
+        .is_file()
 }
 
 fn classify_remote_publication_states(states: &[String]) -> Option<&'static str> {
@@ -372,5 +398,19 @@ mod tests {
     #[test]
     fn no_publications_is_not_an_orphan() {
         assert_eq!(dead_reason(&[]), None);
+    }
+
+    #[test]
+    fn delete_quarantine_marks_the_record_dead() {
+        let root = std::env::temp_dir().join(format!(
+            "knit-orphan-quarantine-test-{}",
+            std::process::id()
+        ));
+        let deleted_dir = root.join(".knit/deleted/bundles");
+        fs::create_dir_all(&deleted_dir).unwrap();
+        fs::write(deleted_dir.join("feature.bundle.json"), b"{}").unwrap();
+        assert!(deleted_artifact_exists(&root, "feature"));
+        assert!(!deleted_artifact_exists(&root, "still-open"));
+        let _ = fs::remove_dir_all(&root);
     }
 }

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -655,10 +655,10 @@ knit cherrypick --from feature-a --repo backend abc123
 - `knit bundle delete <bundle> --force` moves the bundle artifact to `.knit/deleted/bundles/`, preserves git state, and archives the bundle's record on the sync remotes (best-effort; offline deletes warn and continue).
 - `knit bundle delete <bundle> --force --worktrees --branches --force-branches` discards generated worktrees and local feature branches for that bundle.
 - `knit bundle delete <bundle> --force --worktrees --branches --force-branches --remote-branches` also deletes the matching feature branches from `origin`.
-- `knit bundle prune` refreshes GitHub PR states and lists clean dead-work bundles with no recorded open PRs. Landed and archived bundle artifacts are kept as history unless `--archived` is passed.
+- `knit bundle prune` refreshes GitHub PR states and lists clean dead-work bundles with no recorded open PRs. Landed and archived bundle artifacts are kept as history unless `--archived` (which requires `--delete`) is passed.
 - `knit bundle prune --no-refresh` performs the same scan using cached recorded PR states only.
-- `knit bundle prune --apply --worktrees --branches` is the short form for deleting dead bundle artifacts and their generated local state.
-- `knit bundle prune --apply --all` removes dead bundle artifacts, generated and orphaned worktrees, local feature branches, and matching `origin` branches, and archives matching remote bundle records.
+- `knit bundle prune --apply` archives dead bundles as finished history (recording why, removing worktrees, preserving branches) and pushes the terminal state to the sync remotes; add `--delete` to discard the artifacts to `.knit/deleted/bundles/` instead.
+- `knit bundle prune --apply --all` archives dead bundles, removes generated and orphaned worktrees, cleans local feature branches and matching `origin` branches, and archives matching remote bundle records.
 - Remote bundle cleanup uses the configured sync remotes. Orphaned remote records — including records whose bundle sits in the local delete quarantine — are archived (never deleted) with the everyday `bundle:push` scope; true remote deletion stays explicit via `knit bundle prune --apply --remote-bundles` and a `bundle:delete` token.
 - `knit switch <bundle> --workspace` changes the shared workspace fallback bundle (the `--workspace` flag is required so the change is deliberate).
 - `knit project remove <project> --force` removes a reusable project template artifact.

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -652,14 +652,14 @@ knit cherrypick --from feature-a --repo backend abc123
 - `knit bundle list` shows workspace bundles.
 - `knit bundle archive <bundle> [--reason "merged"]` marks a bundle done: it records an archive node and removes generated worktrees while preserving local feature branches (`--keep-worktrees` to leave them, `--force` to discard dirty checkouts). With push-sync remotes configured, archive and restore also push the updated artifact so hosted dashboards flip lifecycle state together with the local ledger.
 - `knit bundle restore <bundle>` reopens an archived bundle; run `knit bundle worktree` afterwards to rematerialize checkouts.
-- `knit bundle delete <bundle> --force` moves the bundle artifact to `.knit/deleted/bundles/` and preserves git state.
+- `knit bundle delete <bundle> --force` moves the bundle artifact to `.knit/deleted/bundles/`, preserves git state, and archives the bundle's record on the sync remotes (best-effort; offline deletes warn and continue).
 - `knit bundle delete <bundle> --force --worktrees --branches --force-branches` discards generated worktrees and local feature branches for that bundle.
 - `knit bundle delete <bundle> --force --worktrees --branches --force-branches --remote-branches` also deletes the matching feature branches from `origin`.
 - `knit bundle prune` refreshes GitHub PR states and lists clean dead-work bundles with no recorded open PRs. Landed and archived bundle artifacts are kept as history unless `--archived` is passed.
 - `knit bundle prune --no-refresh` performs the same scan using cached recorded PR states only.
 - `knit bundle prune --apply --worktrees --branches` is the short form for deleting dead bundle artifacts and their generated local state.
 - `knit bundle prune --apply --all` removes dead bundle artifacts, generated and orphaned worktrees, local feature branches, and matching `origin` branches, and archives matching remote bundle records.
-- Remote bundle cleanup uses the configured sync remote. Orphaned remote records are archived (never deleted) with the everyday `bundle:push` scope; true remote deletion stays per-bundle via `knit bundle delete --remote-bundles` and a `bundle:delete` token.
+- Remote bundle cleanup uses the configured sync remotes. Orphaned remote records — including records whose bundle sits in the local delete quarantine — are archived (never deleted) with the everyday `bundle:push` scope; true remote deletion stays explicit via `knit bundle prune --apply --remote-bundles` and a `bundle:delete` token.
 - `knit switch <bundle> --workspace` changes the shared workspace fallback bundle (the `--workspace` flag is required so the change is deliberate).
 - `knit project remove <project> --force` removes a reusable project template artifact.
 - `knit workspace status` shows each project repo's source checkout, configured local/remote base divergence, dirty state, and the open bundle set.

--- a/src/commands/remote/mod.rs
+++ b/src/commands/remote/mod.rs
@@ -25,10 +25,11 @@ pub use facade::{sync_pull, sync_push, SyncTargets};
 pub use history::pull_history_from_remote;
 pub use projects::list_remote_projects;
 pub use pull::{
-    archive_remote_bundle_by_id, delete_bundle_from_remote, delete_remote_bundle_by_id,
-    fetch_bundles_from_remote, list_remote_bundles, prepare_remote_pull, pull_bundle_by_slug,
-    pull_bundle_remote_state, pull_remote_state, pull_views_from_remote, remote_bundle_lifecycle,
-    RemoteBundleOutcome, RemoteBundleRecord, RemotePullContext,
+    archive_deleted_bundle_on_remotes, archive_remote_bundle_by_id, delete_bundle_from_remote,
+    delete_remote_bundle_by_id, fetch_bundles_from_remote, list_remote_bundles,
+    prepare_remote_pull, pull_bundle_by_slug, pull_bundle_remote_state, pull_remote_state,
+    pull_views_from_remote, remote_bundle_lifecycle, RemoteBundleOutcome, RemoteBundleRecord,
+    RemotePullContext,
 };
 pub use push::sync_remote_helpers_command;
 pub use push::{

--- a/src/commands/remote/pull.rs
+++ b/src/commands/remote/pull.rs
@@ -645,6 +645,70 @@ pub fn delete_bundle_from_remote(
     Ok(())
 }
 
+/// Archive a bundle's record on every configured sync remote after its local
+/// artifact was deleted, so hosted dashboards stop counting deleted work as
+/// open. Archive, never delete: the record stays as durable history, and true
+/// remote deletion remains the explicit `--remote-bundles` door. Records
+/// already archived or tombstoned on a remote are left alone, and a bundle
+/// with no resolvable project is a silent no-op.
+pub fn archive_deleted_bundle_on_remotes(config: &KnitConfig, bundle: &ChangeGroup) -> Result<()> {
+    let Some(project_id) = bundle
+        .project_id
+        .clone()
+        .or_else(|| config.active_project.clone())
+    else {
+        return Ok(());
+    };
+    let mut failures = Vec::new();
+    for remote_name in configured_sync_remote_names(config) {
+        match archive_bundle_record_on_remote(config, &remote_name, &project_id, &bundle.id) {
+            Ok(Some(slug)) => println!(
+                "{}: {} {}",
+                out::node(&bundle.id),
+                out::movement("archived remote bundle"),
+                out::muted(format!("{remote_name}/{slug}"))
+            ),
+            Ok(None) => {}
+            Err(error) => failures.push(format!("{remote_name}: {error:#}")),
+        }
+    }
+    if failures.is_empty() {
+        Ok(())
+    } else {
+        bail!(
+            "failed to archive the remote bundle record on {} remote(s):\n{}",
+            failures.len(),
+            failures.join("\n")
+        )
+    }
+}
+
+fn archive_bundle_record_on_remote(
+    config: &KnitConfig,
+    remote_name: &str,
+    project_id: &str,
+    bundle_id: &str,
+) -> Result<Option<String>> {
+    let remote = resolve_remote(config, remote_name)?;
+    let token = resolve_token(remote_name, remote)?;
+    let export = fetch_project_export(remote, Some(&token), project_id)?;
+    let Some(record) = export.bundles.iter().find(|record| {
+        record.slug == bundle_id
+            && record.lifecycle_state != "deleted"
+            && record.lifecycle_state != "archived"
+    }) else {
+        return Ok(None);
+    };
+    let archived: RemoteBundle = request_json(
+        remote,
+        &token,
+        "PATCH",
+        &format!("/bundles/{}/archive", record.id),
+        None,
+    )?;
+    Ok(Some(archived.slug))
+}
+
 pub fn fetch_bundles_from_remote(
     root: &Path,
     config: &KnitConfig,
@@ -707,9 +771,9 @@ pub fn fetch_bundles_from_remote(
                 continue;
             }
             // The remote lifecycle can still read "open" for a bundle that was
-            // landed or pruned here (nothing pushes terminal state back), so
-            // the local delete quarantine is the authority: a bundle deleted
-            // locally stays deleted.
+            // deleted here (the delete-time remote archive is best-effort and
+            // can be skipped offline), so the local delete quarantine is the
+            // authority: a bundle deleted locally stays deleted.
             if root
                 .join(".knit/deleted/bundles")
                 .join(format!("{}.bundle.json", bundle.id))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -241,6 +241,7 @@ pub fn run(cli: Cli) -> Result<()> {
             }) => commands::list_bundles(all, archived, deleted),
             Some(BundleCommand::Prune {
                 apply,
+                delete,
                 force,
                 refresh,
                 no_refresh,
@@ -263,6 +264,7 @@ pub fn run(cli: Cli) -> Result<()> {
                 let remote_bundles = all || remote_bundles;
                 commands::prune_merged_bundles(
                     apply,
+                    delete,
                     refresh,
                     untracked,
                     report,

--- a/tests/cleanup.rs
+++ b/tests/cleanup.rs
@@ -819,3 +819,105 @@ fn prune_archives_remote_orphan_records_instead_of_deleting() {
 
     fs::remove_dir_all(root).unwrap();
 }
+
+#[test]
+fn delete_archives_the_remote_bundle_record() {
+    let root = unique_temp_dir();
+    let backend = root.join("backend");
+    let workspace = root.join("workspace");
+    fs::create_dir_all(&workspace).unwrap();
+    init_repo(&backend, "backend");
+
+    knit(&workspace, ["init", "demo"]);
+    knit(
+        &workspace,
+        ["project", "add", "backend", backend.to_str().unwrap()],
+    );
+    knit(&workspace, ["bundle", "dead work", "--repo", "backend"]);
+
+    let fake_dir = root.join("fake-remote");
+    let base_url = spawn_fake_remote_push_api(&fake_dir);
+    let export = "{\"data\":{\"project\":{\"slug\":\"demo\"},\"knitProject\":null,\"repositories\":[],\"bundles\":[{\"id\":\"rb-dead-work\",\"slug\":\"dead-work\",\"lifecycleState\":\"open\",\"currentArtifact\":null}],\"historyEvents\":[]}}";
+    fs::write(fake_dir.join("export.json"), export).unwrap();
+    knit(&workspace, ["remote", "add", "hosted", &base_url]);
+    let env = [("KNIT_REMOTE_TOKEN", "test-token")];
+
+    let deleted = knit_with_env(
+        &workspace,
+        ["bundle", "delete", "dead-work", "--force", "--worktrees"],
+        &env,
+    );
+    assert!(deleted.contains("archived remote bundle"), "{deleted}");
+
+    // The local delete mirrored as an archive — never a remote deletion.
+    assert!(fake_dir.join("archived-rb-dead-work").exists());
+    assert!(!fake_dir.join("deleted-rb-dead-work").exists());
+    assert!(workspace
+        .join(".knit/deleted/bundles/dead-work.bundle.json")
+        .exists());
+
+    fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
+fn prune_archives_quarantined_remote_records_without_recorded_prs() {
+    let root = unique_temp_dir();
+    let backend = root.join("backend");
+    let workspace = root.join("workspace");
+    fs::create_dir_all(&workspace).unwrap();
+    init_repo(&backend, "backend");
+
+    knit(&workspace, ["init", "demo"]);
+    knit(
+        &workspace,
+        ["project", "add", "backend", backend.to_str().unwrap()],
+    );
+
+    // Delete a never-published bundle before any remote exists: the remote
+    // record keeps reading "open" and, with no recorded PRs, the publication
+    // classifier alone would keep it as possible work in progress forever.
+    knit(
+        &workspace,
+        ["bundle", "abandoned work", "--repo", "backend"],
+    );
+    knit(
+        &workspace,
+        [
+            "bundle",
+            "delete",
+            "abandoned-work",
+            "--force",
+            "--worktrees",
+        ],
+    );
+    assert!(workspace
+        .join(".knit/deleted/bundles/abandoned-work.bundle.json")
+        .exists());
+
+    let fake_dir = root.join("fake-remote");
+    let base_url = spawn_fake_remote_push_api(&fake_dir);
+    let export = "{\"data\":{\"project\":{\"slug\":\"demo\"},\"knitProject\":null,\"repositories\":[],\"bundles\":[{\"id\":\"rb-abandoned-work\",\"slug\":\"abandoned-work\",\"lifecycleState\":\"open\",\"currentArtifact\":null},{\"id\":\"rb-already-archived\",\"slug\":\"other-work\",\"lifecycleState\":\"archived\",\"currentArtifact\":null}],\"historyEvents\":[]}}";
+    fs::write(fake_dir.join("export.json"), export).unwrap();
+    knit(&workspace, ["remote", "add", "hosted", &base_url]);
+    let env = [("KNIT_REMOTE_TOKEN", "test-token")];
+
+    let pruned = knit_with_env(
+        &workspace,
+        [
+            "bundle",
+            "prune",
+            "--no-refresh",
+            "--apply",
+            "--remote-bundles",
+        ],
+        &env,
+    );
+    assert!(pruned.contains("local bundle was deleted"), "{pruned}");
+
+    // The quarantined record was archived; the already-archived one was left alone.
+    assert!(fake_dir.join("archived-rb-abandoned-work").exists());
+    assert!(!fake_dir.join("deleted-rb-abandoned-work").exists());
+    assert!(!fake_dir.join("archived-rb-already-archived").exists());
+
+    fs::remove_dir_all(root).unwrap();
+}

--- a/tests/cleanup.rs
+++ b/tests/cleanup.rs
@@ -273,14 +273,24 @@ fn bundle_prune_removes_only_bundles_with_all_recorded_prs_merged() {
             "--branches",
         ],
     );
-    assert!(pruned.contains("Deleted bundle"));
-    assert!(pruned.contains("Pruned"));
+    // Dead work whose PRs merged is finished work: archived as history with
+    // the dead reason on the ledger, never moved to the delete quarantine.
+    assert!(pruned.contains("Archived bundle"));
+    assert!(pruned.contains("dead bundle(s) as finished history"));
+    let archived_path = workspace.join(".knit/bundles/merged-cleanup.bundle.json");
+    assert!(archived_path.exists());
     assert!(!workspace
-        .join(".knit/bundles/merged-cleanup.bundle.json")
-        .exists());
-    assert!(workspace
         .join(".knit/deleted/bundles/merged-cleanup.bundle.json")
         .exists());
+    let archived: Value =
+        serde_json::from_str(&fs::read_to_string(&archived_path).unwrap()).unwrap();
+    assert_eq!(archived["state"].as_str(), Some("archived"));
+    let last_node = archived["nodes"].as_array().unwrap().last().unwrap();
+    assert_eq!(last_node["type"].as_str(), Some("feature.archived"));
+    assert_eq!(
+        last_node["message"].as_str(),
+        Some("recorded PRs are merged")
+    );
     assert!(!workspace
         .join(".knit/worktrees/merged-cleanup/backend")
         .exists());
@@ -381,6 +391,7 @@ fn bundle_prune_removes_clean_dead_work_with_missing_publications() {
     assert!(preview.contains("no recorded PRs and no pending changes"));
     assert!(!preview.contains("dirty-cleanup"));
 
+    // Explicit --delete keeps the old discard behavior available.
     let pruned = knit(
         &workspace,
         [
@@ -388,6 +399,7 @@ fn bundle_prune_removes_clean_dead_work_with_missing_publications() {
             "prune",
             "--no-refresh",
             "--apply",
+            "--delete",
             "--worktrees",
             "--branches",
             "--force-branches",
@@ -395,6 +407,7 @@ fn bundle_prune_removes_clean_dead_work_with_missing_publications() {
     );
     assert!(pruned.contains("partial-landed"));
     assert!(pruned.contains("abandoned-cleanup"));
+    assert!(pruned.contains("Pruned:"));
     assert!(!workspace
         .join(".knit/bundles/partial-landed.bundle.json")
         .exists());
@@ -476,10 +489,13 @@ fn bundle_prune_untracked_flag_prunes_untracked_only_dead_work() {
         ],
     );
     assert!(pruned.contains("stray-cleanup"));
+    // Archived by default: the artifact stays as history while the generated
+    // checkout (and its untracked file) is discarded.
+    let stray_path = workspace.join(".knit/bundles/stray-cleanup.bundle.json");
+    assert!(stray_path.exists());
+    let stray: Value = serde_json::from_str(&fs::read_to_string(&stray_path).unwrap()).unwrap();
+    assert_eq!(stray["state"].as_str(), Some("archived"));
     assert!(!workspace
-        .join(".knit/bundles/stray-cleanup.bundle.json")
-        .exists());
-    assert!(workspace
         .join(".knit/deleted/bundles/stray-cleanup.bundle.json")
         .exists());
     assert!(!stray_feature.exists());
@@ -599,7 +615,7 @@ fn prune_can_remove_generated_worktrees_local_branches_and_remote_branches() {
             "--remote-branches",
         ],
     );
-    assert!(pruned.contains("Deleted bundle"));
+    assert!(pruned.contains("Archived bundle"));
     assert!(pruned.contains("origin/knit/remote-cleanup"));
     assert!(!feature.exists());
     assert!(!git_success(
@@ -642,7 +658,7 @@ fn prune_removes_bundle_worktree_container_dir_and_agents_md() {
         &workspace,
         ["bundle", "prune", "--no-refresh", "--apply", "--worktrees"],
     );
-    assert!(pruned.contains("Deleted bundle"));
+    assert!(pruned.contains("Archived bundle"));
     assert!(pruned.contains("container-cleanup"));
     assert!(!feature.exists());
     assert!(!bundle_root.join("AGENTS.md").exists());
@@ -737,11 +753,20 @@ fn bundle_prune_keeps_finished_bundles_unless_archived_flag() {
     assert!(workspace
         .join(".knit/bundles/finished-work.bundle.json")
         .exists());
-    assert!(!workspace
-        .join(".knit/bundles/dead-work.bundle.json")
-        .exists());
+    // The dead bundle is archived in place, joining the finished history.
+    let dead_path = workspace.join(".knit/bundles/dead-work.bundle.json");
+    assert!(dead_path.exists());
+    let dead: Value = serde_json::from_str(&fs::read_to_string(&dead_path).unwrap()).unwrap();
+    assert_eq!(dead["state"].as_str(), Some("archived"));
 
-    // Explicit opt-in prunes the finished artifact too.
+    // Pruning finished bundles discards history, so it demands --delete.
+    let missing_delete = knit_fails(
+        &workspace,
+        ["bundle", "prune", "--no-refresh", "--archived", "--apply"],
+    );
+    assert!(missing_delete.contains("--delete"), "{missing_delete}");
+
+    // Explicit opt-in discards the finished artifacts too.
     let pruned_finished = knit(
         &workspace,
         [
@@ -749,6 +774,7 @@ fn bundle_prune_keeps_finished_bundles_unless_archived_flag() {
             "prune",
             "--no-refresh",
             "--archived",
+            "--delete",
             "--apply",
             "--worktrees",
         ],

--- a/tests/project.rs
+++ b/tests/project.rs
@@ -26,7 +26,7 @@ fn init_can_generate_agents_tutorial() {
     assert!(agents.contains("knit bundle add"));
     assert!(agents.contains("knit bundle remove <repo>"));
     assert!(agents.contains("knit bundle prune"));
-    assert!(agents.contains("knit bundle prune --apply --worktrees --branches"));
+    assert!(agents.contains("archives dead bundles as finished history"));
     assert!(agents.contains("knit bundle prune --apply --all"));
     assert!(agents.contains("--remote-branches"));
     assert!(agents.contains("matching remote bundle records"));


### PR DESCRIPTION
<!-- BEGIN KNIT BUNDLE -->
## Knit Bundle

This PR is part of Knit bundle `archive-remote-bundle-records-on-local-delete`.

See the other review objects in this bundle:
- `knit`: https://github.com/marc-merino/knit/pull/140 (this PR)
- `knithub`: https://github.com/marc-merino/knithub/pull/133

Bundle id: `archive-remote-bundle-records-on-local-delete`
Bundle title: archive remote bundle records on local delete
<!-- END KNIT BUNDLE -->