### PR TITLE
Prepare 0.1.0-alpha.9 release (knit)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -591,7 +591,7 @@ dependencies = [
 
 [[package]]
 name = "knit-cli"
-version = "0.1.0-alpha.8"
+version = "0.1.0-alpha.9"
 dependencies = [
  "anyhow",
  "chrono",
@@ -609,7 +609,7 @@ dependencies = [
 
 [[package]]
 name = "knit-runtime"
-version = "0.1.0-alpha.8"
+version = "0.1.0-alpha.9"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 # Published as `knit-cli` (the crates.io name `knit` is taken); the installed
 # binary is still `knit`.
 name = "knit-cli"
-version = "0.1.0-alpha.8"
+version = "0.1.0-alpha.9"
 edition = "2021"
 license = "Apache-2.0"
 description = "A local-first CLI for coordinating cross-repo feature bundles."
@@ -26,7 +26,7 @@ members = [".", "crates/knit-runtime"]
 
 [dependencies]
 anyhow = "1"
-knit-runtime = { version = "0.1.0-alpha.8", path = "crates/knit-runtime" }
+knit-runtime = { version = "0.1.0-alpha.9", path = "crates/knit-runtime" }
 chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4.5", features = ["derive"] }
 ctrlc = { version = "3.4", features = ["termination"] }

--- a/crates/knit-runtime/Cargo.toml
+++ b/crates/knit-runtime/Cargo.toml
@@ -4,7 +4,7 @@
 # version-control shaped; the CLI compiles it in and adapts bundle state into
 # the crate's RuntimeContext contract.
 name = "knit-runtime"
-version = "0.1.0-alpha.8"
+version = "0.1.0-alpha.9"
 edition = "2021"
 license = "Apache-2.0"
 description = "Per-bundle docker-compose runtime for knit cross-repo bundles."

--- a/dist/README.md
+++ b/dist/README.md
@@ -12,9 +12,9 @@ Templates for publishing knit to package managers. The canonical release flow:
 # 2. Tag and push — triggers .github/workflows/release.yml, which builds
 #    macOS (x64/arm64), Linux (x64/arm64 musl), and Windows (x64) binaries
 #    and uploads them (plus .sha256 files) to a GitHub release. A tag
-#    containing `-` (e.g. v0.1.0-alpha.8) is marked as a pre-release.
-git tag v0.1.0-alpha.8
-git push origin v0.1.0-alpha.8
+#    containing `-` (e.g. v0.1.0-alpha.9) is marked as a pre-release.
+git tag v0.1.0-alpha.9
+git push origin v0.1.0-alpha.9
 
 # 3. Wait for the Release workflow to finish:
 gh run watch --repo knit-cli/knit "$(gh run list --repo knit-cli/knit --workflow Release --limit 1 --json databaseId -q '.[0].databaseId')"
@@ -39,8 +39,8 @@ Users install with `brew install knit-cli/tap/knit`. To release:
 # If that secret is not configured, fill the formula from the release assets:
 #   - bump the `version` stanza in homebrew/knit.rb (URLs derive from it)
 #   - replace each sha256 with the matching .sha256 asset, e.g.:
-gh release view v0.1.0-alpha.8 --repo knit-cli/knit --json assets -q '.assets[].name'
-curl -sL https://github.com/knit-cli/knit/releases/download/v0.1.0-alpha.8/knit-v0.1.0-alpha.8-aarch64-apple-darwin.sha256
+gh release view v0.1.0-alpha.9 --repo knit-cli/knit --json assets -q '.assets[].name'
+curl -sL https://github.com/knit-cli/knit/releases/download/v0.1.0-alpha.9/knit-v0.1.0-alpha.9-aarch64-apple-darwin.sha256
 
 # Copy homebrew/knit.rb into the tap as Formula/knit.rb, commit, push:
 #   github.com/knit-cli/homebrew-tap

--- a/dist/homebrew/knit.rb
+++ b/dist/homebrew/knit.rb
@@ -2,7 +2,7 @@ class Knit < Formula
   desc "Local-first CLI for coordinating cross-repo feature bundles"
   homepage "https://github.com/knit-cli/knit"
   license "Apache-2.0"
-  version "0.1.0-alpha.8"
+  version "0.1.0-alpha.9"
 
   on_macos do
     if Hardware::CPU.arm?

--- a/dist/scoop/knit.json
+++ b/dist/scoop/knit.json
@@ -1,11 +1,11 @@
 {
-    "version": "0.1.0-alpha.8",
+    "version": "0.1.0-alpha.9",
     "description": "Local-first CLI for coordinating cross-repo feature bundles",
     "homepage": "https://github.com/knit-cli/knit",
     "license": "Apache-2.0",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/knit-cli/knit/releases/download/v0.1.0-alpha.8/knit-v0.1.0-alpha.8-x86_64-pc-windows-msvc.zip",
+            "url": "https://github.com/knit-cli/knit/releases/download/v0.1.0-alpha.9/knit-v0.1.0-alpha.9-x86_64-pc-windows-msvc.zip",
             "hash": "REPLACE_WITH_SHA256"
         }
     },

--- a/dist/winget/marc-merino.knit.yaml
+++ b/dist/winget/marc-merino.knit.yaml
@@ -1,5 +1,5 @@
 PackageIdentifier: marc-merino.knit
-PackageVersion: 0.1.0-alpha.8
+PackageVersion: 0.1.0-alpha.9
 PackageLocale: en-US
 Publisher: marc-merino
 PackageName: knit
@@ -12,7 +12,7 @@ Installers:
     NestedInstallerFiles:
       - RelativeFilePath: knit.exe
         PortableCommandAlias: knit
-    InstallerUrl: https://github.com/knit-cli/knit/releases/download/v0.1.0-alpha.8/knit-v0.1.0-alpha.8-x86_64-pc-windows-msvc.zip
+    InstallerUrl: https://github.com/knit-cli/knit/releases/download/v0.1.0-alpha.9/knit-v0.1.0-alpha.9-x86_64-pc-windows-msvc.zip
     InstallerSha256: REPLACE_WITH_SHA256
 ManifestType: singleton
 ManifestVersion: 1.6.0


### PR DESCRIPTION
<!-- BEGIN KNIT BUNDLE -->
## Knit Bundle

This PR is part of Knit bundle `prepare-0-1-0-alpha-9-release`.

See the other review objects in this bundle:
- `knit`: https://github.com/knit-cli/knit/pull/168 (this PR)

Bundle id: `prepare-0-1-0-alpha-9-release`
Bundle title: Prepare 0.1.0-alpha.9 release
<!-- END KNIT BUNDLE -->