### PR TITLE
fix archived worktree cleanup and orphan detection (knit)

### DIFF
--- a/src/commands/bundle/prune/mod.rs
+++ b/src/commands/bundle/prune/mod.rs
@@ -105,11 +105,9 @@ pub fn prune_merged_bundles(
         }
     }
 
-    let (orphan_worktrees, blocked_orphan_worktrees) = if worktrees {
-        orphan_worktree_candidates(&root, force)?
-    } else {
-        (Vec::new(), Vec::new())
-    };
+    // Always scan for orphan worktree dirs so the listing is truthful even
+    // without `--worktrees`; the flag still gates their removal below.
+    let (orphan_worktrees, blocked_orphan_worktrees) = orphan_worktree_candidates(&root, force)?;
     let remote_orphans = if remote_bundles {
         remote_orphan_candidates(config.as_ref(), &local_ids, &root, refresh)
     } else {
@@ -182,7 +180,14 @@ pub fn prune_merged_bundles(
         }
     }
     if !orphan_worktrees.is_empty() {
-        println!("{}", out::heading("Orphan worktree candidates:"));
+        if worktrees {
+            println!("{}", out::heading("Orphan worktree candidates:"));
+        } else {
+            println!(
+                "{}",
+                out::heading("Orphan worktree dirs (pass --worktrees to remove):")
+            );
+        }
         for orphan in &orphan_worktrees {
             if orphan.discards_pending {
                 println!(
@@ -220,7 +225,9 @@ pub fn prune_merged_bundles(
                 "Run `{}` to archive these dead bundles as finished history (add --delete to discard their artifacts instead).",
                 suggested_prune_apply_command(
                     untracked,
-                    worktrees,
+                    worktrees
+                        || !orphan_worktrees.is_empty()
+                        || !blocked_orphan_worktrees.is_empty(),
                     force || !blocked_orphan_worktrees.is_empty(),
                     branches,
                     force_branches,
@@ -257,9 +264,11 @@ pub fn prune_merged_bundles(
         pruned += 1;
     }
     let mut removed_orphans = 0usize;
-    for orphan in orphan_worktrees {
-        remove_orphan_worktree(&orphan, force)?;
-        removed_orphans += 1;
+    if worktrees {
+        for orphan in orphan_worktrees {
+            remove_orphan_worktree(&orphan, force)?;
+            removed_orphans += 1;
+        }
     }
     // Remote orphan records are archived, never deleted: a record whose local
     // artifact is gone is the last remaining trace of shipped work, and the

--- a/src/commands/clean.rs
+++ b/src/commands/clean.rs
@@ -305,7 +305,14 @@ fn clean_archived_bundle_worktrees(force: bool) -> Result<()> {
         }
         let bundle: ChangeGroup = read_json(&path)?;
         let state = crate::commands::bundle::bundle_state(&bundle);
-        if !matches!(state, BundleStatus::Closed | BundleStatus::Archived) {
+        // `Landed` is derived from the ledger and never written to the
+        // artifact, so a landed bundle whose worktrees were kept (for example
+        // `knit land apply --keep-worktrees`) is finished work too — skipping
+        // it here would leave its checkouts behind forever.
+        if !matches!(
+            state,
+            BundleStatus::Closed | BundleStatus::Archived | BundleStatus::Landed
+        ) {
             continue;
         }
         let mut active = ActiveBundle::unlocked(root.clone(), path.clone(), bundle);

--- a/tests/cleanup.rs
+++ b/tests/cleanup.rs
@@ -63,6 +63,44 @@ fn archive_records_ledger_node_and_preserves_branches() {
 }
 
 #[test]
+fn clean_archived_sweeps_landed_bundle_worktrees() {
+    let root = unique_temp_dir();
+    let backend = root.join("backend");
+    let workspace = root.join("workspace");
+    fs::create_dir_all(&workspace).unwrap();
+    init_repo(&backend, "backend");
+
+    knit(&workspace, ["bundle", "landed cleanup"]);
+    knit(&workspace, ["bundle", "add", backend.to_str().unwrap()]);
+    let feature = workspace.join(".knit/worktrees/landed-cleanup/backend");
+    assert!(feature.exists());
+
+    // Mark the bundle landed the way `knit land apply` does: a ledger node,
+    // never a persisted state field. The sweep must treat this derived state
+    // as finished work, not skip it as open.
+    let artifact = workspace.join(".knit/bundles/landed-cleanup.bundle.json");
+    let mut bundle: Value = serde_json::from_str(&fs::read_to_string(&artifact).unwrap()).unwrap();
+    bundle["nodes"]
+        .as_array_mut()
+        .unwrap()
+        .push(serde_json::json!({
+            "id": "n-landed-test",
+            "type": "feature.landed",
+            "createdAt": "2026-01-01T00:00:00.000Z"
+        }));
+    fs::write(&artifact, serde_json::to_string_pretty(&bundle).unwrap()).unwrap();
+    assert!(knit(&workspace, ["bundle", "list"]).contains("landed"));
+
+    knit(&workspace, ["clean", "--archived", "--worktrees"]);
+    assert!(!feature.exists());
+    assert!(
+        git(&backend, ["branch", "--list", "knit/landed-cleanup"]).contains("knit/landed-cleanup")
+    );
+
+    fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
 fn clean_removes_plans_and_generated_worktrees_only() {
     let root = unique_temp_dir();
     let backend = root.join("backend");
@@ -527,6 +565,18 @@ fn prune_removes_orphan_worktree_dirs_without_bundle_artifacts() {
     let dirty_orphan = workspace.join(".knit/worktrees/dirty-orphan");
     fs::create_dir_all(&dirty_orphan).unwrap();
     fs::write(dirty_orphan.join("note.txt"), "untracked work\n").unwrap();
+
+    // Without --worktrees the orphan dirs are still reported — the listing
+    // must not claim there is nothing to prune — but nothing is removed,
+    // and the suggested apply command picks up the missing flag.
+    let listing = knit(&workspace, ["bundle", "prune", "--no-refresh"]);
+    assert!(listing.contains("Orphan worktree dirs (pass --worktrees to remove)"));
+    assert!(listing.contains("empty-orphan"));
+    assert!(listing.contains("--apply --worktrees"));
+    let applied_without_flag = knit(&workspace, ["bundle", "prune", "--no-refresh", "--apply"]);
+    assert!(!applied_without_flag.contains("removed orphan worktree"));
+    assert!(workspace.join(".knit/worktrees/empty-orphan").exists());
+    assert!(dirty_orphan.exists());
 
     let preview = knit(
         &workspace,


### PR DESCRIPTION
<!-- BEGIN KNIT BUNDLE -->
## Knit Bundle

This PR is part of Knit bundle `fix-archived-worktree-cleanup-and-orphan-detection`.

See the other review objects in this bundle:
- `knit`: https://github.com/marc-merino/knit/pull/142 (this PR)

Bundle id: `fix-archived-worktree-cleanup-and-orphan-detection`
Bundle title: fix archived worktree cleanup and orphan detection
<!-- END KNIT BUNDLE -->