### PR TITLE
Saved views tolerate repos removed from the project (knit)

### DIFF
--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -325,19 +325,20 @@ fn select_project_repos(
         &project,
         repo_ids,
         all_repos,
-        view.as_ref(),
+        view.as_ref().map(|(name, view)| (name.as_str(), view)),
         include,
         exclude,
     )
 }
 
 /// Resolve which named view to apply: an explicit `--view` name (which must
-/// exist), otherwise the user's saved default view, otherwise none.
+/// exist), otherwise the user's saved default view, otherwise none. Returns
+/// the view together with its name so warnings can point at the right view.
 pub(crate) fn resolve_active_view(
     root: &Path,
     project_id: &str,
     view_name: Option<&str>,
-) -> Result<Option<ProjectView>> {
+) -> Result<Option<(String, ProjectView)>> {
     let views = load_views(root, project_id)?;
     match view_name {
         Some(name) => {
@@ -349,13 +350,16 @@ pub(crate) fn resolve_active_view(
                     out::repo(&name)
                 )
             })?;
-            Ok(Some(view))
+            Ok(Some((name, view)))
         }
         // A dangling default is ignored rather than blocking `bundle start`.
-        None => Ok(views
-            .default_view
-            .as_ref()
-            .and_then(|name| views.views.get(name).cloned())),
+        None => Ok(views.default_view.as_ref().and_then(|name| {
+            views
+                .views
+                .get(name)
+                .cloned()
+                .map(|view| (name.clone(), view))
+        })),
     }
 }
 
@@ -368,7 +372,7 @@ pub(crate) fn resolve_view_repos(
     project: &KnitProject,
     repo_ids: &[String],
     all_repos: bool,
-    view: Option<&ProjectView>,
+    view: Option<(&str, &ProjectView)>,
     include: &[String],
     exclude: &[String],
 ) -> Result<Vec<ProjectRepoEntry>> {
@@ -389,14 +393,14 @@ pub(crate) fn resolve_view_repos(
     } else {
         // An absolute view (`base: none`) seeds empty; its include list is the
         // complete shape and never absorbs default-set changes.
-        if view.map_or(true, |view| view.base.is_default()) {
+        if view.map_or(true, |(_, view)| view.base.is_default()) {
             for repo in &project.repos {
                 if repo.include_by_default {
                     selected.insert(repo.id.clone());
                 }
             }
         }
-        if let Some(view) = view {
+        if let Some((view_name, view)) = view {
             // Saved views are user data that can outlive project membership
             // changes (a repo removed after the view was saved, or a synced
             // teammate view naming a repo this project never tracked), so
@@ -406,14 +410,14 @@ pub(crate) fn resolve_view_repos(
                 if let Some(repo) = project_repo_opt(project, repo_id) {
                     selected.insert(repo.id.clone());
                 } else {
-                    warn_dangling_view_repo(project, repo_id);
+                    warn_dangling_view_repo(project, view_name, repo_id);
                 }
             }
             for repo_id in &view.exclude {
                 if let Some(repo) = project_repo_opt(project, repo_id) {
                     selected.remove(&repo.id);
                 } else {
-                    warn_dangling_view_repo(project, repo_id);
+                    warn_dangling_view_repo(project, view_name, repo_id);
                 }
             }
         }
@@ -459,13 +463,15 @@ fn project_repo_opt<'a>(project: &'a KnitProject, repo_id: &str) -> Option<&'a P
     project.repos.iter().find(|repo| repo.id == repo_id)
 }
 
-fn warn_dangling_view_repo(project: &KnitProject, repo_id: &str) {
+fn warn_dangling_view_repo(project: &KnitProject, view_name: &str, repo_id: &str) {
     crate::human!(
-        "{} saved view references repo {}, which project {} no longer tracks; skipping. \
-         Remove it with `knit view unset {}`.",
+        "{} saved view {} references repo {}, which project {} no longer tracks; skipping. \
+         Remove it with `knit view unset {} {}`.",
         out::warn("warning:"),
+        out::repo(view_name),
         out::repo(repo_id),
         out::repo(&project.id),
+        view_name,
         repo_id
     );
 }

--- a/src/commands/init.rs
+++ b/src/commands/init.rs
@@ -397,11 +397,24 @@ pub(crate) fn resolve_view_repos(
             }
         }
         if let Some(view) = view {
+            // Saved views are user data that can outlive project membership
+            // changes (a repo removed after the view was saved, or a synced
+            // teammate view naming a repo this project never tracked), so
+            // dangling entries are skipped with a warning instead of
+            // blocking bundle creation.
             for repo_id in &view.include {
-                selected.insert(project_repo(project, repo_id)?.id.clone());
+                if let Some(repo) = project_repo_opt(project, repo_id) {
+                    selected.insert(repo.id.clone());
+                } else {
+                    warn_dangling_view_repo(project, repo_id);
+                }
             }
             for repo_id in &view.exclude {
-                selected.remove(&project_repo(project, repo_id)?.id);
+                if let Some(repo) = project_repo_opt(project, repo_id) {
+                    selected.remove(&repo.id);
+                } else {
+                    warn_dangling_view_repo(project, repo_id);
+                }
             }
         }
     }
@@ -436,6 +449,25 @@ fn project_repo<'a>(project: &'a KnitProject, repo_id: &str) -> Result<&'a Proje
                 out::repo(&repo_id)
             )
         })
