### PR TITLE
Cross-forge repository identity in sync push (knit)

### DIFF
--- a/src/commands/remote/facade.rs
+++ b/src/commands/remote/facade.rs
@@ -104,6 +104,23 @@ pub fn sync_push(
     let multiple = remotes.len() > 1;
     let mut failures = Vec::new();
 
+    // The resolved bundle (when one resolves) decides both which bundle gets
+    // the rich push and which project the project-scoped families target. An
+    // explicit `--bundle` can name a bundle from a project other than the
+    // workspace's active one; history, views, architecture, and kg must
+    // follow that bundle's project instead of silently syncing the active
+    // project's artifacts.
+    let resolved_bundle = crate::store::load_active_bundle()
+        .and_then(|active| {
+            crate::store::ensure_workspace_fallback_status_is_unambiguous(&active)?;
+            Ok((active.bundle.id, active.bundle.project_id))
+        })
+        .ok();
+    let active_id = resolved_bundle.as_ref().map(|(id, _)| id.as_str());
+    let project = resolved_bundle
+        .as_ref()
+        .and_then(|(_, project)| project.as_deref());
+
     for remote in &remotes {
         if multiple {
             println!("{} {}", out::heading("Remote:"), out::repo(remote));
@@ -120,12 +137,6 @@ pub fn sync_push(
             // local ledger. From a root with several open bundles nothing
             // resolves; the sweep covers everything and history is pushed
             // separately.
-            let active_id = crate::store::load_active_bundle()
-                .and_then(|active| {
-                    crate::store::ensure_workspace_fallback_status_is_unambiguous(&active)?;
-                    Ok(active.bundle.id)
-                })
-                .ok();
             match &active_id {
                 Some(_) => {
                     if let Err(error) = push_bundle_to_remote(remote, None, force) {
@@ -133,33 +144,31 @@ pub fn sync_push(
                     }
                 }
                 None => {
-                    if let Err(error) = push_history_to_remote(None, remote) {
+                    if let Err(error) = push_history_to_remote(project, remote) {
                         failures.push(format!("{remote} history: {error:#}"));
                     }
                 }
             }
-            if let Err(error) =
-                push_all_bundles_to_remote(remote, None, active_id.as_deref(), force)
-            {
+            if let Err(error) = push_all_bundles_to_remote(remote, None, active_id, force) {
                 failures.push(format!("{remote} bundles: {error:#}"));
             }
         } else if targets.history {
-            if let Err(error) = push_history_to_remote(None, remote) {
+            if let Err(error) = push_history_to_remote(project, remote) {
                 failures.push(format!("{remote} history: {error:#}"));
             }
         }
         if targets.views {
-            if let Err(error) = push_views_to_remote(None, remote) {
+            if let Err(error) = push_views_to_remote(project, remote) {
                 failures.push(format!("{remote} views: {error:#}"));
             }
         }
         if targets.architecture {
-            if let Err(error) = push_architecture_to_remote(None, remote) {
+            if let Err(error) = push_architecture_to_remote(project, remote) {
                 failures.push(format!("{remote} architecture: {error:#}"));
             }
         }
         if targets.kg {
-            if let Err(error) = push_kg_graph_to_remote(None, remote) {
+            if let Err(error) = push_kg_graph_to_remote(project, remote) {
                 failures.push(format!("{remote} kg: {error:#}"));
             }
         }
@@ -178,6 +187,17 @@ pub fn sync_pull(targets: SyncTargets, remote_overrides: &[String]) -> Result<()
     let remotes = resolve_remotes(remote_overrides)?;
     let multiple = remotes.len() > 1;
     let mut failures = Vec::new();
+
+    // Same project resolution as sync_push: a resolved bundle's project wins
+    // over the workspace's active project for project-scoped families.
+    let project = crate::store::load_active_bundle()
+        .and_then(|active| {
+            crate::store::ensure_workspace_fallback_status_is_unambiguous(&active)?;
+            Ok(active.bundle.project_id)
+        })
+        .ok()
+        .flatten();
+    let project = project.as_deref();
 
     for remote in &remotes {
         if multiple {
@@ -213,12 +233,12 @@ pub fn sync_pull(targets: SyncTargets, remote_overrides: &[String]) -> Result<()
             }
         }
         if targets.history {
-            if let Err(error) = pull_history_from_remote(None, Some(remote)) {
+            if let Err(error) = pull_history_from_remote(project, Some(remote)) {
                 failures.push(format!("{remote} history: {error:#}"));
             }
         }
         if targets.views {
-            if let Err(error) = pull_views_from_remote(None, remote) {
+            if let Err(error) = pull_views_from_remote(project, remote) {
                 failures.push(format!("{remote} views: {error:#}"));
             }
         }

--- a/src/commands/remote/history.rs
+++ b/src/commands/remote/history.rs
@@ -17,6 +17,11 @@ use std::path::Path;
 struct RemoteHistoryPush {
     inserted_count: usize,
     skipped_count: usize,
+    // Older sync remotes report only inserted/skipped.
+    #[serde(default)]
+    updated_count: usize,
+    #[serde(default)]
+    failed_count: usize,
 }
 
 pub fn push_history_to_remote(project: Option<&str>, remote_name: &str) -> Result<()> {
@@ -81,6 +86,7 @@ pub(super) fn push_project_history_events(
     // Batched so a project ledger of thousands of events never rides in one
     // request body; each batch upserts independently and is idempotent.
     let mut accepted = 0;
+    let mut failed = 0;
     for batch in events.chunks(HISTORY_PAGE_SIZE) {
         let payload = json!({ "events": batch });
         let response: RemoteHistoryPush = request_json(
@@ -90,7 +96,14 @@ pub(super) fn push_project_history_events(
             &format!("/projects/{project_slug}/history-events"),
             Some(&payload),
         )?;
-        accepted += response.inserted_count + response.skipped_count;
+        accepted += response.inserted_count + response.updated_count + response.skipped_count;
+        failed += response.failed_count;
+    }
+    if failed > 0 {
+        eprintln!(
+            "{} {failed} history event(s) were rejected by the sync remote and are missing there; the next push retries them",
+            out::warn("warning:")
+        );
     }
     Ok(accepted)
 }

--- a/src/commands/remote/push.rs
+++ b/src/commands/remote/push.rs
@@ -1458,22 +1458,29 @@ fn repo_identity(repo_id: &str, remote: Option<&str>) -> RepoIdentity {
     let Some(remote) = remote else {
         return fallback_repo_identity(repo_id);
     };
-    let remote = remote.trim().trim_end_matches(".git");
-    let marker = "github.com";
-    let Some(index) = remote.find(marker) else {
+    // The forge adapters own remote parsing: the same host detection publish
+    // uses decides the provider id, and the adapter's parser yields the host
+    // path (nested GitLab groups included). This identity must match what the
+    // sync remote derives from bundle artifacts — a repo pushed under its
+    // local id instead of its host path splits into a second repository
+    // record there, and ambiguous records hide the repo's history.
+    let Some(forge) = crate::providers::for_remote(remote) else {
         return fallback_repo_identity(repo_id);
     };
-    let suffix = remote[index + marker.len()..].trim_start_matches([':', '/']);
-    let parts = suffix.split('/').collect::<Vec<_>>();
-    if parts.len() < 2 || parts[0].is_empty() || parts[1].is_empty() {
+    let Some(full_name) = forge.repo_full_name(remote) else {
         return fallback_repo_identity(repo_id);
-    }
-    let owner = parts[0].to_string();
-    let name = parts[1].to_string();
+    };
+    // The final segment is the repository; every leading segment is the owner.
+    let (owner, name) = match full_name.rsplit_once('/') {
+        Some((owner, name)) if !owner.is_empty() && !name.is_empty() => {
+            (owner.to_string(), name.to_string())
+        }
+        _ => return fallback_repo_identity(repo_id),
+    };
     RepoIdentity {
-        provider: "github",
-        owner: Some(owner.clone()),
-        full_name: format!("{owner}/{name}"),
+        provider: forge.id(),
+        owner: Some(owner),
+        full_name,
         name,
     }
 }
@@ -1526,12 +1533,74 @@ fn remote_listing(global: bool) -> Result<(KnitConfig, BTreeMap<String, String>)
 
 #[cfg(test)]
 mod tests {
-    use super::{apply_artifact_force_fields, lease_mismatch_message};
+    use super::{apply_artifact_force_fields, lease_mismatch_message, repo_identity};
     use crate::commands::push::PushForce;
     use serde_json::json;
 
     fn base_payload() -> serde_json::Value {
         json!({"kind": "bundle", "payload": {}})
+    }
+
+    #[test]
+    fn repo_identity_parses_every_supported_forge() {
+        for (remote, provider, owner, name) in [
+            (
+                "https://github.com/acme/backend.git",
+                "github",
+                "acme",
+                "backend",
+            ),
+            (
+                "https://gitlab.com/acme/backend.git",
+                "gitlab",
+                "acme",
+                "backend",
+            ),
+            (
+                "https://codeberg.org/acme/backend.git",
+                "forgejo",
+                "acme",
+                "backend",
+            ),
+            (
+                "https://bitbucket.org/acme/backend.git",
+                "bitbucket",
+                "acme",
+                "backend",
+            ),
+            (
+                "git@gitlab.com:acme/backend.git",
+                "gitlab",
+                "acme",
+                "backend",
+            ),
+        ] {
+            let identity = repo_identity("local-id", Some(remote));
+            assert_eq!(identity.provider, provider, "{remote}");
+            assert_eq!(identity.owner.as_deref(), Some(owner), "{remote}");
+            assert_eq!(identity.name, name, "{remote}");
+            assert_eq!(identity.full_name, format!("{owner}/{name}"), "{remote}");
+        }
+    }
+
+    #[test]
+    fn repo_identity_keeps_nested_gitlab_groups_in_the_owner() {
+        let identity = repo_identity("local-id", Some("https://gitlab.com/acme/team/backend.git"));
+        assert_eq!(identity.provider, "gitlab");
+        assert_eq!(identity.owner.as_deref(), Some("acme/team"));
+        assert_eq!(identity.name, "backend");
+        assert_eq!(identity.full_name, "acme/team/backend");
+    }
+
+    #[test]
+    fn repo_identity_falls_back_to_the_local_id_for_unknown_hosts() {
+        for remote in [None, Some("https://git.example.com/acme/backend.git")] {
+            let identity = repo_identity("backend", remote);
+            assert_eq!(identity.provider, "git");
+            assert_eq!(identity.owner, None);
+            assert_eq!(identity.name, "backend");
+            assert_eq!(identity.full_name, "backend");
+        }
     }
 
     #[test]


### PR DESCRIPTION
<!-- BEGIN KNIT BUNDLE -->
## Knit Bundle

This PR is part of Knit bundle `cross-forge-repository-identity-in-sync-push`.

See the other review objects in this bundle:
- `knit`: https://github.com/knit-cli/knit/pull/158 (this PR)
- `knithub`: https://github.com/marc-merino/knithub/pull/178

Bundle id: `cross-forge-repository-identity-in-sync-push`
Bundle title: Cross-forge repository identity in sync push
<!-- END KNIT BUNDLE -->