### PR TITLE
Prepare the 0.1.0-alpha.14 release (knit)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -591,7 +591,7 @@ dependencies = [
 
 [[package]]
 name = "knit-cli"
-version = "0.1.0-alpha.13"
+version = "0.1.0-alpha.14"
 dependencies = [
  "anyhow",
  "chrono",
@@ -609,7 +609,7 @@ dependencies = [
 
 [[package]]
 name = "knit-runtime"
-version = "0.1.0-alpha.13"
+version = "0.1.0-alpha.14"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 # Published as `knit-cli` (the crates.io name `knit` is taken); the installed
 # binary is still `knit`.
 name = "knit-cli"
-version = "0.1.0-alpha.13"
+version = "0.1.0-alpha.14"
 edition = "2021"
 license = "Apache-2.0"
 description = "A local-first CLI for coordinating cross-repo feature bundles."
@@ -26,7 +26,7 @@ members = [".", "crates/knit-runtime"]
 
 [dependencies]
 anyhow = "1"
-knit-runtime = { version = "0.1.0-alpha.13", path = "crates/knit-runtime" }
+knit-runtime = { version = "0.1.0-alpha.14", path = "crates/knit-runtime" }
 chrono = { version = "0.4", features = ["serde"] }
 clap = { version = "4.5", features = ["derive"] }
 ctrlc = { version = "3.4", features = ["termination"] }

--- a/crates/knit-runtime/Cargo.toml
+++ b/crates/knit-runtime/Cargo.toml
@@ -4,7 +4,7 @@
 # version-control shaped; the CLI compiles it in and adapts bundle state into
 # the crate's RuntimeContext contract.
 name = "knit-runtime"
-version = "0.1.0-alpha.13"
+version = "0.1.0-alpha.14"
 edition = "2021"
 license = "Apache-2.0"
 description = "Per-bundle docker-compose runtime for knit cross-repo bundles."

--- a/dist/README.md
+++ b/dist/README.md
@@ -12,9 +12,9 @@ Templates for publishing knit to package managers. The canonical release flow:
 # 2. Tag and push — triggers .github/workflows/release.yml, which builds
 #    macOS (x64/arm64), Linux (x64/arm64 musl), and Windows (x64) binaries
 #    and uploads them (plus .sha256 files) to a GitHub release. A tag
-#    containing `-` (e.g. v0.1.0-alpha.13) is marked as a pre-release.
-git tag v0.1.0-alpha.13
-git push origin v0.1.0-alpha.13
+#    containing `-` (e.g. v0.1.0-alpha.14) is marked as a pre-release.
+git tag v0.1.0-alpha.14
+git push origin v0.1.0-alpha.14
 
 # 3. Wait for the Release workflow to finish:
 gh run watch --repo knit-cli/knit "$(gh run list --repo knit-cli/knit --workflow Release --limit 1 --json databaseId -q '.[0].databaseId')"
@@ -39,8 +39,8 @@ Users install with `brew install knit-cli/tap/knit`. To release:
 # If that secret is not configured, fill the formula from the release assets:
 #   - bump the `version` stanza in homebrew/knit.rb (URLs derive from it)
 #   - replace each sha256 with the matching .sha256 asset, e.g.:
-gh release view v0.1.0-alpha.13 --repo knit-cli/knit --json assets -q '.assets[].name'
-curl -sL https://github.com/knit-cli/knit/releases/download/v0.1.0-alpha.13/knit-v0.1.0-alpha.13-aarch64-apple-darwin.sha256
+gh release view v0.1.0-alpha.14 --repo knit-cli/knit --json assets -q '.assets[].name'
+curl -sL https://github.com/knit-cli/knit/releases/download/v0.1.0-alpha.14/knit-v0.1.0-alpha.14-aarch64-apple-darwin.sha256
 
 # Copy homebrew/knit.rb into the tap as Formula/knit.rb, commit, push:
 #   github.com/knit-cli/homebrew-tap


### PR DESCRIPTION
<!-- BEGIN KNIT BUNDLE -->
## Knit Bundle

This PR is part of Knit bundle `prepare-the-0-1-0-alpha-14-release`.

See the other review objects in this bundle:
- `knit`: https://github.com/knit-cli/knit/pull/182 (this PR)

Bundle id: `prepare-the-0-1-0-alpha-14-release`
Bundle title: Prepare the 0.1.0-alpha.14 release
<!-- END KNIT BUNDLE -->