+}
+
+/// Like [`project_repo`] but tolerant: view deltas may reference repos the
+/// project no longer tracks, which callers surface as a warning rather than
+/// an error.
+fn project_repo_opt<'a>(project: &'a KnitProject, repo_id: &str) -> Option<&'a ProjectRepoEntry> {
+    let repo_id = slugify(repo_id);
+    project.repos.iter().find(|repo| repo.id == repo_id)
+}
+
+fn warn_dangling_view_repo(project: &KnitProject, repo_id: &str) {
+    crate::human!(
+        "{} saved view references repo {}, which project {} no longer tracks; skipping. \
+         Remove it with `knit view unset {}`.",
+        out::warn("warning:"),
+        out::repo(repo_id),
+        out::repo(&project.id),
+        repo_id
+    );
 }
 
 fn write_agents_md(root: &Path) -> Result<std::path::PathBuf> {

--- a/src/commands/project.rs
+++ b/src/commands/project.rs
@@ -8,7 +8,7 @@ use crate::model::{
 use crate::output as out;
 use crate::store::{
     acquire_named_lock, find_knit_root, load_config, project_path, read_json, save_config,
-    write_json,
+    views_path, write_json,
 };
 use crate::time::now_iso;
 use anyhow::{bail, Context, Result};
@@ -269,6 +269,19 @@ pub fn remove_project(name: &str, force: bool) -> Result<()> {
     }
 
     fs::remove_file(&path).with_context(|| format!("failed to remove {}", path.display()))?;
+    // The project's saved views are meaningless without it; leaving the file
+    // behind would resurrect stale views if a project with the same id is
+    // created later.
+    let views_file = views_path(&root, &project_id);
+    if views_file.exists() {
+        fs::remove_file(&views_file)
+            .with_context(|| format!("failed to remove {}", views_file.display()))?;
+        println!(
+            "{} {}",
+            out::heading("Removed views:"),
+            out::path(views_file.display())
+        );
+    }
     let mut config = load_config(&root)?;
     if config.active_project.as_deref() == Some(project_id.as_str()) {
         config.active_project = None;
@@ -322,12 +335,26 @@ pub fn remove_project_repos(name: &str, repos: &[String]) -> Result<()> {
     project.updated_at = now_iso();
     write_json(&path, &project)?;
 
+    // Maintain saved views at the removal point so they never reference repos
+    // the project can no longer select.
+    let pruned =
+        crate::commands::view::prune_removed_repos_from_views(&root, &project_id, &targets)?;
+
     for target in &targets {
         println!(
             "{} {} {}",
             out::heading("Removed repo:"),
             out::repo(target),
             out::muted(format!("from project {project_id}"))
+        );
+    }
+    for target in &pruned {
+        println!(
+            "{} {} {} {}",
+            out::heading("Views:"),
+            out::movement("pruned"),
+            out::repo(target),
+            out::muted("from saved view(s)")
         );
     }
     Ok(())

--- a/src/commands/remote/pull.rs
+++ b/src/commands/remote/pull.rs
@@ -372,6 +372,15 @@ fn reconcile_project_repositories(
         write_json(&project_path(root, &project.id), project)?;
     }
 
+    // Maintain saved views at the removal point: a membership removal must
+    // prune the repo from the user's views, not leave stale entries that
+    // resolution has to skip around.
+    let pruned_from_views = if removed.is_empty() {
+        Vec::new()
+    } else {
+        crate::commands::view::prune_removed_repos_from_views(root, &project.id, &removed)?
+    };
+
     for id in &added {
         println!(
             "{} {} {}",
@@ -386,6 +395,15 @@ fn reconcile_project_repositories(
             out::heading("Project repo:"),
             out::movement("removed"),
             out::repo(id)
+        );
+    }
+    for id in &pruned_from_views {
+        println!(
+            "{} {} {} {}",
+            out::heading("Views:"),
+            out::movement("pruned"),
+            out::repo(id),
+            out::muted("from saved view(s)")
         );
     }
     for (id, reason) in &failed {

--- a/src/commands/shape.rs
+++ b/src/commands/shape.rs
@@ -126,7 +126,14 @@ pub fn bundle_apply_view(
         .context("This bundle is not based on a project, so views cannot be applied.")?;
     let project = load_project_by_id(&active.root, &project_id)?;
     let view = resolve_active_view(&active.root, &project_id, Some(name))?;
-    let target = resolve_view_repos(&project, &[], false, view.as_ref(), &[], &[])?;
+    let target = resolve_view_repos(
+        &project,
+        &[],
+        false,
+        view.as_ref().map(|(name, view)| (name.as_str(), view)),
+        &[],
+        &[],
+    )?;
 
     let target_ids: Vec<String> = target.iter().map(|repo| repo.id.clone()).collect();
     let current_ids: Vec<String> = active.bundle.repos.iter().map(|r| r.id.clone()).collect();

--- a/src/commands/view.rs
+++ b/src/commands/view.rs
@@ -48,7 +48,14 @@ pub fn show_view(name: Option<&str>, project: Option<&str>, repos: bool) -> Resu
     if repos {
         let project_artifact = load_project_by_id(&root, &project_id)?;
         let view = resolve_active_view(&root, &project_id, name)?;
-        let resolved = resolve_view_repos(&project_artifact, &[], false, view.as_ref(), &[], &[])?;
+        let resolved = resolve_view_repos(
+            &project_artifact,
+            &[],
+            false,
+            view.as_ref().map(|(name, view)| (name.as_str(), view)),
+            &[],
+            &[],
+        )?;
         if resolved.is_empty() {
             println!("{}", out::muted("(no repos)"));
         }
@@ -166,7 +173,7 @@ pub fn freeze_view(name: &str, project: Option<&str>) -> Result<()> {
         return Ok(());
     }
     let include: Vec<String> =
-        resolve_view_repos(&project_artifact, &[], false, Some(view), &[], &[])?
+        resolve_view_repos(&project_artifact, &[], false, Some((&name, view)), &[], &[])?
             .into_iter()
             .map(|repo| repo.id)
             .collect();
@@ -208,9 +215,17 @@ pub fn view_exclude(name: &str, repos: &[String], project: Option<&str>) -> Resu
 
 pub fn view_unset(name: &str, repos: &[String], project: Option<&str>) -> Result<()> {
     let (root, project_id) = resolve_project(project)?;
-    let project_artifact = load_project_by_id(&root, &project_id)?;
     let name = slugify(name);
-    let ids = normalize_ids(&project_artifact, repos)?;
+    // Unset is removal, so the repo need not still be in the project: this is
+    // exactly how a dangling view entry (repo removed from the project, or a
+    // view synced from another machine) gets cleaned up.
+    let mut ids: Vec<String> = Vec::new();
+    for repo in expand_repo_selectors(repos) {
+        let id = slugify(&repo);
+        if !ids.contains(&id) {
+            ids.push(id);
+        }
+    }
 
     let _lock = acquire_named_lock(&root, &format!("views-{project_id}"))?;
     let mut views = load_views(&root, &project_id)?;

--- a/src/commands/view.rs
+++ b/src/commands/view.rs
@@ -16,7 +16,7 @@ use crate::store::{
 };
 use crate::time::now_iso;
 use anyhow::{bail, Context, Result};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 
 pub fn list_views(project: Option<&str>) -> Result<()> {
@@ -262,6 +262,43 @@ pub fn remove_view(name: &str, project: Option<&str>) -> Result<()> {
     save_views(&root, &views)?;
     println!("{} {}", out::movement("removed view"), out::repo(&name));
     Ok(())
+}
+
+/// Views are maintained state, not a rotting cache: when a repo leaves its
+/// project, every saved view's references to it are pruned at the removal
+/// point so resolution never has to reconcile stale ids from local edits.
+/// (Tolerant resolution stays as the safety net for views synced in from
+/// other machines, which can skew from local membership.) Returns the repo
+/// ids that were actually present in at least one view.
+pub fn prune_removed_repos_from_views(
+    root: &Path,
+    project_id: &str,
+    repo_ids: &[String],
+) -> Result<Vec<String>> {
+    let ids: Vec<String> = repo_ids.iter().map(|id| slugify(id)).collect();
+    let _lock = acquire_named_lock(root, &format!("views-{project_id}"))?;
+    let mut views = load_views(root, project_id)?;
+    let mut pruned: Vec<String> = Vec::new();
+    for view in views.views.values_mut() {
+        for id in &ids {
+            if list_remove(&mut view.include, id) | list_remove(&mut view.exclude, id)
+                && !pruned.contains(id)
+            {
+                pruned.push(id.clone());
+            }
+        }
+    }
+    if !pruned.is_empty() {
+        views.updated_at = now_iso();
+        save_views(root, &views)?;
+    }
+    Ok(pruned)
+}
+
+fn list_remove(list: &mut Vec<String>, id: &str) -> bool {
+    let before = list.len();
+    list.retain(|existing| existing != id);
+    before != list.len()
 }
 
 pub fn edit_views(project: Option<&str>) -> Result<()> {

--- a/tests/project.rs
+++ b/tests/project.rs
@@ -586,6 +586,68 @@ fn views_apply_default_and_named_shapes_on_bundle_start() {
 }
 
 #[test]
+fn views_skip_repos_removed_from_the_project() {
+    let root = unique_temp_dir();
+    let workspace = root.join("workspace");
+    setup_three_repo_project(&workspace, &root);
+
+    // core = defaults minus frontend; wide names frontend explicitly.
+    knit(
+        &workspace,
+        ["view", "save", "core", "--exclude", "frontend"],
+    );
+    knit(
+        &workspace,
+        ["view", "save", "wide", "--include", "frontend"],
+    );
+    knit(&workspace, ["view", "default", "core"]);
+
+    // frontend leaves the project after the views were saved; the saved
+    // entries now dangle.
+    knit(
+        &workspace,
+        ["project", "remove", "demo", "--repo", "frontend"],
+    );
+
+    // Default and named views skip the dangling entries with a warning
+    // instead of blocking bundle creation.
+    let started = knit(&workspace, ["bundle", "stale view feature"]);
+    assert!(started.contains("no longer tracks"), "{started}");
+    assert_eq!(
+        bundle_repo_ids(&workspace, "stale-view-feature"),
+        vec!["backend"]
+    );
+
+    let named = knit(
+        &workspace,
+        ["bundle", "stale wide feature", "--view", "wide"],
+    );
+    assert!(named.contains("no longer tracks"), "{named}");
+    assert_eq!(
+        bundle_repo_ids(&workspace, "stale-wide-feature"),
+        vec!["backend"]
+    );
+
+    // `view show --repos` resolves through the same tolerant path.
+    let shown = knit(&workspace, ["view", "show", "wide", "--repos"]);
+    assert!(shown.contains("no longer tracks"), "{shown}");
+    let repos: Vec<&str> = shown
+        .lines()
+        .filter(|line| !line.starts_with("warning:"))
+        .collect();
+    assert_eq!(repos, vec!["backend"], "{shown}");
+
+    // Ad-hoc flags still fail hard: the user just typed the repo id.
+    let error = knit_fails(
+        &workspace,
+        ["bundle", "ghost feature", "--include", "ghost"],
+    );
+    assert!(error.contains("has no repo named ghost"), "{error}");
+
+    fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
 fn absolute_views_ignore_the_default_set() {
     let root = unique_temp_dir();
     let workspace = root.join("workspace");

--- a/tests/project.rs
+++ b/tests/project.rs
@@ -602,17 +602,30 @@ fn views_skip_repos_removed_from_the_project() {
     );
     knit(&workspace, ["view", "default", "core"]);
 
-    // frontend leaves the project after the views were saved; the saved
-    // entries now dangle.
-    knit(
+    // frontend leaves the project after the views were saved; the removal
+    // maintains the views instead of leaving the entries to rot.
+    let removed = knit(
         &workspace,
         ["project", "remove", "demo", "--repo", "frontend"],
     );
+    assert!(removed.contains("pruned"), "{removed}");
+    assert!(removed.contains("frontend"), "{removed}");
+    let core: Value = serde_json::from_str(&knit(&workspace, ["view", "show", "core"])).unwrap();
+    assert!(
+        !core.to_string().contains("frontend"),
+        "{}",
+        core.to_string()
+    );
+    let wide: Value = serde_json::from_str(&knit(&workspace, ["view", "show", "wide"])).unwrap();
+    assert!(
+        !wide.to_string().contains("frontend"),
+        "{}",
+        wide.to_string()
+    );
 
-    // Default and named views skip the dangling entries with a warning
-    // instead of blocking bundle creation.
+    // With views maintained, bundle starts resolve cleanly — no warnings.
     let started = knit(&workspace, ["bundle", "stale view feature"]);
-    assert!(started.contains("no longer tracks"), "{started}");
+    assert!(!started.contains("no longer tracks"), "{started}");
     assert_eq!(
         bundle_repo_ids(&workspace, "stale-view-feature"),
         vec!["backend"]
@@ -622,13 +635,25 @@ fn views_skip_repos_removed_from_the_project() {
         &workspace,
         ["bundle", "stale wide feature", "--view", "wide"],
     );
-    assert!(named.contains("no longer tracks"), "{named}");
+    assert!(!named.contains("no longer tracks"), "{named}");
     assert_eq!(
         bundle_repo_ids(&workspace, "stale-wide-feature"),
         vec!["backend"]
     );
 
-    // `view show --repos` resolves through the same tolerant path.
+    // Ad-hoc flags still fail hard: the user just typed the repo id.
+    let error = knit_fails(
+        &workspace,
+        ["bundle", "ghost feature", "--include", "ghost"],
+    );
+    assert!(error.contains("has no repo named ghost"), "{error}");
+
+    // Tolerant resolution stays as the safety net for views synced in from
+    // other machines: a hand-written dangling entry warns but resolves.
+    let views_path = workspace.join(".knit/views/demo.views.json");
+    let mut views: Value = serde_json::from_str(&fs::read_to_string(&views_path).unwrap()).unwrap();
+    views["views"]["wide"]["exclude"] = json!(["frontend"]);
+    fs::write(&views_path, serde_json::to_string_pretty(&views).unwrap()).unwrap();
     let shown = knit(&workspace, ["view", "show", "wide", "--repos"]);
     assert!(shown.contains("no longer tracks"), "{shown}");
     let repos: Vec<&str> = shown
@@ -637,12 +662,11 @@ fn views_skip_repos_removed_from_the_project() {
         .collect();
     assert_eq!(repos, vec!["backend"], "{shown}");
 
-    // Ad-hoc flags still fail hard: the user just typed the repo id.
-    let error = knit_fails(
-        &workspace,
-        ["bundle", "ghost feature", "--include", "ghost"],
-    );
-    assert!(error.contains("has no repo named ghost"), "{error}");
+    // Removing the whole project takes its saved views with it, so a future
+    // project with the same id starts from a clean slate.
+    let gone = knit(&workspace, ["project", "remove", "demo", "--force"]);
+    assert!(gone.contains("Removed views:"), "{gone}");
+    assert!(!views_path.exists());
 
     fs::remove_dir_all(root).unwrap();
 }

--- a/tests/project.rs
+++ b/tests/project.rs
@@ -662,6 +662,14 @@ fn views_skip_repos_removed_from_the_project() {
         .collect();
     assert_eq!(repos, vec!["backend"], "{shown}");
 
+    // The warning's suggested command must be runnable as printed, even
+    // though the repo is no longer in the project.
+    assert!(shown.contains("knit view unset wide frontend"), "{shown}");
+    let unset = knit(&workspace, ["view", "unset", "wide", "frontend"]);
+    assert!(unset.contains("updated view"), "{unset}");
+    let reshown = knit(&workspace, ["view", "show", "wide", "--repos"]);
+    assert!(!reshown.contains("no longer tracks"), "{reshown}");
+
     // Removing the whole project takes its saved views with it, so a future
     // project with the same id starts from a clean slate.
     let gone = knit(&workspace, ["project", "remove", "demo", "--force"]);

--- a/tests/sync.rs
+++ b/tests/sync.rs
@@ -2229,6 +2229,47 @@ fn pull_reconcile_applies_adds_and_removals_together() {
 }
 
 #[test]
+fn pull_reconcile_prunes_removed_repos_from_saved_views() {
+    let root = unique_temp_dir();
+    let workspace = reconcile_scaffold(&root, &["backend", "oldrepo"]);
+
+    // A saved view references oldrepo; the membership removal below must
+    // prune it, not leave a stale entry resolution has to skip around.
+    knit(&workspace, ["view", "save", "core", "--exclude", "oldrepo"]);
+
+    let export = membership_export(
+        serde_json::json!([
+            {"id": "backend", "path": "", "remote": root.join("backend").to_str().unwrap(), "baseBranch": "main"},
+        ]),
+        serde_json::json!([
+            {"localId": "backend", "name": "backend", "remoteUrl": root.join("backend").to_str().unwrap(), "metadata": {}},
+        ]),
+        0,
+    );
+    let base_url = spawn_fake_remote_with_body(export);
+    knit(&workspace, ["remote", "add", "hosted", &base_url]);
+    let env = [("KNIT_REMOTE_TOKEN", "test-token")];
+
+    let output = knit_with_env(&workspace, ["pull", "--bundles"], &env);
+    assert!(output.contains("removed"), "{output}");
+    assert!(output.contains("oldrepo"), "{output}");
+    assert!(output.contains("pruned"), "{output}");
+
+    let views_path = workspace.join(".knit/views/demo.views.json");
+    let views: serde_json::Value =
+        serde_json::from_str(&fs::read_to_string(&views_path).unwrap()).unwrap();
+    let raw = views.to_string();
+    assert!(!raw.contains("oldrepo"), "{raw}");
+
+    // The pruned view starts bundles without warnings.
+    let started = knit(&workspace, ["bundle", "post pull feature"]);
+    assert!(!started.contains("no longer tracks"), "{started}");
+    assert_eq!(project_repo_ids(&workspace), vec!["backend"]);
+
+    fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
 fn pull_reconcile_skips_removals_on_incomplete_export() {
     let root = unique_temp_dir();
     let workspace = reconcile_scaffold(&root, &["backend", "oldrepo"]);


### PR DESCRIPTION
<!-- BEGIN KNIT BUNDLE -->
## Knit Bundle

This PR is part of Knit bundle `saved-views-tolerate-repos-removed-from-the-project`.

See the other review objects in this bundle:
- `knit`: https://github.com/knit-cli/knit/pull/159 (this PR)

Bundle id: `saved-views-tolerate-repos-removed-from-the-project`
Bundle title: Saved views tolerate repos removed from the project
<!-- END KNIT BUNDLE -->