### PR TITLE
Checkpoint and hand off bundles between machines

### DIFF
--- a/docs/change-group-schema.md
+++ b/docs/change-group-schema.md
@@ -251,3 +251,35 @@ Project files can carry a reusable `landing` template with merge priority, merge
 A land plan step is `merge_pr` (merge a recorded review object), `merge_branch` (merge the bundle's feature branch into that step's `targetBranch` and push it, which is how a bundle reaches an environment it only passes through), `wait_checks`, `run`, or `deploy`. `knit land apply` and `knit land resume` write run logs under `.knit/land-runs/`. Run files are operational logs, not the source of truth for code state. The bundle records a `feature.landed` summary node after every step succeeds. That node carries an optional `landing` object — `terminal`, plus the `lane` or `targetBranch` it went to — which says whether the landing finished the bundle; nodes written before this field existed always landed on the configured bases and read as terminal. A successful `knit land apply` into a terminal destination then archives the bundle with a `feature.archived` node while preserving the landed node for log selectors and provider reverts. A landing into an intermediate destination records only the landed node and leaves the bundle open. A later `knit revert <feature.landed> --apply` can create provider-native revert PRs across the landed repos and records that follow-up review group as `pr.revert`.
 
 Gloss should treat the bundle as read-only input. Gloss can analyze the current `headNodeId`, a specific `commit.group` node, or the full current bundle.
+
+## Handoff attribution and requirements
+
+New ledger nodes carry optional `origin` (`environmentId`, `hostname`,
+`platform`). `KNIT_ENVIRONMENT_ID` supplies the stable environment identity;
+plain CLI usage records hostname and normalized OS/architecture. Old nodes
+remain unchanged.
+
+`checkpoint` references its normal commit group via `commitGroupId`.
+`handoff.out` and `handoff.in` carry a structured `handoff` payload:
+
+```json
+{
+  "id": "handoff-unique-id",
+  "source": { "hostname": "laptop", "platform": "darwin/arm64" },
+  "destination": "vps",
+  "checkpointCommitGroupIds": ["kg_checkpoint"],
+  "sizeMib": 2048
+}
+```
+
+The acceptance copies the same payload and adds `outNodeId`, referencing its
+outgoing node. Incoming nodes also set `targetNodeId` to that outgoing node;
+an outgoing node sets `targetNodeId` to the preceding handoff node, if any.
+These causal links make the advisory location independent of array order or
+clock skew. A single outgoing tip means `pending`; an incoming tip means
+`active`. Competing tips mean `conflict`, never an arbitrarily chosen owner.
+This is an advisory record, not a distributed lock.
+
+Projects may declare `requirements` with `platforms`, `tools` (name,
+minVersion, optional, and `for: "runtime"`), `diskMib`, `memoryMib`, `agents`,
+and `env` variable names. Requirement declarations contain no secret values.

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -899,3 +899,50 @@ See [architecture.md](architecture.md) for the module boundaries and test layout
 - Additional self-hosted forge variants and pagination hardening
 - Better detection of existing registered worktrees
 - Optional bundle export/import flows for handoff to Gloss
+
+## Continue a bundle on another machine
+
+`knit handoff` keeps the same feature branches and ledger while moving editing to
+another workspace. Each agent continuation starts a new thread; provider session
+files, credentials, ignored build outputs, and running stacks remain on their host.
+
+```sh
+knit --bundle feature-a handoff out --to vps -m "Continue the parser work"
+knit handoff probe owner/project feature-a --workspace ./workspace
+knit handoff in owner/project feature-a --workspace ./workspace
+knit handoff status --json
+```
+
+Return with the same `out` and `in` verbs. `out` stages all nonignored files and
+commits dirty repositories, records a checkpoint, pushes feature branches, then
+publishes a typed `handoff.out` node. Git hooks and signing still apply. A partial
+commit failure records successful repositories before returning an error. Retry
+`out` to finish an interrupted publication without duplicating its checkpoint.
+Once publication succeeds, a second `out` refuses unless `--force` is supplied.
+`status --json` includes the current acknowledged outgoing report under `out`,
+allowing clients to recover a lost response.
+
+`in` checks readiness again, clones missing repositories, materializes the bundle,
+and publishes `handoff.in`. An interrupted clone or acceptance can be retried;
+existing dirty checkouts, wrong repository origins, unfinished Git operations,
+and divergent ledgers block acceptance. Ledger divergence uses the existing
+`knit --bundle <slug> pull --merge` recovery. Branch divergence is resolved with
+Git before retrying. Location is advisory, derived from causal handoff links;
+competing acceptances are shown as a conflict rather than choosing a host by clock.
+
+Project requirements are declared in `knit.project.json` under `requirements`:
+`platforms`, `tools` (`name`, `minVersion`, `optional`, `for: "runtime"`), `diskMib`,
+`memoryMib`, `agents`, and `env`. Probe emits `ok`, `warn`, or `fail` per check and
+returns exit 2 for a failed verdict. Optional/runtime tools and low available
+memory warn. Required editing tools, unsupported platforms, missing named env
+variables, disk shortage, authentication, and Git access fail. Environment values
+are never printed. Agent availability is reported as unverifiable by the CLI.
+Before the first publication, probe can check the exported project's requirements
+and repositories and warns that the bundle-specific checkpoint is not available.
+
+`in --force` can bypass declared tool, platform, disk, and environment readiness
+failures; it cannot bypass credentials, schema compatibility, local changes, or
+handoff conflicts. A valid sync remote must exist in user-global config. Tokens
+remain in that config; handoff does not copy them into the new workspace. SSH
+origins may use HTTPS when SSH fails and the exact forge host has a Knit credential
+helper; `knit clone --prefer-https` exposes the same transport fallback.

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -919,6 +919,9 @@ publishes a typed `handoff.out` node. Git hooks and signing still apply. A parti
 commit failure records successful repositories before returning an error. Retry
 `out` to finish an interrupted publication without duplicating its checkpoint.
 Once publication succeeds, a second `out` refuses unless `--force` is supplied.
+This first handoff implementation targets Linux and macOS. Disk readiness uses
+Unix `statvfs` and source size measurement requires `du`; Windows target disk
+readiness currently reports unsupported.
 `status --json` includes the current acknowledged outgoing report under `out`,
 allowing clients to recover a lost response.
 

--- a/schemas/bundle.schema.json
+++ b/schemas/bundle.schema.json
@@ -30,7 +30,83 @@
         }
       }
     },
-    "nodes": { "type": "array" },
+    "nodes": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "origin": {
+            "type": "object",
+            "required": [
+              "hostname",
+              "platform"
+            ],
+            "properties": {
+              "environmentId": {
+                "type": "string"
+              },
+              "hostname": {
+                "type": "string",
+                "minLength": 1
+              },
+              "platform": {
+                "type": "string",
+                "minLength": 1
+              }
+            }
+          },
+          "handoff": {
+            "type": "object",
+            "required": [
+              "id",
+              "source"
+            ],
+            "properties": {
+              "id": {
+                "type": "string",
+                "minLength": 1
+              },
+              "source": {
+                "type": "object",
+                "required": [
+                  "hostname",
+                  "platform"
+                ],
+                "properties": {
+                  "environmentId": {
+                    "type": "string"
+                  },
+                  "hostname": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "platform": {
+                    "type": "string",
+                    "minLength": 1
+                  }
+                }
+              },
+              "destination": {
+                "type": "string"
+              },
+              "checkpointCommitGroupIds": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              "sizeMib": {
+                "type": "integer",
+                "minimum": 0
+              },
+              "outNodeId": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    },
     "publications": { "type": "array" }
   }
 }

--- a/schemas/project.schema.json
+++ b/schemas/project.schema.json
@@ -11,6 +11,65 @@
     "repos"
   ],
   "properties": {
+    "requirements": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "platforms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "tools": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "name"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "name": {
+                "type": "string",
+                "minLength": 1
+              },
+              "minVersion": {
+                "type": "string"
+              },
+              "optional": {
+                "type": "boolean"
+              },
+              "for": {
+                "enum": [
+                  "runtime"
+                ]
+              }
+            }
+          }
+        },
+        "diskMib": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "memoryMib": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "agents": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "env": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
     "schemaVersion": {
       "const": "0.1"
     },

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -33,6 +33,11 @@ pub enum GitCredentialOperation {
 
 #[derive(Subcommand)]
 pub enum Commands {
+    /// Continue a bundle on another machine.
+    Handoff {
+        #[command(subcommand)]
+        command: HandoffCommand,
+    },
     /// Initialize a reusable project repo template (like `git init`, for a project).
     Init {
         /// Project name.
@@ -96,6 +101,9 @@ pub enum Commands {
         /// Only write project and bundle JSON; do not create feature worktrees.
         #[arg(long)]
         no_worktree: bool,
+        /// Use a connected forge's HTTPS transport when SSH authentication fails.
+        #[arg(long)]
+        prefer_https: bool,
         /// Print a machine-readable clone result document to stdout. Progress
         /// lines move to stderr.
         #[arg(long)]
@@ -1359,5 +1367,45 @@ pub enum LandCommand {
         /// Record already-resolved local branch movements as a land update without running git merge.
         #[arg(long)]
         continue_merge: bool,
+    },
+}
+
+#[derive(Subcommand)]
+pub enum HandoffCommand {
+    /// Checkpoint and publish this bundle for continuation elsewhere.
+    Out {
+        #[arg(long)]
+        to: Option<String>,
+        #[arg(short = 'm', long)]
+        message: Option<String>,
+        #[arg(long)]
+        force: bool,
+        #[arg(long)]
+        json: bool,
+    },
+    /// Check whether this machine can continue a remote bundle.
+    Probe {
+        project: Option<String>,
+        slug: Option<String>,
+        #[arg(long)]
+        workspace: Option<PathBuf>,
+        #[arg(long)]
+        json: bool,
+    },
+    /// Accept a published handoff and print its worktree root.
+    In {
+        project: String,
+        slug: String,
+        #[arg(long)]
+        workspace: Option<PathBuf>,
+        #[arg(long)]
+        force: bool,
+        #[arg(long)]
+        json: bool,
+    },
+    /// Show the bundle's advisory handoff location.
+    Status {
+        #[arg(long)]
+        json: bool,
     },
 }

--- a/src/commands/bundle/mod.rs
+++ b/src/commands/bundle/mod.rs
@@ -135,6 +135,7 @@ pub fn list_bundles(all: bool, archived: bool, deleted: bool) -> Result<()> {
             state,
             bundle.repos.len()
         );
+        crate::commands::handoff::print_location(&bundle);
         shown += 1;
     }
     if shown == 0 {

--- a/src/commands/bundle/prune/assess.rs
+++ b/src/commands/bundle/prune/assess.rs
@@ -5,33 +5,15 @@
 
 use super::print_prune_warning;
 use crate::checkout::is_in_place;
-use crate::git::{git_output, is_git_worktree, ref_exists, resolve_base_ref};
 use crate::model::{ChangeGroup, RepoEntry};
+use crate::pending::feature_branch_unmerged_commits;
+pub(super) use crate::pending::{path_pending_changes, Pending};
 use crate::providers::{self, Forge, PrTarget, PullRequest};
 use crate::store::{read_json, write_json};
 use anyhow::{Context, Result};
 use std::collections::{BTreeSet, HashMap};
-use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
-
-/// Uncommitted work found in a checkout, split by whether Git tracks it.
-#[derive(Clone, Copy, Default)]
-pub(super) struct Pending {
-    pub(super) tracked: bool,
-    pub(super) untracked: bool,
-}
-
-impl Pending {
-    pub(super) fn any(self) -> bool {
-        self.tracked || self.untracked
-    }
-
-    pub(super) fn merge(&mut self, other: Pending) {
-        self.tracked |= other.tracked;
-        self.untracked |= other.untracked;
-    }
-}
 
 /// Everything prune learned about one bundle, so the same signals drive the
 /// prune decision, the `--untracked` relaxation, and the `--report` view.
@@ -502,31 +484,6 @@ fn assess_repo_signals(
     })
 }
 
-/// True when the bundle's feature branch (the local branch or its `origin/`
-/// counterpart in the source repo) carries commits the base branch does not.
-fn feature_branch_unmerged_commits(repo: &RepoEntry) -> Result<bool> {
-    let Some(branch) = repo.feature_branch.as_deref() else {
-        return Ok(false);
-    };
-    let repo_root = Path::new(&repo.path);
-    if !repo_root.exists() {
-        return Ok(false);
-    }
-    let base_ref = resolve_base_ref(repo_root, &repo.base_branch);
-    for candidate in [branch.to_string(), format!("origin/{branch}")] {
-        if !ref_exists(repo_root, &candidate) {
-            continue;
-        }
-        let range = format!("{base_ref}..{candidate}");
-        let count = git_output(repo_root, ["rev-list", "--count", &range])
-            .with_context(|| format!("failed to count commits in {range}"))?;
-        if count.trim() != "0" {
-            return Ok(true);
-        }
-    }
-    Ok(false)
-}
-
 fn publication_flags_from_publication(
     branch: Option<&str>,
     publication: &crate::model::PublicationEntry,
@@ -582,41 +539,4 @@ fn resolve_path(root: &Path, path: &str) -> PathBuf {
     } else {
         root.join(path)
     }
-}
-
-pub(super) fn path_pending_changes(path: &Path) -> Result<Pending> {
-    if !path.exists() {
-        return Ok(Pending::default());
-    }
-    if is_git_worktree(path) {
-        let status = git_output(path, ["status", "--porcelain"])?;
-        let mut pending = Pending::default();
-        for line in status.lines() {
-            if line.trim().is_empty() {
-                continue;
-            }
-            if line.starts_with("??") {
-                pending.untracked = true;
-            } else {
-                pending.tracked = true;
-            }
-        }
-        return Ok(pending);
-    }
-    // Stray files outside a Git worktree can't be classified, so treat them
-    // as tracked changes: they block pruning even with --untracked.
-    if path.is_file() {
-        return Ok(Pending {
-            tracked: true,
-            untracked: false,
-        });
-    }
-    let mut pending = Pending::default();
-    for entry in fs::read_dir(path).with_context(|| format!("failed to read {}", path.display()))? {
-        pending.merge(path_pending_changes(&entry?.path())?);
-        if pending.tracked && pending.untracked {
-            break;
-        }
-    }
-    Ok(pending)
 }

--- a/src/commands/bundle/validate.rs
+++ b/src/commands/bundle/validate.rs
@@ -187,6 +187,40 @@ fn validate_node(node: &BundleNode, node_ids: &mut BTreeSet<String>, errors: &mu
         "checkpoint" if node.message.as_deref().unwrap_or("").trim().is_empty() => {
             errors.push(format!("node `{}` must record message", node.id));
         }
+        "handoff.out" | "handoff.in" => {
+            if node
+                .origin
+                .as_ref()
+                .is_none_or(|o| o.hostname.trim().is_empty() || o.platform.trim().is_empty())
+            {
+                errors.push(format!(
+                    "node `{}` must record origin hostname and platform",
+                    node.id
+                ));
+            }
+            match &node.handoff {
+                None => errors.push(format!("node `{}` must record handoff", node.id)),
+                Some(handoff) => {
+                    if handoff.id.trim().is_empty()
+                        || handoff.source.hostname.trim().is_empty()
+                        || handoff.source.platform.trim().is_empty()
+                    {
+                        errors.push(format!(
+                            "node `{}` must record handoff id and source",
+                            node.id
+                        ));
+                    }
+                    if node.node_type == "handoff.in"
+                        && handoff
+                            .out_node_id
+                            .as_deref()
+                            .is_none_or(|id| id.trim().is_empty())
+                    {
+                        errors.push(format!("node `{}` must record handoff outNodeId", node.id));
+                    }
+                }
+            }
+        }
         "check.recorded" | "tag.created" => {
             if node.title.as_deref().unwrap_or("").trim().is_empty() {
                 errors.push(format!("node `{}` must record title", node.id));

--- a/src/commands/commit.rs
+++ b/src/commands/commit.rs
@@ -18,10 +18,19 @@ use std::path::{Path, PathBuf};
 
 pub fn commit_staged(message: &str, stage_first: bool) -> Result<()> {
     let mut active = load_active_bundle_for_update()?;
-    ensure_mutable_checkouts(&active)?;
-    let observed = sync_observed_changes(&mut active)?;
+    crate::commands::handoff::warn_elsewhere(&active.bundle);
+    commit_active(&mut active, message, stage_first).map(|_| ())
+}
+
+pub(crate) fn commit_active(
+    active: &mut ActiveBundle,
+    message: &str,
+    stage_first: bool,
+) -> Result<String> {
+    ensure_mutable_checkouts(active)?;
+    let observed = sync_observed_changes(active)?;
     for change in &observed {
-        println!(
+        crate::human!(
             "{}: {}",
             out::repo(&change.repo_id),
             out::warn(sync_note(change))
@@ -76,7 +85,7 @@ pub fn commit_staged(message: &str, stage_first: bool) -> Result<()> {
     for (repo_id, result) in results {
         match result {
             Ok(outcome) => {
-                println!(
+                crate::human!(
                     "{}: {} {}",
                     out::repo(&repo_id),
                     out::movement("committed"),
@@ -102,13 +111,13 @@ pub fn commit_staged(message: &str, stage_first: bool) -> Result<()> {
                 active.bundle.repos[outcome.repo_index].head_sha = Some(outcome.sha);
             }
             Err(error) => {
-                println!("{}: {}", out::repo(&repo_id), out::danger("commit failed"));
+                crate::human!("{}: {}", out::repo(&repo_id), out::danger("commit failed"));
                 failures.push(format!("{repo_id}: {error:#}"));
             }
         }
     }
 
-    if !failures.is_empty() {
+    if commits.is_empty() {
         bail!("commit failed:\n{}", failures.join("\n"));
     }
 
@@ -130,12 +139,18 @@ pub fn commit_staged(message: &str, stage_first: bool) -> Result<()> {
     active.bundle.updated_at = now_iso();
     save_active_bundle(&active)?;
 
-    println!(
+    crate::human!(
         "{} {}",
         out::heading("Recorded commit group"),
-        out::node(group_id)
+        out::node(&group_id)
     );
-    Ok(())
+    if !failures.is_empty() {
+        bail!(
+            "Recorded successful commits in {group_id}; retry remaining repositories:\n{}",
+            failures.join("\n")
+        );
+    }
+    Ok(group_id)
 }
 
 struct CommitOutcome {

--- a/src/commands/commit.rs
+++ b/src/commands/commit.rs
@@ -38,13 +38,13 @@ pub(crate) fn commit_active(
     }
 
     if stage_first {
-        stage_all_tracked(&active)?;
+        stage_all_tracked(active)?;
     }
-    let repos_to_commit = repos_with_staged_changes(&active)?;
+    let repos_to_commit = repos_with_staged_changes(active)?;
 
     if repos_to_commit.is_empty() {
         if !observed.is_empty() {
-            save_active_bundle(&active)?;
+            save_active_bundle(active)?;
         }
         bail!("No staged changes found in tracked checkouts.");
     }
@@ -137,7 +137,7 @@ pub(crate) fn commit_active(
     ));
     active.bundle.head_node_id = active.bundle.nodes.last().map(|node| node.id.clone());
     active.bundle.updated_at = now_iso();
-    save_active_bundle(&active)?;
+    save_active_bundle(active)?;
 
     crate::human!(
         "{} {}",

--- a/src/commands/handoff/in_.rs
+++ b/src/commands/handoff/in_.rs
@@ -1,0 +1,106 @@
+use super::*;
+use crate::{
+    commands::remote::push_handoff_bundle_to_remote,
+    model::{BundleNode, HandoffLocationState},
+    time::now_iso,
+};
+
+pub fn handoff_in(
+    project: &str,
+    slug: &str,
+    workspace: Option<&Path>,
+    force: bool,
+    json: bool,
+) -> Result<()> {
+    if json {
+        crate::output::route_human_lines_to_stderr();
+    }
+    let root = target_root(project, workspace)?;
+    let (report, remote) = prepare_probe(project, slug, &root, false);
+    report.print(false)?;
+    if report.verdict == "fail" && !force {
+        return Err(report::ProbeFailed.into());
+    }
+    let remote = remote.context("Cannot accept without a valid authenticated remote export")?;
+    // --force bypasses declared readiness only, never local work, identity,
+    // schema, transport, or competing continuation checks.
+    if report.checks.iter().any(|c| {
+        c.status == "fail"
+            && !c.id.starts_with("tool:")
+            && !c.id.starts_with("env:")
+            && !matches!(c.id.as_str(), "disk" | "memory" | "platform")
+    }) {
+        bail!("Handoff has a blocking transport or checkout failure; --force cannot bypass it");
+    }
+    check_existing_target(&root, &remote.bundle)?;
+    let remote_name = remote.remote_name.clone();
+    let location = remote
+        .bundle
+        .handoff_location()
+        .context("Bundle has no handoff; run handoff out on the source first")?;
+    if location.state == HandoffLocationState::Conflict {
+        bail!("Resolve competing handoffs before accepting");
+    }
+    let outgoing = remote
+        .bundle
+        .nodes
+        .iter()
+        .find(|n| {
+            n.node_type == "handoff.out"
+                && n.handoff
+                    .as_ref()
+                    .is_some_and(|h| h.id == location.handoff_id)
+        })
+        .context("Handoff has no outgoing checkpoint")?
+        .clone();
+    let mut payload = outgoing
+        .handoff
+        .clone()
+        .context("Outgoing handoff has no payload")?;
+    payload.out_node_id = Some(outgoing.id);
+    let mut active = remote.materialize(&root)?;
+    let _lock = store::acquire_named_lock(&root, &active.bundle.id)?;
+    // Reload under the acceptance lock, after materialization saved its paths.
+    active.bundle = store::read_json(&active.bundle_path)?;
+    let origin = ambient_origin();
+    let accepted = active.bundle.nodes.iter().any(|n| {
+        n.node_type == "handoff.in"
+            && n.handoff.as_ref().is_some_and(|h| h.id == payload.id)
+            && n.origin.as_ref().is_some_and(|o| same_origin(o, &origin))
+    });
+    if !accepted {
+        let node = BundleNode::handoff_in(
+            crate::ids::node_id("hin"),
+            now_iso(),
+            Some(payload.source.hostname.clone()),
+            None,
+            active.bundle.repos.iter().map(|r| r.id.clone()).collect(),
+            payload.clone(),
+        );
+        active.bundle.head_node_id = Some(node.id.clone());
+        active.bundle.nodes.push(node);
+        active.bundle.updated_at = now_iso();
+        store::save_active_bundle(&active)?;
+    }
+    push_handoff_bundle_to_remote(&remote_name, &mut active)
+        .context("Acceptance saved locally; retry handoff in to publish it")?;
+    let checkpoint_commits: Vec<_> = active
+        .bundle
+        .commit_groups
+        .iter()
+        .filter(|g| payload.checkpoint_commit_group_ids.contains(&g.id))
+        .flat_map(|g| g.commits.iter().map(|c| format!("{}:{}", c.repo_id, c.sha)))
+        .collect();
+    let worktree = active.root.join(".knit/worktrees").join(&active.bundle.id);
+    if json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(
+                &serde_json::json!({"handoffId":payload.id,"bundleSlug":active.bundle.id,"bundleId":active.bundle.id,"workspaceRoot":active.root,"worktreePath":worktree,"checkpointCommits":checkpoint_commits})
+            )?
+        );
+    } else {
+        crate::human!("{}", worktree.display());
+    }
+    Ok(())
+}

--- a/src/commands/handoff/mod.rs
+++ b/src/commands/handoff/mod.rs
@@ -1,0 +1,282 @@
+//! Explicit, checkpointed bundle continuation between machines.
+mod in_;
+mod out;
+pub(crate) mod probe;
+pub mod report;
+use crate::{
+    model::{ambient_origin, ChangeGroup, HandoffLocationState, NodeOrigin},
+    store,
+};
+use anyhow::{bail, Context, Result};
+pub use in_::handoff_in;
+pub use out::handoff_out;
+use std::path::{Path, PathBuf};
+
+pub fn handoff_probe(
+    project: Option<&str>,
+    slug: Option<&str>,
+    workspace: Option<&Path>,
+    json: bool,
+) -> Result<()> {
+    if json {
+        crate::output::route_human_lines_to_stderr();
+    }
+    let (project, slug) = resolve_reference(project, slug)?;
+    let root = target_root(&project, workspace)?;
+    let (report, _) = prepare_probe(&project, &slug, &root, true);
+    report.print(json)?;
+    if report.verdict == "fail" {
+        return Err(report::ProbeFailed.into());
+    }
+    Ok(())
+}
+
+pub(crate) fn prepare_probe(
+    project: &str,
+    slug: &str,
+    root: &Path,
+    allow_unpublished: bool,
+) -> (
+    report::ProbeReport,
+    Option<crate::commands::remote::handoff::HandoffExport>,
+) {
+    use report::Check;
+    let mut remote = match crate::commands::remote::handoff::HandoffExport::fetch(
+        project,
+        slug,
+        allow_unpublished,
+    ) {
+        Ok(remote) => remote,
+        Err(e) => {
+            let mut r = report::ProbeReport::default();
+            r.add(Check::fail("remote", "Sync remote", format!("{e:#}")));
+            return (r, None);
+        }
+    };
+    let requirements = remote
+        .project
+        .as_ref()
+        .and_then(|p| p.requirements.clone())
+        .unwrap_or_default();
+    let size = remote
+        .bundle
+        .nodes
+        .iter()
+        .rev()
+        .filter_map(|n| n.handoff.as_ref())
+        .find_map(|h| h.size_mib);
+    let mut r = probe::system_checks(root, &requirements, size);
+    if remote.unpublished {
+        r.add(Check::warn("bundle", "Bundle checkpoint", "Bundle not published yet; checking project requirements and repository access. Acceptance will recheck the published checkpoint."));
+    }
+    r.add(Check::ok(
+        "remote",
+        "Sync remote",
+        "Global remote configured and token valid",
+    ));
+    if remote.bundle.schema_version != crate::model::SCHEMA_VERSION {
+        r.add(Check::fail(
+            "schema",
+            "Bundle schema",
+            format!(
+                "Expected {}; found {}",
+                crate::model::SCHEMA_VERSION,
+                remote.bundle.schema_version
+            ),
+        ));
+    }
+    let parent = probe::existing_parent(root).unwrap_or_else(|_| std::env::temp_dir());
+    for (id, result) in remote.probe_repositories(&parent) {
+        r.add(match result {
+            Ok(()) => Check::ok(&format!("forge:{id}"), &id, "Repository reachable"),
+            Err(e) => Check::fail(&format!("forge:{id}"), &id, format!("{e:#}")),
+        });
+    }
+    match remote.bundle.handoff_location() {
+        Some(location) if location.state == HandoffLocationState::Conflict => r.add(Check::fail(
+            "location",
+            "Bundle location",
+            "Competing handoffs require reconciliation",
+        )),
+        Some(location)
+            if location.state == HandoffLocationState::Active
+                && !location
+                    .origin
+                    .as_ref()
+                    .is_some_and(|o| same_origin(o, &ambient_origin())) =>
+        {
+            let message = format!(
+                "Active on {}; source must publish handoff out before acceptance",
+                location.label
+            );
+            r.add(if allow_unpublished {
+                Check::warn("location", "Bundle location", message)
+            } else {
+                Check::fail("location", "Bundle location", message)
+            })
+        }
+        _ => r.add(Check::ok(
+            "location",
+            "Bundle location",
+            "Ready for continuation",
+        )),
+    }
+    if let Err(e) = check_existing_target(root, &remote.bundle) {
+        r.add(Check::fail(
+            "target-state",
+            "Existing checkout",
+            format!("{e:#}"),
+        ));
+    }
+    (r, Some(remote))
+}
+
+pub(crate) fn target_root(project: &str, workspace: Option<&Path>) -> Result<PathBuf> {
+    let cwd = std::env::current_dir()?;
+    if let Some(path) = workspace {
+        return Ok(if path.is_absolute() {
+            path.into()
+        } else {
+            cwd.join(path)
+        });
+    }
+    if let Some(root) = store::find_knit_root(&cwd) {
+        return Ok(root);
+    }
+    Ok(cwd.join(project.rsplit('/').next().context("Project ref is empty")?))
+}
+fn resolve_reference(project: Option<&str>, slug: Option<&str>) -> Result<(String, String)> {
+    if let (Some(p), Some(s)) = (project, slug) {
+        return Ok((p.into(), s.into()));
+    }
+    let active = store::load_active_bundle()?;
+    Ok((
+        project
+            .map(str::to_owned)
+            .or(active.bundle.project_id)
+            .context("No project selected")?,
+        slug.unwrap_or(&active.bundle.id).into(),
+    ))
+}
+pub(crate) fn same_origin(left: &NodeOrigin, right: &NodeOrigin) -> bool {
+    match (&left.environment_id, &right.environment_id) {
+        (Some(a), Some(b)) => a == b,
+        (None, None) => left.hostname == right.hostname && left.platform == right.platform,
+        _ => false,
+    }
+}
+pub(crate) fn check_git_operation(path: &Path) -> Result<()> {
+    for marker in [
+        "MERGE_HEAD",
+        "CHERRY_PICK_HEAD",
+        "REVERT_HEAD",
+        "rebase-merge",
+        "rebase-apply",
+        "BISECT_LOG",
+    ] {
+        let gitpath = crate::git::git_output(path, ["rev-parse", "--git-path", marker])?;
+        let p = PathBuf::from(gitpath.trim());
+        let p = if p.is_absolute() { p } else { path.join(p) };
+        if p.exists() {
+            bail!(
+                "Finish or abort the Git operation in {} before handoff",
+                path.display()
+            );
+        }
+    }
+    if !crate::git::git_output(path, ["ls-files", "-u"])?
+        .trim()
+        .is_empty()
+    {
+        bail!("Resolve unmerged files in {}", path.display());
+    }
+    Ok(())
+}
+pub(crate) fn check_existing_target(root: &Path, remote: &ChangeGroup) -> Result<()> {
+    if root.exists()
+        && !root.join(".knit/config.json").exists()
+        && std::fs::read_dir(root)?.next().is_some()
+    {
+        bail!("Target directory is not empty and is not a Knit workspace");
+    }
+    let path = store::bundle_path(root, &remote.id);
+    if !path.exists() {
+        return Ok(());
+    }
+    let local: ChangeGroup = store::read_json(&path)?;
+    if crate::model::ledger_relation(&local.node_id_sequence(), &remote.node_id_sequence())
+        == crate::model::LedgerRelation::Diverged
+    {
+        bail!(
+            "Ledgers diverged; run `knit --bundle {} pull --merge` and retry",
+            remote.id
+        );
+    }
+    let active = store::ActiveBundle::unlocked(root.into(), path, local);
+    for repo in &active.bundle.repos {
+        if let Some(cwd) = crate::checkout::checkout_dir(&active, repo) {
+            check_git_operation(&cwd)?;
+            if let Some(expected) = remote
+                .repos
+                .iter()
+                .find(|r| r.id == repo.id)
+                .and_then(|r| r.remote.as_deref())
+            {
+                let actual = crate::git::git_output(&cwd, ["remote", "get-url", "origin"])?;
+                if !crate::commands::remote::handoff::same_repository_url(actual.trim(), expected) {
+                    bail!(
+                        "{} has a different repository origin than the handoff",
+                        repo.id
+                    );
+                }
+            }
+
+            if crate::pending::path_pending_changes(&cwd)?.any() {
+                bail!("{} has uncommitted changes; commit or preserve them before accepting the handoff",repo.id);
+            }
+            if crate::git::current_branch(&cwd)?.as_deref() != repo.feature_branch.as_deref() {
+                bail!("{} checkout is on a different branch", repo.id);
+            }
+        }
+    }
+    Ok(())
+}
+pub fn handoff_status(json: bool) -> Result<()> {
+    let active = store::load_active_bundle()?;
+    if json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(
+                &serde_json::json!({"bundleSlug":active.bundle.id,"location":active.bundle.handoff_location(),"out":out::published_out(&active)?})
+            )?
+        );
+    } else {
+        print_location(&active.bundle);
+    }
+    Ok(())
+}
+pub(crate) fn print_location(bundle: &ChangeGroup) {
+    if let Some(l) = bundle.handoff_location() {
+        let verb = match l.state {
+            HandoffLocationState::Pending => "Awaiting continuation on",
+            HandoffLocationState::Active => "Continued on",
+            HandoffLocationState::Conflict => "Conflicting handoffs:",
+        };
+        crate::human!("{verb} {} ({})", l.label, l.updated_at);
+    }
+}
+pub(crate) fn warn_elsewhere(bundle: &ChangeGroup) {
+    if let Some(l) = bundle.handoff_location() {
+        if l.state != HandoffLocationState::Active
+            || !l
+                .origin
+                .as_ref()
+                .is_some_and(|o| same_origin(o, &ambient_origin()))
+        {
+            eprintln!(
+                "Warning: bundle handoff location is {} ({}); sync before continuing edits here.",
+                l.label, l.updated_at
+            );
+        }
+    }
+}

--- a/src/commands/handoff/out.rs
+++ b/src/commands/handoff/out.rs
@@ -1,0 +1,302 @@
+use super::*;
+use crate::{
+    commands::{
+        commit::commit_active,
+        remote::{configured_sync_remote_names, push_active_bundle_to_remote},
+    },
+    model::{BundleNode, BundleState, NodeHandoff},
+    store::{read_json, save_active_bundle, write_json, ActiveBundle},
+    time::now_iso,
+};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeSet;
+
+#[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct OutJournal {
+    id: String,
+    node_id: String,
+    destination: Option<String>,
+    message: Option<String>,
+    source: NodeOrigin,
+    checkpoint_commit_group_ids: Vec<String>,
+    published: bool,
+    previous_handoff: Option<String>,
+}
+
+pub fn handoff_out(to: Option<&str>, message: Option<&str>, force: bool, json: bool) -> Result<()> {
+    if json {
+        crate::output::route_human_lines_to_stderr();
+    }
+    let mut active = store::load_active_bundle_for_update()?;
+    if !matches!(active.bundle.state, None | Some(BundleState::Open)) {
+        bail!("Only open bundles can be handed off");
+    }
+    let config = store::load_effective_config(&active.root)?;
+    let remote = configured_sync_remote_names(&config)
+        .into_iter()
+        .next()
+        .context("Configure a sync remote before handing off")?;
+    let project_ref = active
+        .bundle
+        .project_id
+        .clone()
+        .context("Bundle must belong to a project")?;
+    let journal_path = active
+        .root
+        .join(".knit/handoffs")
+        .join(format!("{}.out.json", active.bundle.id));
+    std::fs::create_dir_all(
+        journal_path
+            .parent()
+            .context("Handoff journal has no parent")?,
+    )?;
+    let existing: Option<OutJournal> = journal_path
+        .exists()
+        .then(|| read_json(&journal_path))
+        .transpose()?;
+    let mut journal = if let Some(j) = existing.filter(|j| !j.published) {
+        if !same_origin(&j.source, &ambient_origin()) {
+            bail!("Unfinished handoff belongs to a different source environment");
+        }
+        if to.is_some() && to != j.destination.as_deref() {
+            bail!("Retry the unfinished handoff to its original destination");
+        }
+        j
+    } else {
+        if let Some(location) = active.bundle.handoff_location() {
+            if location.state == HandoffLocationState::Conflict {
+                bail!("Resolve competing handoffs before publishing another handoff");
+            }
+
+            if !force
+                && (location.state != HandoffLocationState::Active
+                    || !location
+                        .origin
+                        .as_ref()
+                        .is_some_and(|o| same_origin(o, &ambient_origin())))
+            {
+                bail!("Bundle already handed off to {}; use handoff in to continue here, or --force to publish a new handoff", location.label);
+            }
+        }
+        OutJournal {
+            id: crate::ids::node_id("handoff"),
+            node_id: crate::ids::node_id("hout"),
+            destination: to.map(str::to_owned),
+            message: message.map(str::to_owned),
+            source: ambient_origin(),
+            checkpoint_commit_group_ids: vec![],
+            published: false,
+            previous_handoff: active.bundle.handoff_location().and_then(|location| {
+                let kind = if location.state == HandoffLocationState::Active {
+                    "handoff.in"
+                } else {
+                    "handoff.out"
+                };
+                active
+                    .bundle
+                    .nodes
+                    .iter()
+                    .find(|n| {
+                        n.node_type == kind
+                            && n.handoff
+                                .as_ref()
+                                .is_some_and(|h| h.id == location.handoff_id)
+                    })
+                    .map(|n| n.id.clone())
+            }),
+        }
+    };
+    let mut dirty = false;
+    for repo in &active.bundle.repos {
+        let cwd = crate::checkout::checkout_dir(&active, repo)
+            .with_context(|| format!("{} has no materialized checkout", repo.id))?;
+        if crate::git::current_branch(&cwd)?.as_deref() != repo.feature_branch.as_deref() {
+            bail!("{} is not on its recorded feature branch", repo.id);
+        }
+        if repo.remote.is_none() {
+            bail!("{} has no Git remote; handoff cannot transport it", repo.id);
+        }
+        check_git_operation(&cwd)?;
+        dirty |= crate::pending::path_pending_changes(&cwd)?.any();
+        // Dirty submodules cannot be transported by committing their parent.
+        let submodules = crate::git::git_output(
+            &cwd,
+            ["submodule", "foreach", "--quiet", "git status --porcelain"],
+        )?;
+        if !submodules.trim().is_empty() {
+            bail!(
+                "{} has dirty submodules; commit and push those repositories first",
+                repo.id
+            );
+        }
+    }
+    if let Some(index) = active
+        .bundle
+        .nodes
+        .iter()
+        .position(|n| n.id == journal.node_id)
+    {
+        let newer_recorded_work = active.bundle.nodes[index + 1..]
+            .iter()
+            .any(|n| !n.commits.is_empty() || !n.repo_changes.is_empty());
+        if dirty
+            || newer_recorded_work
+            || !crate::tracking::detect_unrecorded_changes(&active)?.is_empty()
+        {
+            bail!("The prepared handoff snapshot has newer local changes. Preserve those changes separately before retrying this publication; its recorded checkpoint is immutable.");
+        }
+    }
+    write_json(&journal_path, &journal)?;
+    if dirty {
+        let before: BTreeSet<_> = active
+            .bundle
+            .commit_groups
+            .iter()
+            .map(|g| g.id.clone())
+            .collect();
+        let checkpoint_message = format!("knit handoff checkpoint: {}", active.bundle.id);
+        let result = commit_active(&mut active, &checkpoint_message, true);
+        for group in active
+            .bundle
+            .commit_groups
+            .clone()
+            .into_iter()
+            .filter(|g| !before.contains(&g.id))
+        {
+            journal.checkpoint_commit_group_ids.push(group.id.clone());
+            active.bundle.nodes.push(BundleNode::checkpoint(
+                crate::ids::node_id("checkpoint"),
+                now_iso(),
+                checkpoint_message.clone(),
+                group.commits.iter().map(|c| c.repo_id.clone()).collect(),
+                group.id,
+            ));
+        }
+        active.bundle.head_node_id = active.bundle.nodes.last().map(|n| n.id.clone());
+        save_active_bundle(&active)?;
+        write_json(&journal_path, &journal)?;
+        result?;
+    }
+    let observed = crate::tracking::sync_observed_changes(&mut active)?;
+    if !observed.is_empty() {
+        save_active_bundle(&active)?;
+    }
+    if !active.bundle.nodes.iter().any(|n| n.id == journal.node_id) {
+        // Publish every checkpoint and branch before announcing the handoff.
+        push_active_bundle_to_remote(&remote, None, &mut active, crate::commands::PushForce::No)?;
+        let payload = NodeHandoff {
+            id: journal.id.clone(),
+            source: journal.source.clone(),
+            destination: journal.destination.clone(),
+            checkpoint_commit_group_ids: journal.checkpoint_commit_group_ids.clone(),
+            size_mib: Some(measure_size(&active)?),
+            out_node_id: None,
+        };
+        let mut node = BundleNode::handoff_out(
+            journal.node_id.clone(),
+            now_iso(),
+            journal.destination.clone(),
+            journal.message.clone(),
+            active.bundle.repos.iter().map(|r| r.id.clone()).collect(),
+            payload,
+        );
+        node.target_node_id = journal.previous_handoff.clone();
+        active.bundle.head_node_id = Some(node.id.clone());
+        active.bundle.nodes.push(node);
+        active.bundle.updated_at = now_iso();
+        save_active_bundle(&active)?;
+    }
+    push_active_bundle_to_remote(&remote, None, &mut active, crate::commands::PushForce::No)
+        .context(
+            "Handoff saved locally; retry handoff out to finish publishing the same handoff",
+        )?;
+    journal.published = true;
+    write_json(&journal_path, &journal)?;
+    if json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(
+                &serde_json::json!({"handoffId":journal.id,"bundleSlug":active.bundle.id,"projectRef":project_ref,"worktreePath":active.root.join(".knit/worktrees").join(&active.bundle.id),"checkpointCommitGroupIds":journal.checkpoint_commit_group_ids})
+            )?
+        );
+    } else {
+        crate::human!(
+            "Continue on the target: knit handoff in {} {}",
+            project_ref,
+            active.bundle.id
+        );
+    }
+    Ok(())
+}
+
+/// Count the common object store once and tracked/unignored working files.
+/// Build outputs are excluded, and linked-worktree .git pointer files are resolved.
+fn measure_size(active: &ActiveBundle) -> Result<u64> {
+    let mut bytes = 0u64;
+    let mut git_dirs = BTreeSet::new();
+    for repo in &active.bundle.repos {
+        let cwd = crate::checkout::checkout_dir(active, repo).context("Missing checkout")?;
+        let common = crate::git::git_output(&cwd, ["rev-parse", "--git-common-dir"])?;
+        let path = PathBuf::from(common.trim());
+        let path = if path.is_absolute() {
+            path
+        } else {
+            cwd.join(path)
+        };
+        let path = std::fs::canonicalize(path)?;
+        if git_dirs.insert(path.clone()) {
+            let size = probe::command_output(
+                "du",
+                &["-sk".into(), path.to_string_lossy().into_owned()],
+                &cwd,
+            )?;
+            bytes = bytes.saturating_add(
+                size.split_whitespace()
+                    .next()
+                    .context("du returned no size")?
+                    .parse::<u64>()?
+                    .saturating_mul(1024),
+            );
+        }
+        let files = crate::git::git_output(
+            &cwd,
+            [
+                "ls-files",
+                "-z",
+                "--cached",
+                "--others",
+                "--exclude-standard",
+            ],
+        )?;
+        for file in files.split('\0').filter(|s| !s.is_empty()) {
+            if let Ok(m) = std::fs::symlink_metadata(cwd.join(file)) {
+                if m.is_file() || m.file_type().is_symlink() {
+                    bytes = bytes.saturating_add(m.len());
+                }
+            }
+        }
+    }
+    Ok(bytes.saturating_mul(13).div_ceil(10 * 1_048_576))
+}
+
+pub(super) fn published_out(active: &ActiveBundle) -> Result<Option<serde_json::Value>> {
+    let path = active
+        .root
+        .join(".knit/handoffs")
+        .join(format!("{}.out.json", active.bundle.id));
+    if !path.exists() {
+        return Ok(None);
+    }
+    let journal: OutJournal = read_json(&path)?;
+    let current = active.bundle.handoff_location();
+    if !journal.published
+        || !current
+            .is_some_and(|l| l.state == HandoffLocationState::Pending && l.handoff_id == journal.id)
+    {
+        return Ok(None);
+    }
+    Ok(Some(
+        serde_json::json!({"handoffId":journal.id,"bundleSlug":active.bundle.id,"projectRef":active.bundle.project_id,"worktreePath":active.root.join(".knit/worktrees").join(&active.bundle.id),"checkpointCommitGroupIds":journal.checkpoint_commit_group_ids}),
+    ))
+}

--- a/src/commands/handoff/probe.rs
+++ b/src/commands/handoff/probe.rs
@@ -310,7 +310,9 @@ fn disk_available_mib(path: &Path) -> Result<u64> {
         return Err(std::io::Error::last_os_error().into());
     }
     let stat = unsafe { stat.assume_init() };
-    Ok((stat.f_bavail as u64).saturating_mul(stat.f_frsize as u64) / 1_048_576)
+    // statvfs field widths vary across Unix platforms. Widen before multiplying.
+    let mib = u128::from(stat.f_bavail) * u128::from(stat.f_frsize) / 1_048_576;
+    Ok(mib.try_into().unwrap_or(u64::MAX))
 }
 #[cfg(not(unix))]
 fn disk_available_mib(_path: &Path) -> Result<u64> {

--- a/src/commands/handoff/probe.rs
+++ b/src/commands/handoff/probe.rs
@@ -1,0 +1,380 @@
+use super::report::{Check, ProbeReport};
+use crate::model::ProjectRequirements;
+use anyhow::{bail, Context, Result};
+use std::{
+    fs,
+    io::Read,
+    path::{Path, PathBuf},
+    process::{Command, Stdio},
+    time::{Duration, Instant},
+};
+
+/// Commands are argv, never shell strings. Drain pipes while waiting, cap output,
+/// disable Git prompts, and terminate hung probes (including SSH children).
+pub(crate) fn command_output(program: &str, args: &[String], cwd: &Path) -> Result<String> {
+    let mut command = Command::new(program);
+    command
+        .args(args)
+        .current_dir(cwd)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .env("GIT_TERMINAL_PROMPT", "0")
+        .env(
+            "GIT_SSH_COMMAND",
+            "ssh -o BatchMode=yes -o ConnectTimeout=10",
+        );
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt;
+        unsafe {
+            command.pre_exec(|| {
+                if libc::setpgid(0, 0) == -1 {
+                    return Err(std::io::Error::last_os_error());
+                }
+                Ok(())
+            });
+        }
+    }
+    let mut child = command
+        .spawn()
+        .with_context(|| format!("{program} is unavailable"))?;
+    fn drain(mut pipe: impl Read) -> String {
+        let mut retained = Vec::new();
+        let mut buf = [0u8; 4096];
+        while let Ok(n) = pipe.read(&mut buf) {
+            if n == 0 {
+                break;
+            }
+            let keep = n.min(16384usize.saturating_sub(retained.len()));
+            retained.extend_from_slice(&buf[..keep]);
+        }
+        String::from_utf8_lossy(&retained).into_owned()
+    }
+    let stdout = child.stdout.take().unwrap();
+    let stderr = child.stderr.take().unwrap();
+    let out = std::thread::spawn(move || drain(stdout));
+    let err = std::thread::spawn(move || drain(stderr));
+    let started = Instant::now();
+    let status = loop {
+        if let Some(status) = child.try_wait()? {
+            break Some(status);
+        }
+        if started.elapsed() > Duration::from_secs(30) {
+            #[cfg(unix)]
+            unsafe {
+                libc::kill(-(child.id() as i32), libc::SIGKILL);
+            }
+            let _ = child.kill();
+            let _ = child.wait();
+            break None;
+        }
+        std::thread::sleep(Duration::from_millis(30));
+    };
+    let out = out.join().unwrap_or_default();
+    let err = err.join().unwrap_or_default();
+    match status {
+        Some(s) if s.success() => Ok(format!("{out}\n{err}")),
+        Some(_) => bail!("{program} probe failed"),
+        None => bail!("{program} probe timed out after 30 seconds"),
+    }
+}
+
+pub(crate) fn version_numbers(value: &str) -> Option<Vec<u64>> {
+    value
+        .split(|c: char| !c.is_ascii_digit() && c != '.')
+        .find_map(|part| {
+            let part = part.trim_matches('.');
+            if part.is_empty() {
+                return None;
+            }
+            let numbers: Option<Vec<_>> = part.split('.').map(|s| s.parse::<u64>().ok()).collect();
+            numbers
+        })
+}
+fn version_at_least(actual: &str, minimum: &str) -> bool {
+    let (Some(mut a), Some(mut b)) = (version_numbers(actual), version_numbers(minimum)) else {
+        return false;
+    };
+    let len = a.len().max(b.len());
+    a.resize(len, 0);
+    b.resize(len, 0);
+    a >= b
+}
+
+pub(crate) fn existing_parent(root: &Path) -> Result<PathBuf> {
+    let mut parent = root.to_path_buf();
+    while !parent.exists() {
+        if !parent.pop() {
+            bail!("Workspace has no existing parent");
+        }
+    }
+    if !parent.is_dir() {
+        bail!("Workspace path is not a directory");
+    }
+    Ok(parent)
+}
+
+pub(crate) fn system_checks(
+    root: &Path,
+    requirements: &ProjectRequirements,
+    measured_mib: Option<u64>,
+) -> ProbeReport {
+    let mut report = ProbeReport::default();
+    let parent = match existing_parent(root) {
+        Ok(p) => p,
+        Err(e) => {
+            report.add(Check::fail("workspace", "Workspace", e.to_string()));
+            return report;
+        }
+    };
+    report.add(Check::ok(
+        "knit",
+        "Knit",
+        format!(
+            "{}; schema {}",
+            env!("CARGO_PKG_VERSION"),
+            crate::model::SCHEMA_VERSION
+        ),
+    ));
+    match command_output("git", &["--version".into()], &parent) {
+        Ok(v) if version_at_least(&v, "2.20") => {
+            report.add(Check::ok("git", "Git worktrees", v.trim()))
+        }
+        _ => report.add(Check::fail(
+            "git",
+            "Git worktrees",
+            "Git >= 2.20 is required",
+        )),
+    }
+    let writable = (|| -> Result<()> {
+        let path = parent.join(format!(
+            ".knit-handoff-probe-{}",
+            crate::ids::node_id("write")
+        ));
+        let file = fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&path)?;
+        drop(file);
+        fs::remove_file(path)?;
+        Ok(())
+    })();
+    report.add(if writable.is_ok() {
+        Check::ok(
+            "workspace",
+            "Writable workspace",
+            root.display().to_string(),
+        )
+    } else {
+        Check::fail(
+            "workspace",
+            "Writable workspace",
+            "Cannot create files in workspace parent",
+        )
+    });
+    let platform = crate::model::ambient_origin().platform;
+    report.add(
+        if requirements.platforms.is_empty() || requirements.platforms.contains(&platform) {
+            Check::ok("platform", "Platform", platform)
+        } else {
+            Check::fail(
+                "platform",
+                "Platform",
+                format!("{platform} is not in the project's supported platforms"),
+            )
+        },
+    );
+    let required = requirements
+        .disk_mib
+        .unwrap_or(0)
+        .max(measured_mib.unwrap_or(0));
+    match disk_available_mib(&parent) {
+        Ok(free) if free >= required => report.add(Check::ok(
+            "disk",
+            "Free disk",
+            format!("{free} MiB available; {required} MiB required"),
+        )),
+        Ok(free) => report.add(Check::fail(
+            "disk",
+            "Free disk",
+            format!("{free} MiB available; {required} MiB required"),
+        )),
+        Err(_) => report.add(Check::fail(
+            "disk",
+            "Free disk",
+            "Cannot determine available disk",
+        )),
+    }
+    for tool in &requirements.tools {
+        let scope = if tool.for_.as_deref() == Some("runtime") {
+            "runtime"
+        } else {
+            "editing"
+        };
+        let valid = !tool.name.is_empty()
+            && tool
+                .name
+                .chars()
+                .all(|c| c.is_ascii_alphanumeric() || matches!(c, '-' | '_' | '.'))
+            && !tool.name.starts_with('.');
+        let outcome = if valid {
+            command_output(&tool.name, &["--version".into()], &parent)
+        } else {
+            Err(anyhow::anyhow!("Invalid tool name"))
+        };
+        let satisfied = outcome.as_ref().is_ok_and(|v| {
+            let name = tool.name.to_ascii_lowercase();
+            let version_line = v
+                .lines()
+                .find(|line| line.trim().to_ascii_lowercase().starts_with(&name))
+                .unwrap_or(v);
+            tool.min_version
+                .as_ref()
+                .is_none_or(|min| version_at_least(version_line, min))
+        });
+        let message = if satisfied {
+            "available".to_string()
+        } else {
+            format!(
+                "{}{} is required",
+                tool.name,
+                tool.min_version
+                    .as_ref()
+                    .map(|v| format!(" >= {v}"))
+                    .unwrap_or_default()
+            )
+        };
+        let mut check = if satisfied {
+            Check::ok(&format!("tool:{}", tool.name), &tool.name, message)
+        } else if tool.optional || scope == "runtime" {
+            Check::warn(&format!("tool:{}", tool.name), &tool.name, message)
+        } else {
+            Check::fail(&format!("tool:{}", tool.name), &tool.name, message)
+        };
+        check.scope = scope.into();
+        report.add(check);
+    }
+    if let Some(min) = requirements.memory_mib {
+        let memory = memory_available_mib(&parent);
+        report.add(match memory {
+            Some(n) if n >= min => Check::ok(
+                "memory",
+                "Available memory",
+                format!("{n} MiB available; {min} MiB requested"),
+            ),
+            Some(n) => Check::warn(
+                "memory",
+                "Available memory",
+                format!("{n} MiB available; {min} MiB requested"),
+            ),
+            None => Check::warn(
+                "memory",
+                "Available memory",
+                "Cannot verify available memory",
+            ),
+        });
+    }
+    for name in &requirements.env {
+        report.add(if std::env::var_os(name).is_some_and(|v| !v.is_empty()) {
+            Check::ok(&format!("env:{name}"), name, "present")
+        } else {
+            Check::fail(
+                &format!("env:{name}"),
+                name,
+                "Environment variable is absent",
+            )
+        });
+    }
+    if !requirements.agents.is_empty() {
+        let mut c = Check::warn(
+            "agents",
+            "Agent adapters",
+            format!(
+                "Verify provider availability in the client: {}",
+                requirements.agents.join(", ")
+            ),
+        );
+        c.scope = "agent".into();
+        report.add(c);
+    }
+    report
+}
+
+#[cfg(unix)]
+fn disk_available_mib(path: &Path) -> Result<u64> {
+    use std::os::unix::ffi::OsStrExt;
+    let path = std::ffi::CString::new(path.as_os_str().as_bytes())?;
+    let mut stat = std::mem::MaybeUninit::<libc::statvfs>::uninit();
+    if unsafe { libc::statvfs(path.as_ptr(), stat.as_mut_ptr()) } != 0 {
+        return Err(std::io::Error::last_os_error().into());
+    }
+    let stat = unsafe { stat.assume_init() };
+    Ok((stat.f_bavail as u64).saturating_mul(stat.f_frsize as u64) / 1_048_576)
+}
+#[cfg(not(unix))]
+fn disk_available_mib(_path: &Path) -> Result<u64> {
+    bail!("Disk probe unsupported on this platform")
+}
+fn memory_available_mib(cwd: &Path) -> Option<u64> {
+    if let Ok(info) = fs::read_to_string("/proc/meminfo") {
+        return info
+            .lines()
+            .find(|l| l.starts_with("MemAvailable:"))?
+            .split_whitespace()
+            .nth(1)?
+            .parse::<u64>()
+            .ok()
+            .map(|kb| kb / 1024);
+    }
+    if std::env::consts::OS == "macos" {
+        let info = command_output("vm_stat", &[], cwd).ok()?;
+        let page_size = info
+            .lines()
+            .next()?
+            .split("page size of ")
+            .nth(1)?
+            .split_whitespace()
+            .next()?
+            .parse::<u64>()
+            .ok()?;
+        let pages: u64 = info
+            .lines()
+            .filter(|l| {
+                l.starts_with("Pages free:")
+                    || l.starts_with("Pages inactive:")
+                    || l.starts_with("Pages speculative:")
+            })
+            .filter_map(|l| {
+                l.split(':')
+                    .nth(1)?
+                    .trim()
+                    .trim_end_matches('.')
+                    .parse::<u64>()
+                    .ok()
+            })
+            .sum();
+        return Some(pages.saturating_mul(page_size) / 1_048_576);
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn numeric_versions_compare_components() {
+        assert!(version_at_least("cargo 1.90.0", "1.85"));
+        assert!(!version_at_least("node v9.12.1", "24"));
+        assert!(version_at_least("v24.1.0", "24"));
+        assert!(!version_at_least("unknown", "1"));
+    }
+    #[test]
+    fn env_probe_never_includes_values() {
+        let requirements: ProjectRequirements =
+            serde_json::from_value(serde_json::json!({"env":["PATH"]})).unwrap();
+        let report = system_checks(&std::env::temp_dir(), &requirements, None);
+        let json = serde_json::to_string(&report).unwrap();
+        assert!(!json.contains(&std::env::var("PATH").unwrap()));
+    }
+}

--- a/src/commands/handoff/probe.rs
+++ b/src/commands/handoff/probe.rs
@@ -320,14 +320,11 @@ fn disk_available_mib(_path: &Path) -> Result<u64> {
 }
 fn memory_available_mib(cwd: &Path) -> Option<u64> {
     if let Ok(info) = fs::read_to_string("/proc/meminfo") {
-        return info
-            .lines()
-            .find(|l| l.starts_with("MemAvailable:"))?
-            .split_whitespace()
-            .nth(1)?
-            .parse::<u64>()
-            .ok()
-            .map(|kb| kb / 1024);
+        let membership = fs::read_to_string("/proc/self/cgroup").unwrap_or_default();
+        let mounts = fs::read_to_string("/proc/self/mountinfo").unwrap_or_default();
+        return linux_memory_available_mib(&info, &membership, &mounts, |path| {
+            fs::read_to_string(path).ok()
+        });
     }
     if std::env::consts::OS == "macos" {
         let info = command_output("vm_stat", &[], cwd).ok()?;
@@ -361,6 +358,114 @@ fn memory_available_mib(cwd: &Path) -> Option<u64> {
     None
 }
 
+/// MemAvailable describes the host even inside a container. Cgroup usage includes
+/// this workspace's processes, so its remaining allowance can be much smaller.
+fn linux_memory_available_mib(
+    meminfo: &str,
+    membership: &str,
+    mountinfo: &str,
+    read: impl Fn(&Path) -> Option<String>,
+) -> Option<u64> {
+    let host = meminfo
+        .lines()
+        .find(|line| line.starts_with("MemAvailable:"))?
+        .split_whitespace()
+        .nth(1)?
+        .parse::<u64>()
+        .ok()?
+        .saturating_mul(1024);
+    let mut available = host;
+    for mount in mountinfo.lines() {
+        let Some((fields, filesystem)) = mount.split_once(" - ") else {
+            continue;
+        };
+        let filesystem: Vec<_> = filesystem.split_whitespace().collect();
+        let v2 = filesystem.first() == Some(&"cgroup2");
+        let v1 = filesystem.first() == Some(&"cgroup")
+            && filesystem
+                .get(2)
+                .is_some_and(|options| options.split(',').any(|option| option == "memory"));
+        if !v1 && !v2 {
+            continue;
+        }
+        let fields: Vec<_> = fields.split_whitespace().collect();
+        let (Some(root), Some(mountpoint)) = (fields.get(3), fields.get(4)) else {
+            continue;
+        };
+        let root = PathBuf::from(unescape_mount_path(root));
+        let mountpoint = PathBuf::from(unescape_mount_path(mountpoint));
+        for group in membership.lines() {
+            let mut parts = group.splitn(3, ':');
+            let (Some(_), Some(controllers), Some(group)) =
+                (parts.next(), parts.next(), parts.next())
+            else {
+                continue;
+            };
+            if !(v2 && controllers.is_empty()
+                || v1
+                    && controllers
+                        .split(',')
+                        .any(|controller| controller == "memory"))
+            {
+                continue;
+            }
+            let group = Path::new(group);
+            let relative = match group.strip_prefix(&root) {
+                Ok(relative) => relative,
+                // A cgroup namespace can expose its own root as `/`.
+                Err(_) if group == Path::new("/") => Path::new(""),
+                Err(_) => continue,
+            };
+            if relative
+                .components()
+                .any(|component| matches!(component, std::path::Component::ParentDir))
+            {
+                continue;
+            }
+            let mut directory = mountpoint.join(relative);
+            let (limit_file, usage_file) = if v2 {
+                ("memory.max", "memory.current")
+            } else {
+                ("memory.limit_in_bytes", "memory.usage_in_bytes")
+            };
+            // A child may be unlimited while a parent imposes the effective cap.
+            loop {
+                let remaining = (|| {
+                    let limit = read(&directory.join(limit_file))?
+                        .trim()
+                        .parse::<u64>()
+                        .ok()?;
+                    // v1 represents "unlimited" with a page-rounded LONG_MAX.
+                    if v1 && limit >= (1 << 60) {
+                        return None;
+                    }
+                    // Even without a usable usage counter, never report more
+                    // memory than the container's known hard limit.
+                    let usage = read(&directory.join(usage_file))
+                        .and_then(|value| value.trim().parse::<u64>().ok())
+                        .unwrap_or(0);
+                    Some(limit.saturating_sub(usage))
+                })();
+                if let Some(remaining) = remaining {
+                    available = available.min(remaining);
+                }
+                if directory == mountpoint || !directory.pop() {
+                    break;
+                }
+            }
+        }
+    }
+    Some(available / 1_048_576)
+}
+
+fn unescape_mount_path(path: &str) -> String {
+    // mountinfo escapes these four characters, including literal backslashes.
+    path.replace("\\040", " ")
+        .replace("\\011", "\t")
+        .replace("\\012", "\n")
+        .replace("\\134", "\\")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -378,5 +483,133 @@ mod tests {
         let report = system_checks(&std::env::temp_dir(), &requirements, None);
         let json = serde_json::to_string(&report).unwrap();
         assert!(!json.contains(&std::env::var("PATH").unwrap()));
+    }
+    fn memory_fixture(membership: &str, mounts: &str, files: &[(&str, &str)]) -> Option<u64> {
+        linux_memory_available_mib("MemAvailable:   2930688 kB\n", membership, mounts, |path| {
+            files
+                .iter()
+                .find_map(|(name, value)| (path == Path::new(name)).then(|| value.to_string()))
+        })
+    }
+
+    const V2_MOUNT: &str = "31 20 0:28 / /sys/fs/cgroup rw - cgroup2 cgroup rw";
+
+    #[test]
+    fn memory_respects_container_limit_and_current_usage() {
+        assert_eq!(
+            memory_fixture(
+                "0::/",
+                V2_MOUNT,
+                &[
+                    ("/sys/fs/cgroup/memory.max", "1073741824\n"),
+                    ("/sys/fs/cgroup/memory.current", "268435456\n"),
+                ]
+            ),
+            Some(768)
+        );
+        assert_eq!(
+            linux_memory_available_mib("MemAvailable: 131072 kB", "0::/", V2_MOUNT, |path| {
+                Some(
+                    if path.ends_with("memory.max") {
+                        "1073741824"
+                    } else {
+                        "268435456"
+                    }
+                    .into(),
+                )
+            }),
+            Some(128)
+        );
+        assert_eq!(
+            memory_fixture(
+                "0::/",
+                V2_MOUNT,
+                &[
+                    ("/sys/fs/cgroup/memory.max", "100"),
+                    ("/sys/fs/cgroup/memory.current", "101"),
+                ]
+            ),
+            Some(0)
+        );
+    }
+
+    #[test]
+    fn memory_falls_back_for_missing_unlimited_or_malformed_cgroups() {
+        for files in [
+            vec![],
+            vec![
+                ("/sys/fs/cgroup/memory.max", "max"),
+                ("/sys/fs/cgroup/memory.current", "100"),
+            ],
+            vec![
+                ("/sys/fs/cgroup/memory.max", "invalid"),
+                ("/sys/fs/cgroup/memory.current", "100"),
+            ],
+        ] {
+            assert_eq!(memory_fixture("0::/", V2_MOUNT, &files), Some(2862));
+        }
+        assert_eq!(memory_fixture("", "", &[]), Some(2862));
+        for files in [
+            vec![("/sys/fs/cgroup/memory.max", "1073741824")],
+            vec![
+                ("/sys/fs/cgroup/memory.max", "1073741824"),
+                ("/sys/fs/cgroup/memory.current", "invalid"),
+            ],
+        ] {
+            assert_eq!(memory_fixture("0::/", V2_MOUNT, &files), Some(1024));
+        }
+    }
+
+    #[test]
+    fn memory_resolves_cgroup_mounts_and_parent_limits() {
+        let mounts = "31 20 0:28 /docker/test /custom\\040cgroup rw - cgroup2 cgroup rw";
+        assert_eq!(
+            memory_fixture(
+                "0::/docker/test/child",
+                mounts,
+                &[
+                    ("/custom cgroup/child/memory.max", "max"),
+                    ("/custom cgroup/child/memory.current", "0"),
+                    ("/custom cgroup/memory.max", "1073741824"),
+                    ("/custom cgroup/memory.current", "536870912"),
+                ]
+            ),
+            Some(512)
+        );
+        assert_eq!(
+            memory_fixture(
+                "0::/",
+                mounts,
+                &[
+                    ("/custom cgroup/memory.max", "1073741824"),
+                    ("/custom cgroup/memory.current", "536870912"),
+                ]
+            ),
+            Some(512)
+        );
+    }
+
+    #[test]
+    fn memory_supports_v1_limits_and_unlimited_sentinel() {
+        let mounts = "31 20 0:28 / /sys/fs/cgroup/memory rw - cgroup cgroup rw,memory";
+        let membership = "3:cpu,cpuacct:/other\n4:memory:/workspace";
+        let limit = "/sys/fs/cgroup/memory/workspace/memory.limit_in_bytes";
+        let usage = "/sys/fs/cgroup/memory/workspace/memory.usage_in_bytes";
+        assert_eq!(
+            memory_fixture(
+                membership,
+                mounts,
+                &[(limit, "1073741824"), (usage, "268435456")]
+            ),
+            Some(768)
+        );
+        assert_eq!(
+            memory_fixture(
+                membership,
+                mounts,
+                &[(limit, "9223372036854771712"), (usage, "268435456")]
+            ),
+            Some(2862)
+        );
     }
 }

--- a/src/commands/handoff/report.rs
+++ b/src/commands/handoff/report.rs
@@ -1,0 +1,69 @@
+use serde::Serialize;
+#[derive(Debug, Serialize)]
+pub(crate) struct Check {
+    pub id: String,
+    pub label: String,
+    pub status: String,
+    pub message: String,
+    pub scope: String,
+}
+impl Check {
+    fn new(id: &str, label: &str, status: &str, message: impl Into<String>) -> Self {
+        Self {
+            id: id.into(),
+            label: label.into(),
+            status: status.into(),
+            message: message.into(),
+            scope: "editing".into(),
+        }
+    }
+    pub fn ok(id: &str, label: &str, message: impl Into<String>) -> Self {
+        Self::new(id, label, "ok", message)
+    }
+    pub fn warn(id: &str, label: &str, message: impl Into<String>) -> Self {
+        Self::new(id, label, "warn", message)
+    }
+    pub fn fail(id: &str, label: &str, message: impl Into<String>) -> Self {
+        Self::new(id, label, "fail", message)
+    }
+}
+#[derive(Debug, Serialize)]
+pub(crate) struct ProbeReport {
+    pub checks: Vec<Check>,
+    pub verdict: String,
+}
+impl Default for ProbeReport {
+    fn default() -> Self {
+        Self {
+            checks: vec![],
+            verdict: "ok".into(),
+        }
+    }
+}
+impl ProbeReport {
+    pub fn add(&mut self, check: Check) {
+        if check.status == "fail" || (check.status == "warn" && self.verdict == "ok") {
+            self.verdict = check.status.clone();
+        }
+        self.checks.push(check);
+    }
+    pub fn print(&self, json: bool) -> anyhow::Result<()> {
+        if json {
+            println!("{}", serde_json::to_string_pretty(self)?);
+        } else {
+            for c in &self.checks {
+                crate::human!("{:5} {:22} {}", c.status, c.label, c.message);
+            }
+            crate::human!("Readiness: {}", self.verdict);
+        }
+        Ok(())
+    }
+}
+#[derive(Debug)]
+pub struct ProbeFailed;
+impl std::fmt::Display for ProbeFailed {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("Handoff readiness checks failed")
+    }
+}
+impl std::error::Error for ProbeFailed {}

--- a/src/commands/log.rs
+++ b/src/commands/log.rs
@@ -12,6 +12,7 @@ use std::path::PathBuf;
 pub fn show_log(limit: Option<usize>, shorthand_limit: Option<&str>) -> Result<()> {
     let limit = resolve_limit(limit, shorthand_limit)?;
     let active = load_active_bundle()?;
+    crate::commands::handoff::print_location(&active.bundle);
     if active.bundle.nodes.is_empty() && active.bundle.commit_groups.is_empty() {
         println!("{}", out::muted("No bundle nodes recorded yet."));
         return Ok(());

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -11,6 +11,7 @@ pub mod doctor;
 pub mod fetch;
 pub mod git_credential;
 pub mod git_passthrough;
+pub mod handoff;
 pub mod history;
 pub mod init;
 pub mod land;

--- a/src/commands/project.rs
+++ b/src/commands/project.rs
@@ -536,7 +536,23 @@ pub fn pull_project_config(name: Option<&str>, repo_id: &str, agents: bool) -> R
         .iter()
         .find(|repo| repo.id == repo_id)
         .with_context(|| format!("repo `{repo_id}` is not listed in project `{}`", project.id))?;
-    let repo_root = Path::new(&repo_entry.path);
+    let bundle_checkout = crate::store::load_active_bundle()
+        .ok()
+        .filter(|active| {
+            active.bundle.project_id.as_deref() == Some(project_id.as_str())
+                && active.resolution_source != crate::store::BundleResolutionSource::Config
+        })
+        .and_then(|active| {
+            active
+                .bundle
+                .repos
+                .iter()
+                .find(|repo| repo.id == repo_id)
+                .and_then(|repo| crate::checkout::checkout_dir(&active, repo))
+        });
+    let repo_root = bundle_checkout
+        .as_deref()
+        .unwrap_or_else(|| Path::new(&repo_entry.path));
     let config_path = repo_root.join(PROJECT_CONFIG_FILE);
     if !config_path.exists() {
         bail!(
@@ -556,6 +572,9 @@ pub fn pull_project_config(name: Option<&str>, repo_id: &str, agents: bool) -> R
         );
     }
 
+    if incoming.requirements.is_some() {
+        project.requirements = incoming.requirements;
+    }
     if incoming.runtime.is_some() {
         project.runtime = incoming.runtime;
     }

--- a/src/commands/remote/clone.rs
+++ b/src/commands/remote/clone.rs
@@ -94,6 +94,7 @@ pub fn clone_project_from_remote(
     token: Option<&str>,
     active_bundle: Option<&str>,
     materialize: bool,
+    prefer_https: bool,
     json: bool,
 ) -> Result<()> {
     if json {
@@ -107,6 +108,7 @@ pub fn clone_project_from_remote(
         token,
         active_bundle,
         materialize,
+        prefer_https,
     ) {
         Ok(document) => {
             if json {
@@ -137,13 +139,31 @@ fn clone_project_classified(
     token: Option<&str>,
     active_bundle: Option<&str>,
     materialize: bool,
+    prefer_https: bool,
 ) -> std::result::Result<CloneDocument, (RemoteErrorKind, anyhow::Error)> {
     let reference = parse_clone_reference(project_identifier, url)
         .map_err(|error| (RemoteErrorKind::NoRemote, error))?;
     let (remote_name, remote, stored_token, token) =
         resolve_remote_for_clone_classified(remote_name, reference.remote_url.as_deref(), token)?;
-    let export = fetch_project_export(&remote, token.as_deref(), &reference.project_identifier)
+    let mut export = fetch_project_export(&remote, token.as_deref(), &reference.project_identifier)
         .map_err(|error| (RemoteErrorKind::Http, error))?;
+    if prefer_https {
+        if let Some(token) = token.as_deref() {
+            let hosts = super::helpers::connected_forge_hosts(&remote, token).unwrap_or_default();
+            let cwd = std::env::current_dir().map_err(|e| (RemoteErrorKind::Other, e.into()))?;
+            for repository in &mut export.repositories {
+                if let Some(url) = repository.remote_url.clone() {
+                    if let Some(https) = super::handoff::prefer_https_url(&url, &hosts) {
+                        if super::handoff::reachable(&cwd, &url, &remote_name, &hosts).is_err()
+                            && super::handoff::reachable(&cwd, &https, &remote_name, &hosts).is_ok()
+                        {
+                            repository.remote_url = Some(https);
+                        }
+                    }
+                }
+            }
+        }
+    }
     clone_fetched_export(
         &reference.project_identifier,
         target,
@@ -159,7 +179,7 @@ fn clone_project_classified(
 }
 
 #[allow(clippy::too_many_arguments)]
-fn clone_fetched_export(
+pub(super) fn clone_fetched_export(
     project_identifier: &str,
     target: Option<&Path>,
     remote_name: String,
@@ -603,7 +623,7 @@ pub(super) fn clone_export_repositories(
 /// Clone (or adopt) one exported repository. Authentication comes from the
 /// installed Git credential helpers; a failed non-public clone carries the
 /// access hint.
-fn clone_one_export_repository(
+pub(super) fn clone_one_export_repository(
     target_root: &Path,
     repository: &RemoteExportRepository,
 ) -> Result<(String, PathBuf)> {
@@ -619,13 +639,19 @@ fn clone_one_export_repository(
         if !is_git_worktree(&repo_path) {
             bail!("{} exists but is not a git checkout.", repo_path.display());
         }
+        let origin = git_output(&repo_path, ["remote", "get-url", "origin"])?;
+        if !super::handoff::same_repository_url(origin.trim(), remote_url) {
+            bail!(
+                "{} belongs to a different Git origin; refusing to adopt it",
+                repo_path.display()
+            );
+        }
         crate::human!(
             "{}: {} {}",
             out::repo(&local_id),
             out::muted("using existing checkout"),
             out::path(repo_path.display())
         );
-        checkout_export_base_branch(&repo_path, repository)?;
         return Ok((local_id, repo_path));
     }
 

--- a/src/commands/remote/clone.rs
+++ b/src/commands/remote/clone.rs
@@ -131,6 +131,7 @@ pub fn clone_project_from_remote(
 
 /// Run the clone, tagging every failure with its machine-readable error kind so
 /// the `--json` wrapper can emit the contract error envelope.
+#[allow(clippy::too_many_arguments)] // Mirrors the public clone command's CLI options.
 fn clone_project_classified(
     project_identifier: &str,
     target: Option<&Path>,

--- a/src/commands/remote/handoff.rs
+++ b/src/commands/remote/handoff.rs
@@ -1,0 +1,328 @@
+//! Transport adapter for handoff. Keep remote credentials and export internals here.
+use super::{client, clone, helpers, RemoteProjectExport};
+use crate::model::{ChangeGroup, KnitProject, KnitRemote, LedgerRelation};
+use crate::store::{self, ActiveBundle};
+use anyhow::{bail, Context, Result};
+use std::{collections::BTreeSet, path::Path};
+
+pub(crate) struct HandoffExport {
+    pub unpublished: bool,
+    pub remote_name: String,
+    pub bundle: ChangeGroup,
+    pub project: Option<KnitProject>,
+    remote: KnitRemote,
+    token: String,
+    export: RemoteProjectExport,
+    artifact_hash: String,
+    remote_bundle_id: String,
+}
+
+impl HandoffExport {
+    pub fn fetch(project: &str, slug: &str, allow_unpublished: bool) -> Result<Self> {
+        let (name, remote, _stored, token) =
+            clone::resolve_remote_for_clone_classified(None, None, None).map_err(|(_, e)| e)?;
+        let token = token
+            .context("A sync remote token is required. Configure it in global Knit config.")?;
+        let global = store::load_global_config()?;
+        let global_remote = global.remotes.get(&name).context("Handoff requires the sync remote in global config; run `knit remote add <name> <url> --global`.")?;
+        if global_remote.url.trim_end_matches('/') != remote.url.trim_end_matches('/') {
+            bail!("Workspace and global sync remote URLs differ; correct the remote before handing off.");
+        }
+        let _: serde_json::Value =
+            client::request_json(&remote, &token, "GET", "/me/access-token", None)
+                .context("Sync remote token validation failed")?;
+        let export = client::fetch_project_export(&remote, Some(&token), project)?;
+        let entry = export.bundles.iter().find(|b| b.slug == slug);
+        let unpublished = entry.is_none();
+        let (bundle, artifact_hash, remote_bundle_id) = if let Some(entry) = entry {
+            if entry.lifecycle_state != "open" {
+                bail!("Bundle `{slug}` is not open.");
+            }
+            let (bundle, hash) =
+                client::resolve_export_bundle_payload(&remote, Some(&token), entry)?;
+            (bundle, hash, entry.id.clone())
+        } else if allow_unpublished {
+            let mut bundle = ChangeGroup::new(slug.into(), slug.into(), crate::time::now_iso());
+            bundle.project_id = Some(export.project.slug.clone());
+            for record in &export.repositories {
+                bundle.repos.push(serde_json::from_value(serde_json::json!({
+                    "id": clone::export_repo_local_id(record), "path": "", "remote": record.remote_url,
+                    "baseBranch": record.default_branch.as_deref().unwrap_or("main")
+                }))?);
+            }
+            (bundle, String::new(), String::new())
+        } else {
+            bail!("Remote has no bundle `{slug}` in `{project}`; publish handoff out first.");
+        };
+        if !bundle.sync_targets.is_empty()
+            && !bundle
+                .sync_targets
+                .iter()
+                .any(|t| t.api_url.trim_end_matches('/') == remote.url.trim_end_matches('/'))
+        {
+            bail!("Bundle sync targets do not include this sync remote API.");
+        }
+        Ok(Self {
+            unpublished,
+            remote_name: name,
+            bundle,
+            project: export.knit_project.clone(),
+            remote,
+            token,
+            export,
+            artifact_hash,
+            remote_bundle_id,
+        })
+    }
+
+    /// Resolve transport on this machine, without persisting a rewritten origin URL.
+    pub fn probe_repositories(&mut self, cwd: &Path) -> Vec<(String, Result<()>)> {
+        let mut results = Vec::new();
+        let hosts = helpers::connected_forge_hosts(&self.remote, &self.token).unwrap_or_default();
+        for repo in &self.bundle.repos {
+            let result = (|| {
+                let record = self
+                    .export
+                    .repositories
+                    .iter_mut()
+                    .find(|r| clone::export_repo_local_id(r) == repo.id)
+                    .with_context(|| {
+                        format!(
+                            "{} is missing from the export (check project access)",
+                            repo.id
+                        )
+                    })?;
+                let remote = record
+                    .remote_url
+                    .as_deref()
+                    .context("Repository has no remote URL")?;
+                // Install a temporary exact-host helper only on this Git invocation.
+                // Probe must not mutate the user's global Git configuration.
+                if reachable(cwd, remote, &self.remote_name, &hosts).is_ok() {
+                    return Ok(());
+                }
+                if let Some(https) = prefer_https_url(remote, &hosts) {
+                    reachable(cwd, &https, &self.remote_name, &hosts)?;
+                    record.remote_url = Some(https);
+                    return Ok(());
+                }
+                bail!("Cannot reach repository origin with this machine's Git credentials")
+            })();
+            results.push((repo.id.clone(), result));
+        }
+        results
+    }
+
+    pub fn materialize(mut self, root: &Path) -> Result<ActiveBundle> {
+        let slug = self.bundle.id.clone();
+        self.export.bundles.retain(|b| b.slug == slug);
+        if !root.join(".knit/config.json").exists() {
+            // Persist the bootstrap before cloning so a failed repository clone
+            // resumes through the same missing-repository path on retry.
+            if root.exists() && std::fs::read_dir(root)?.next().is_some() {
+                bail!("Target directory is not empty");
+            }
+            for directory in [".knit/projects", ".knit/bundles", ".knit/worktrees"] {
+                std::fs::create_dir_all(root.join(directory))?;
+            }
+            let mut project = self.project.clone().unwrap_or_else(|| {
+                KnitProject::new(self.export.project.slug.clone(), crate::time::now_iso())
+            });
+            if self.project.is_none() {
+                project.repos = self
+                    .export
+                    .repositories
+                    .iter()
+                    .map(|record| {
+                        clone::project_repo_entry_from_export(
+                            record,
+                            &root.join(clone::export_repo_local_id(record)),
+                        )
+                    })
+                    .collect();
+            } else {
+                for repo in &mut project.repos {
+                    repo.path = root.join(&repo.id).to_string_lossy().into_owned();
+                }
+            }
+            let mut config = crate::model::KnitConfig::new_project(project.id.clone());
+            config.active_bundle = Some(slug.clone());
+            config.sync_remote = Some(self.remote_name.clone());
+            config.sync_remotes = vec![self.remote_name.clone()];
+            // Tokens stay in the target user's global config.
+            store::write_json(&store::project_path(root, &project.id), &project)?;
+            store::save_config(root, &config)?;
+        }
+        {
+            let config = store::load_effective_config(root)?;
+            let project_id = config
+                .active_project
+                .context("Target workspace has no active project")?;
+            let expected_id = self
+                .project
+                .as_ref()
+                .map(|p| p.id.as_str())
+                .unwrap_or(&self.export.project.slug);
+            if project_id != expected_id {
+                bail!(
+                    "Target workspace belongs to project `{project_id}`, expected `{expected_id}`."
+                );
+            }
+            let path = store::bundle_path(root, &slug);
+            let _lock = store::acquire_named_lock(root, &slug)?;
+            let local: Option<ChangeGroup> =
+                path.exists().then(|| store::read_json(&path)).transpose()?;
+            if let Some(local) = &local {
+                match crate::model::ledger_relation(&local.node_id_sequence(), &self.bundle.node_id_sequence()) {
+                    LedgerRelation::Diverged => bail!("Local and remote ledgers diverged; run `knit --bundle {slug} pull --merge` in {} and retry handoff in.", root.display()),
+                    LedgerRelation::LocalAhead => {
+                        // A previous acceptance may be saved but its artifact push failed.
+                        self.bundle = local.clone();
+                    }
+                    _ => {}
+                }
+            }
+            let mut project: KnitProject =
+                store::read_json(&store::project_path(root, &project_id))?;
+            helpers::ensure_helpers_for_git(&self.remote_name);
+            ensure_bundle_repositories(root, &mut project, &self.export, &self.bundle)?;
+            let mut localized = client::localize_bundle(self.bundle, &project)?;
+            if let Some(local) = local {
+                for repo in &mut localized.repos {
+                    repo.worktree_path = local
+                        .repos
+                        .iter()
+                        .find(|r| r.id == repo.id)
+                        .and_then(|r| r.worktree_path.clone());
+                }
+            }
+            localized.record_sync_target_with_artifact(
+                &self.remote_name,
+                &self.remote_bundle_id,
+                &self.remote.url,
+                Some(&self.artifact_hash),
+            );
+            store::write_json(&path, &localized)?;
+            drop(_lock);
+            helpers::ensure_helpers_for_git(&self.remote_name);
+            clone::materialize_imported_bundle(root, &slug)?;
+        }
+        let path = store::bundle_path(root, &slug);
+        Ok(ActiveBundle::unlocked(
+            root.to_path_buf(),
+            path.clone(),
+            store::read_json(&path)?,
+        ))
+    }
+}
+
+/// Clone only missing bundle repositories. Existing checkouts retain their branches.
+pub(super) fn ensure_bundle_repositories(
+    root: &Path,
+    project: &mut KnitProject,
+    export: &RemoteProjectExport,
+    bundle: &ChangeGroup,
+) -> Result<()> {
+    for repo in &bundle.repos {
+        if project
+            .repos
+            .iter()
+            .any(|r| r.id == repo.id && Path::new(&r.path).exists())
+        {
+            continue;
+        }
+        let record = export
+            .repositories
+            .iter()
+            .find(|r| clone::export_repo_local_id(r) == repo.id)
+            .with_context(|| {
+                format!(
+                    "{} is missing from the export; check project access",
+                    repo.id
+                )
+            })?;
+        let (_, path) = clone::clone_one_export_repository(root, record)?;
+        let entry = clone::project_repo_entry_from_export(record, &path);
+        project.repos.retain(|r| r.id != repo.id);
+        project.repos.push(entry);
+        store::write_json(&store::project_path(root, &project.id), project)?;
+    }
+    Ok(())
+}
+
+pub(crate) fn prefer_https_url(remote: &str, hosts: &BTreeSet<String>) -> Option<String> {
+    let (host, path) = if let Some(rest) = remote.strip_prefix("git@") {
+        rest.split_once(':')?
+    } else {
+        return None;
+    };
+    if !hosts.contains(host)
+        || path.is_empty()
+        || path.starts_with('/')
+        || path.contains(['?', '#', '\\'])
+        || path.split('/').any(|s| s == "..")
+    {
+        return None;
+    }
+    Some(format!("https://{host}/{path}"))
+}
+
+pub(super) fn reachable(
+    cwd: &Path,
+    remote: &str,
+    name: &str,
+    hosts: &BTreeSet<String>,
+) -> Result<()> {
+    let mut args = Vec::<String>::new();
+    for host in hosts {
+        args.extend([
+            "-c".into(),
+            format!(
+                "credential.https://{host}.helper={}",
+                helpers::helper_command(name)?
+            ),
+        ]);
+    }
+    args.extend(["ls-remote".into(), "--".into(), remote.into()]);
+    crate::commands::handoff::probe::command_output("git", &args, cwd).map(|_| ())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn https_rewrite_is_exact_host_and_path_scoped() {
+        let hosts = BTreeSet::from(["github.com".into()]);
+        assert_eq!(
+            prefer_https_url("git@github.com:o/r.git", &hosts).as_deref(),
+            Some("https://github.com/o/r.git")
+        );
+        assert!(prefer_https_url("git@evil.github.com:o/r", &hosts).is_none());
+        assert!(prefer_https_url("git@github.com:../r", &hosts).is_none());
+        assert!(prefer_https_url("https://github.com/o/r", &hosts).is_none());
+    }
+}
+
+/// Compare equivalent SSH/HTTPS forge forms without relaxing the repository path.
+pub(crate) fn same_repository_url(left: &str, right: &str) -> bool {
+    fn identity(value: &str) -> String {
+        let value = value.trim_end_matches('/').trim_end_matches(".git");
+        if let Some(rest) = value.strip_prefix("git@") {
+            if let Some((host, path)) = rest.split_once(':') {
+                return format!("{}/{}", host.to_ascii_lowercase(), path);
+            }
+        }
+        if let Ok(url) = url::Url::parse(value) {
+            if let Some(host) = url.host_str() {
+                return format!(
+                    "{}{}{}",
+                    host.to_ascii_lowercase(),
+                    url.port().map(|p| format!(":{p}")).unwrap_or_default(),
+                    url.path()
+                );
+            }
+        }
+        value.to_string()
+    }
+    identity(left) == identity(right)
+}

--- a/src/commands/remote/handoff.rs
+++ b/src/commands/remote/handoff.rs
@@ -251,11 +251,7 @@ pub(super) fn ensure_bundle_repositories(
 }
 
 pub(crate) fn prefer_https_url(remote: &str, hosts: &BTreeSet<String>) -> Option<String> {
-    let (host, path) = if let Some(rest) = remote.strip_prefix("git@") {
-        rest.split_once(':')?
-    } else {
-        return None;
-    };
+    let (host, path) = remote.strip_prefix("git@")?.split_once(':')?;
     if !hosts.contains(host)
         || path.is_empty()
         || path.starts_with('/')
@@ -287,22 +283,6 @@ pub(super) fn reachable(
     crate::commands::handoff::probe::command_output("git", &args, cwd).map(|_| ())
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    #[test]
-    fn https_rewrite_is_exact_host_and_path_scoped() {
-        let hosts = BTreeSet::from(["github.com".into()]);
-        assert_eq!(
-            prefer_https_url("git@github.com:o/r.git", &hosts).as_deref(),
-            Some("https://github.com/o/r.git")
-        );
-        assert!(prefer_https_url("git@evil.github.com:o/r", &hosts).is_none());
-        assert!(prefer_https_url("git@github.com:../r", &hosts).is_none());
-        assert!(prefer_https_url("https://github.com/o/r", &hosts).is_none());
-    }
-}
-
 /// Compare equivalent SSH/HTTPS forge forms without relaxing the repository path.
 pub(crate) fn same_repository_url(left: &str, right: &str) -> bool {
     fn identity(value: &str) -> String {
@@ -325,4 +305,20 @@ pub(crate) fn same_repository_url(left: &str, right: &str) -> bool {
         value.to_string()
     }
     identity(left) == identity(right)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn https_rewrite_is_exact_host_and_path_scoped() {
+        let hosts = BTreeSet::from(["github.com".into()]);
+        assert_eq!(
+            prefer_https_url("git@github.com:o/r.git", &hosts).as_deref(),
+            Some("https://github.com/o/r.git")
+        );
+        assert!(prefer_https_url("git@evil.github.com:o/r", &hosts).is_none());
+        assert!(prefer_https_url("git@github.com:../r", &hosts).is_none());
+        assert!(prefer_https_url("https://github.com/o/r", &hosts).is_none());
+    }
 }

--- a/src/commands/remote/helpers.rs
+++ b/src/commands/remote/helpers.rs
@@ -26,7 +26,7 @@ fn is_knit_helper_for(value: &str, remote_name: &str) -> bool {
         && value.ends_with(&format!("{HELPER_MARKER}{}", shell_quote(remote_name)))
 }
 
-fn helper_command(remote_name: &str) -> Result<String> {
+pub(super) fn helper_command(remote_name: &str) -> Result<String> {
     let executable = std::env::current_exe().context("failed to resolve the knit executable")?;
     let executable = executable
         .to_str()
@@ -218,7 +218,7 @@ fn git_config(args: &[&str]) -> Result<()> {
 
 /// The remote's connected forge hosts, exact-HTTPS-host validated on our side
 /// regardless of what the server sent.
-fn connected_forge_hosts(remote: &KnitRemote, token: &str) -> Result<BTreeSet<String>> {
+pub(super) fn connected_forge_hosts(remote: &KnitRemote, token: &str) -> Result<BTreeSet<String>> {
     #[derive(Deserialize)]
     struct Descriptor {
         connected: bool,

--- a/src/commands/remote/mod.rs
+++ b/src/commands/remote/mod.rs
@@ -11,6 +11,7 @@ mod client;
 mod clone;
 mod credentials;
 mod facade;
+pub(crate) mod handoff;
 mod helpers;
 mod history;
 mod projects;
@@ -38,6 +39,7 @@ pub use push::{
     remove_remote, set_remote_token, show_remote, sync_active_bundle_to_remote_if_enabled,
     sync_bundle_to_remote_if_enabled,
 };
+pub(crate) use push::{push_active_bundle_to_remote, push_handoff_bundle_to_remote};
 
 use crate::model::{HistoryEvent, KnitProject, ProjectView};
 use serde::Deserialize;

--- a/src/commands/remote/pull.rs
+++ b/src/commands/remote/pull.rs
@@ -1234,7 +1234,7 @@ fn pull_bundle_by_slug_classified(
         &export.decoded_history_events(&project_id),
     )
     .map_err(other)?;
-    let local_project = load_project_if_present(&root, &project_id)
+    let mut local_project = load_project_if_present(&root, &project_id)
         .map_err(other)?
         .with_context(|| format!("No local Knit project named `{project_id}`."))
         .map_err(other)?;
@@ -1260,6 +1260,9 @@ fn pull_bundle_by_slug_classified(
     let (mut bundle, artifact_hash) =
         resolve_export_bundle_payload(&remote, Some(&token), remote_bundle)
             .map_err(|error| (RemoteErrorKind::Http, error))?;
+    super::helpers::ensure_helpers_for_git(&remote_name);
+    super::handoff::ensure_bundle_repositories(&root, &mut local_project, &export, &bundle)
+        .map_err(other)?;
     let bundle_id = bundle.id.clone();
     if root
         .join(".knit/deleted/bundles")

--- a/src/commands/remote/push.rs
+++ b/src/commands/remote/push.rs
@@ -656,11 +656,29 @@ pub fn push_bundle_to_remote(
     push_active_bundle_to_remote(remote_name, project, &mut active, force)
 }
 
-fn push_active_bundle_to_remote(
+pub(crate) fn push_active_bundle_to_remote(
     remote_name: &str,
     project: Option<&str>,
     active: &mut ActiveBundle,
     force: PushForce,
+) -> Result<()> {
+    push_active_bundle_to_remote_impl(remote_name, project, active, force, true)
+}
+
+/// Handoff moves one bundle; it must not reshape an existing hosted project.
+pub(crate) fn push_handoff_bundle_to_remote(
+    remote_name: &str,
+    active: &mut ActiveBundle,
+) -> Result<()> {
+    push_active_bundle_to_remote_impl(remote_name, None, active, PushForce::No, false)
+}
+
+fn push_active_bundle_to_remote_impl(
+    remote_name: &str,
+    project: Option<&str>,
+    active: &mut ActiveBundle,
+    force: PushForce,
+    publish_project_shape: bool,
 ) -> Result<()> {
     // An open bundle's artifact must never reach a sync remote unless its
     // feature branches are on git origin: pushing a bundle means branches +
@@ -669,7 +687,7 @@ fn push_active_bundle_to_remote(
         crate::commands::push::ensure_open_bundle_branches_on_origin(&active.root, &active.bundle)
             .context("feature branches not pushed; artifact not synced")?;
     for line in &branch_lines {
-        println!("{line}");
+        crate::human!("{line}");
     }
 
     let config = load_effective_config(&active.root)?;
@@ -680,15 +698,29 @@ fn push_active_bundle_to_remote(
         .context("No project selected. Pass --project or run `knit init <name>`.")?;
     // Say that the sync has started: the branch pushes above finish in
     // seconds, and a silent minute after them read as a hang.
-    println!(
+    crate::human!(
         "{}",
         out::muted(format!("syncing {} to {remote_name}…", active.bundle.id))
     );
     let remote = resolve_remote(&config, remote_name)?;
     let token = resolve_token(remote_name, remote)?;
     let local_project = load_project_if_present(&active.root, &project_id)?;
-    let (pushed_project, shape_push) =
-        upsert_or_fetch_project(remote, &token, &project_id, local_project.as_ref())?;
+    let (pushed_project, shape_push) = if publish_project_shape {
+        upsert_or_fetch_project(remote, &token, &project_id, local_project.as_ref())?
+    } else {
+        let response = request(
+            remote,
+            &token,
+            "GET",
+            &format!("/projects/{project_id}"),
+            None,
+        )?;
+        if response.status == 404 {
+            upsert_or_fetch_project(remote, &token, &project_id, local_project.as_ref())?
+        } else {
+            (decode_response(response)?, ProjectShapePush::ReadOnly)
+        }
+    };
     if let (Some(project), ProjectShapePush::Pushed) = (local_project.as_ref(), &shape_push) {
         push_repositories(remote, &token, &pushed_project.slug, &project.repos)?;
     }
@@ -710,7 +742,7 @@ fn push_active_bundle_to_remote(
         remote_name,
     );
 
-    println!(
+    crate::human!(
         "{} {} -> {}",
         out::movement(if force.is_force() {
             "pushed (forced)"
@@ -720,7 +752,7 @@ fn push_active_bundle_to_remote(
         out::repo(&active.bundle.id),
         out::repo(&pushed_bundle.slug)
     );
-    println!(
+    crate::human!(
         "{} {} {}",
         out::heading("Artifact:"),
         artifact.id,
@@ -728,7 +760,7 @@ fn push_active_bundle_to_remote(
     );
     match history_result {
         Ok(history_count) if history_count > 0 => {
-            println!(
+            crate::human!(
                 "{} {}",
                 out::heading("History:"),
                 out::muted(format!("{history_count} event(s) synced"))
@@ -736,7 +768,7 @@ fn push_active_bundle_to_remote(
         }
         Ok(_) => {}
         Err(error) => {
-            println!("{} {error:#}", out::warn("History sync skipped:"));
+            crate::human!("{} {error:#}", out::warn("History sync skipped:"));
         }
     }
     Ok(())

--- a/src/commands/stage.rs
+++ b/src/commands/stage.rs
@@ -19,6 +19,7 @@ pub fn stage_paths(
         bail!("Use either --intent-to-add or --update, not both.");
     }
     let active = load_active_bundle_for_update()?;
+    crate::commands::handoff::warn_elsewhere(&active.bundle);
     let (repos, pathspecs) = resolve_stage_targets(&active, explicit_repos, args)?;
 
     if intent_to_add && pathspecs.is_empty() {

--- a/src/commands/status.rs
+++ b/src/commands/status.rs
@@ -13,6 +13,7 @@ use anyhow::Result;
 
 pub fn show_status() -> Result<()> {
     let active = load_active_bundle()?;
+    crate::commands::handoff::print_location(&active.bundle);
     ensure_workspace_fallback_status_is_unambiguous(&active)?;
     let unrecorded = detect_unrecorded_changes(&active)?;
     let state = bundle_state(&active.bundle);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ pub mod model;
 pub mod output;
 pub mod parallel;
 pub mod paths;
+pub mod pending;
 pub mod providers;
 pub mod repo_selectors;
 pub mod retry;
@@ -31,6 +32,33 @@ pub fn run(cli: Cli) -> Result<()> {
     let bundle_context = cli.bundle.clone();
     store::set_bundle_override(cli.bundle);
     match cli.command {
+        Commands::Handoff { command } => match command {
+            cli::HandoffCommand::Out {
+                to,
+                message,
+                force,
+                json,
+            } => commands::handoff::handoff_out(to.as_deref(), message.as_deref(), force, json),
+            cli::HandoffCommand::Probe {
+                project,
+                slug,
+                workspace,
+                json,
+            } => commands::handoff::handoff_probe(
+                project.as_deref(),
+                slug.as_deref(),
+                workspace.as_deref(),
+                json,
+            ),
+            cli::HandoffCommand::In {
+                project,
+                slug,
+                workspace,
+                force,
+                json,
+            } => commands::handoff::handoff_in(&project, &slug, workspace.as_deref(), force, json),
+            cli::HandoffCommand::Status { json } => commands::handoff::handoff_status(json),
+        },
         Commands::Init { name, agents } => commands::init_project(&name, agents),
         Commands::Agents { project } => commands::refresh_agents(project.as_deref()),
         Commands::Project { command } => match command {
@@ -171,6 +199,7 @@ pub fn run(cli: Cli) -> Result<()> {
             token,
             active_bundle,
             no_worktree,
+            prefer_https,
             json,
         } => commands::clone_project_from_remote(
             &project,
@@ -180,6 +209,7 @@ pub fn run(cli: Cli) -> Result<()> {
             token.as_deref(),
             active_bundle.as_deref(),
             !no_worktree,
+            prefer_https,
             json,
         ),
         Commands::Add {

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,11 +8,18 @@ fn main() -> Result<()> {
     // descents (serde_json parsing, directory walks) can exceed that, so the
     // entire CLI — including argument parsing — runs on a worker thread with
     // an explicit stack size to make behavior uniform across platforms.
-    std::thread::Builder::new()
+    let result = std::thread::Builder::new()
         .name("knit".to_string())
         .stack_size(16 * 1024 * 1024)
         .spawn(|| run(Cli::parse()))
         .context("failed to spawn knit worker thread")?
         .join()
-        .unwrap_or_else(|panic| std::panic::resume_unwind(panic))
+        .unwrap_or_else(|panic| std::panic::resume_unwind(panic));
+    if result
+        .as_ref()
+        .is_err_and(|e| e.is::<knit::commands::handoff::report::ProbeFailed>())
+    {
+        std::process::exit(2);
+    }
+    result
 }

--- a/src/model/bundle.rs
+++ b/src/model/bundle.rs
@@ -496,6 +496,114 @@ pub fn is_terminal_landed_node(node: &BundleNode) -> bool {
         && node.landing.as_ref().is_none_or(|landing| landing.terminal)
 }
 
+/// Machine attribution is advisory; environment ids are stable host identities when available.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NodeOrigin {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub environment_id: Option<String>,
+    pub hostname: String,
+    pub platform: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NodeHandoff {
+    pub id: String,
+    pub source: NodeOrigin,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub destination: Option<String>,
+    #[serde(default)]
+    pub checkpoint_commit_group_ids: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub size_mib: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub out_node_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum HandoffLocationState {
+    Pending,
+    Active,
+    Conflict,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct HandoffLocation {
+    pub state: HandoffLocationState,
+    pub label: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub origin: Option<NodeOrigin>,
+    pub updated_at: String,
+    pub handoff_id: String,
+}
+
+impl ChangeGroup {
+    /// Derive location from causal handoff edges, never array order or clocks.
+    /// Outgoing nodes link the previous handoff through targetNodeId; incoming
+    /// nodes link their publication through outNodeId. Competing tips are a
+    /// visible conflict until explicitly reconciled, not a fabricated owner.
+    pub fn handoff_location(&self) -> Option<HandoffLocation> {
+        let nodes: Vec<_> = self
+            .nodes
+            .iter()
+            .filter(|node| {
+                matches!(node.node_type.as_str(), "handoff.out" | "handoff.in")
+                    && node.handoff.is_some()
+            })
+            .collect();
+        let superseded: std::collections::BTreeSet<&str> = nodes
+            .iter()
+            .flat_map(|node| {
+                node.target_node_id
+                    .as_deref()
+                    .into_iter()
+                    .chain(node.handoff.as_ref().and_then(|h| h.out_node_id.as_deref()))
+            })
+            .collect();
+        let mut tips: Vec<_> = nodes
+            .into_iter()
+            .filter(|n| !superseded.contains(n.id.as_str()))
+            .collect();
+        tips.sort_by(|a, b| (&a.created_at, &a.id).cmp(&(&b.created_at, &b.id)));
+        let node = *tips.last()?;
+        let handoff = node.handoff.as_ref()?;
+        let conflict = tips.len() > 1;
+        let pending = node.node_type == "handoff.out";
+        Some(HandoffLocation {
+            state: if conflict {
+                HandoffLocationState::Conflict
+            } else if pending {
+                HandoffLocationState::Pending
+            } else {
+                HandoffLocationState::Active
+            },
+            label: if conflict {
+                "competing handoffs".into()
+            } else if pending {
+                handoff
+                    .destination
+                    .clone()
+                    .unwrap_or_else(|| "another machine".into())
+            } else {
+                node.origin
+                    .as_ref()
+                    .map(|o| o.hostname.clone())
+                    .unwrap_or_else(|| "unknown machine".into())
+            },
+            origin: if conflict || pending {
+                None
+            } else {
+                node.origin.clone()
+            },
+            updated_at: node.created_at.clone(),
+            handoff_id: handoff.id.clone(),
+        })
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct BundleNode {
@@ -512,6 +620,10 @@ pub struct BundleNode {
     /// T3_ACTOR_*; absent for plain CLI use and single-user setups.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub actor: Option<NodeActor>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub origin: Option<NodeOrigin>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub handoff: Option<NodeHandoff>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub title: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -564,6 +676,36 @@ fn ambient_actor() -> Option<NodeActor> {
     })
 }
 
+/// Attribution for newly written nodes. Never backfill old nodes while reading.
+pub fn ambient_origin() -> NodeOrigin {
+    let hostname = non_empty_env("HOSTNAME")
+        .or_else(|| non_empty_env("COMPUTERNAME"))
+        .or_else(|| {
+            std::process::Command::new("hostname")
+                .output()
+                .ok()
+                .filter(|o| o.status.success())
+                .and_then(|o| String::from_utf8(o.stdout).ok())
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty())
+        })
+        .unwrap_or_else(|| "unknown".into());
+    let os = match std::env::consts::OS {
+        "macos" => "darwin",
+        other => other,
+    };
+    let arch = match std::env::consts::ARCH {
+        "x86_64" => "amd64",
+        "aarch64" => "arm64",
+        other => other,
+    };
+    NodeOrigin {
+        environment_id: non_empty_env("KNIT_ENVIRONMENT_ID"),
+        hostname,
+        platform: format!("{os}/{arch}"),
+    }
+}
+
 impl BundleNode {
     /// Every node starts here so cross-cutting attribution (session id)
     /// is recorded uniformly regardless of which command created it.
@@ -574,6 +716,8 @@ impl BundleNode {
             created_at,
             session_id: ambient_session_id(),
             actor: ambient_actor(),
+            origin: Some(ambient_origin()),
+            handoff: None,
             title: None,
             repo_ids: None,
             commit_group_id: None,
@@ -593,6 +737,56 @@ impl BundleNode {
         Self {
             title: Some(title),
             ..Self::base(feature_id, "feature.created", created_at)
+        }
+    }
+
+    pub fn checkpoint(
+        id: String,
+        created_at: String,
+        message: String,
+        repo_ids: Vec<String>,
+        commit_group_id: String,
+    ) -> Self {
+        Self {
+            message: Some(message),
+            repo_ids: Some(repo_ids),
+            commit_group_id: Some(commit_group_id),
+            ..Self::base(id, "checkpoint", created_at)
+        }
+    }
+
+    pub fn handoff_out(
+        id: String,
+        created_at: String,
+        title: Option<String>,
+        message: Option<String>,
+        repo_ids: Vec<String>,
+        handoff: NodeHandoff,
+    ) -> Self {
+        Self {
+            title,
+            message,
+            repo_ids: Some(repo_ids),
+            handoff: Some(handoff),
+            ..Self::base(id, "handoff.out", created_at)
+        }
+    }
+
+    pub fn handoff_in(
+        id: String,
+        created_at: String,
+        title: Option<String>,
+        message: Option<String>,
+        repo_ids: Vec<String>,
+        handoff: NodeHandoff,
+    ) -> Self {
+        Self {
+            title,
+            message,
+            repo_ids: Some(repo_ids),
+            target_node_id: handoff.out_node_id.clone(),
+            handoff: Some(handoff),
+            ..Self::base(id, "handoff.in", created_at)
         }
     }
 
@@ -766,5 +960,128 @@ impl BundleNode {
             publication_urls,
             ..Self::base(id, "pr.revert", created_at)
         }
+    }
+}
+
+#[cfg(test)]
+mod handoff_tests {
+    use super::*;
+
+    fn origin(host: &str) -> NodeOrigin {
+        NodeOrigin {
+            environment_id: Some(host.into()),
+            hostname: host.into(),
+            platform: "linux/amd64".into(),
+        }
+    }
+    fn outgoing(id: &str, predecessor: Option<&str>) -> BundleNode {
+        let mut node = BundleNode::handoff_out(
+            id.into(),
+            "2026-09-05T00:00:00Z".into(),
+            None,
+            None,
+            vec![],
+            NodeHandoff {
+                id: format!("handoff-{id}"),
+                source: origin("laptop"),
+                destination: Some("vps".into()),
+                checkpoint_commit_group_ids: vec![],
+                size_mib: Some(128),
+                out_node_id: None,
+            },
+        );
+        node.target_node_id = predecessor.map(str::to_string);
+        node
+    }
+    fn incoming(id: &str, out: &BundleNode, host: &str) -> BundleNode {
+        let mut payload = out.handoff.clone().unwrap();
+        payload.out_node_id = Some(out.id.clone());
+        let mut node = BundleNode::handoff_in(
+            id.into(),
+            "2026-09-04T00:00:00Z".into(),
+            None,
+            None,
+            vec![],
+            payload,
+        );
+        node.origin = Some(origin(host));
+        node
+    }
+    #[test]
+    fn handoff_location_follows_causality_despite_order_and_clock_skew() {
+        let mut bundle = ChangeGroup::new("bundle".into(), "test".into(), "now".into());
+        assert!(bundle.handoff_location().is_none());
+        let out = outgoing("out", None);
+        bundle.nodes.push(out.clone());
+        assert_eq!(
+            bundle.handoff_location().unwrap().state,
+            HandoffLocationState::Pending
+        );
+        let accepted = incoming("in", &out, "vps");
+        bundle.nodes.insert(0, accepted);
+        let location = bundle.handoff_location().unwrap();
+        assert_eq!(location.state, HandoffLocationState::Active);
+        assert_eq!(location.label, "vps");
+        let returning = outgoing("return-out", Some("in"));
+        let returned = incoming("return-in", &returning, "laptop");
+        bundle.nodes.insert(0, returned);
+        bundle.nodes.insert(0, returning);
+        assert_eq!(bundle.handoff_location().unwrap().label, "laptop");
+    }
+    #[test]
+    fn competing_acceptances_are_a_conflict_even_after_one_moves_again() {
+        let out = outgoing("out", None);
+        let mut bundle = ChangeGroup::new("bundle".into(), "test".into(), "now".into());
+        bundle.nodes.extend([
+            out.clone(),
+            incoming("in-a", &out, "vps-a"),
+            incoming("in-b", &out, "vps-b"),
+        ]);
+        assert_eq!(
+            bundle.handoff_location().unwrap().state,
+            HandoffLocationState::Conflict
+        );
+        bundle.nodes.push(outgoing("return", Some("in-a")));
+        assert_eq!(
+            bundle.handoff_location().unwrap().state,
+            HandoffLocationState::Conflict
+        );
+    }
+    #[test]
+    fn origin_is_additive_and_checkpoint_references_normal_commit_group() {
+        let node: BundleNode = serde_json::from_value(
+            serde_json::json!({"id":"old","type":"checkpoint","createdAt":"then","message":"old"}),
+        )
+        .unwrap();
+        assert!(node.origin.is_none());
+        assert!(node.handoff.is_none());
+        let checkpoint = BundleNode::checkpoint(
+            "cp".into(),
+            "now".into(),
+            "saved".into(),
+            vec!["repo".into()],
+            "kg".into(),
+        );
+        assert_eq!(checkpoint.commit_group_id.as_deref(), Some("kg"));
+        assert!(!checkpoint.origin.unwrap().platform.is_empty());
+        let encoded = serde_json::to_value(outgoing("out", None)).unwrap();
+        assert_eq!(encoded["handoff"]["sizeMib"], 128);
+        assert_eq!(encoded["handoff"]["source"]["environmentId"], "laptop");
+    }
+    #[test]
+    fn handoff_payload_matches_published_schema() {
+        let mut bundle = ChangeGroup::new("bundle".into(), "test".into(), "now".into());
+        let out = outgoing("out", None);
+        bundle
+            .nodes
+            .extend([out.clone(), incoming("in", &out, "vps")]);
+        let schema: serde_json::Value =
+            serde_json::from_str(include_str!("../../schemas/bundle.schema.json")).unwrap();
+        let validator = jsonschema::validator_for(&schema).unwrap();
+        let value = serde_json::to_value(bundle).unwrap();
+        assert!(validator.is_valid(&value));
+        let mut invalid = value;
+        invalid["nodes"][1]["handoff"]["sizeMib"] = serde_json::json!(-1);
+        assert!(!validator.is_valid(&invalid));
     }
 }

--- a/src/model/project.rs
+++ b/src/model/project.rs
@@ -27,6 +27,8 @@ pub struct KnitProject {
     pub runtime: Option<ProjectRuntime>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub landing: Option<ProjectLandingPlan>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub requirements: Option<ProjectRequirements>,
 }
 
 impl KnitProject {
@@ -42,8 +44,38 @@ impl KnitProject {
             commands: BTreeMap::new(),
             runtime: None,
             landing: None,
+            requirements: None,
         }
     }
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ProjectRequirements {
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub platforms: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub tools: Vec<ProjectToolRequirement>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub disk_mib: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub memory_mib: Option<u64>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub agents: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub env: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ProjectToolRequirement {
+    pub name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub min_version: Option<String>,
+    #[serde(default)]
+    pub optional: bool,
+    #[serde(default, rename = "for", skip_serializing_if = "Option::is_none")]
+    pub for_: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -207,4 +239,36 @@ pub struct ProjectLandingCheckout {
 
 fn default_include_by_default() -> bool {
     true
+}
+
+#[cfg(test)]
+mod requirements_tests {
+    use super::*;
+
+    #[test]
+    fn project_requirements_roundtrip_and_match_schema() {
+        let mut project = KnitProject::new("tools".into(), "2026-09-05T00:00:00Z".into());
+        assert!(serde_json::to_value(&project)
+            .unwrap()
+            .get("requirements")
+            .is_none());
+        project.requirements = Some(serde_json::from_value(serde_json::json!({
+            "platforms": ["linux/amd64", "darwin/arm64"],
+            "tools": [{"name":"cargo", "minVersion":"1.85"}, {"name":"docker", "optional":true, "for":"runtime"}],
+            "diskMib":20480, "memoryMib":4096, "agents":["codex"], "env":["FLY_ACCESS_TOKEN"]
+        })).unwrap());
+        let value = serde_json::to_value(&project).unwrap();
+        let schema: serde_json::Value =
+            serde_json::from_str(include_str!("../../schemas/project.schema.json")).unwrap();
+        let validator = jsonschema::validator_for(&schema).unwrap();
+        let errors: Vec<_> = validator
+            .iter_errors(&value)
+            .map(|e| e.to_string())
+            .collect();
+        assert!(errors.is_empty(), "{errors:?}");
+        let decoded: KnitProject = serde_json::from_value(value).unwrap();
+        let requirements = decoded.requirements.unwrap();
+        assert_eq!(requirements.tools[1].for_.as_deref(), Some("runtime"));
+        assert!(!requirements.tools[0].optional);
+    }
 }

--- a/src/pending.rs
+++ b/src/pending.rs
@@ -1,0 +1,85 @@
+//! Shared, conservative pending-work detection.
+use crate::git::{git_output, is_git_worktree, ref_exists, resolve_base_ref};
+use crate::model::RepoEntry;
+use anyhow::{Context, Result};
+use std::{fs, path::Path};
+
+/// Uncommitted work found in a checkout, split by whether Git tracks it.
+#[derive(Clone, Copy, Default)]
+pub(crate) struct Pending {
+    pub(crate) tracked: bool,
+    pub(crate) untracked: bool,
+}
+
+impl Pending {
+    pub(crate) fn from_porcelain(status: &str) -> Self {
+        let mut pending = Self::default();
+        for line in status.lines().filter(|line| !line.trim().is_empty()) {
+            if line.starts_with("??") {
+                pending.untracked = true;
+            } else {
+                pending.tracked = true;
+            }
+        }
+        pending
+    }
+    pub(crate) fn any(self) -> bool {
+        self.tracked || self.untracked
+    }
+
+    pub(crate) fn merge(&mut self, other: Pending) {
+        self.tracked |= other.tracked;
+        self.untracked |= other.untracked;
+    }
+}
+
+/// True when the bundle's feature branch (the local branch or its `origin/`
+/// counterpart in the source repo) carries commits the base branch does not.
+pub(crate) fn feature_branch_unmerged_commits(repo: &RepoEntry) -> Result<bool> {
+    let Some(branch) = repo.feature_branch.as_deref() else {
+        return Ok(false);
+    };
+    let repo_root = Path::new(&repo.path);
+    if !repo_root.exists() {
+        return Ok(false);
+    }
+    let base_ref = resolve_base_ref(repo_root, &repo.base_branch);
+    for candidate in [branch.to_string(), format!("origin/{branch}")] {
+        if !ref_exists(repo_root, &candidate) {
+            continue;
+        }
+        let range = format!("{base_ref}..{candidate}");
+        let count = git_output(repo_root, ["rev-list", "--count", &range])
+            .with_context(|| format!("failed to count commits in {range}"))?;
+        if count.trim() != "0" {
+            return Ok(true);
+        }
+    }
+    Ok(false)
+}
+
+pub(crate) fn path_pending_changes(path: &Path) -> Result<Pending> {
+    if !path.exists() {
+        return Ok(Pending::default());
+    }
+    if is_git_worktree(path) {
+        let status = git_output(path, ["status", "--porcelain"])?;
+        return Ok(Pending::from_porcelain(&status));
+    }
+    // Stray files outside a Git worktree can't be classified, so treat them
+    // as tracked changes: they block pruning even with --untracked.
+    if path.is_file() {
+        return Ok(Pending {
+            tracked: true,
+            untracked: false,
+        });
+    }
+    let mut pending = Pending::default();
+    for entry in fs::read_dir(path).with_context(|| format!("failed to read {}", path.display()))? {
+        pending.merge(path_pending_changes(&entry?.path())?);
+        if pending.tracked && pending.untracked {
+            break;
+        }
+    }
+    Ok(pending)
+}

--- a/src/selectors.rs
+++ b/src/selectors.rs
@@ -6,6 +6,8 @@ pub fn is_loggable_node(node: &BundleNode) -> bool {
         node.node_type.as_str(),
         "check.recorded"
             | "checkpoint"
+            | "handoff.out"
+            | "handoff.in"
             | "commit.group"
             | "feature.closed"
             | "feature.landed"

--- a/src/status.rs
+++ b/src/status.rs
@@ -1,5 +1,5 @@
 pub fn status_label(short_status: &str) -> &'static str {
-    if short_status.trim().is_empty() {
+    if !crate::pending::Pending::from_porcelain(short_status).any() {
         return "clean";
     }
 

--- a/tests/bundle_pull.rs
+++ b/tests/bundle_pull.rs
@@ -150,3 +150,62 @@ fn bundle_pull_unknown_slug_is_not_found() {
 
     fs::remove_dir_all(root).unwrap();
 }
+
+#[test]
+fn bundle_pull_clones_a_repository_added_to_the_remote_bundle() {
+    let root = unique_temp_dir();
+    let fake_dir = root.join("fake");
+    let (mut export, _) = export_with_feature_bundle(&root);
+    let base_url = spawn_fake_remote_api(&fake_dir, export.to_string());
+    let workspace = cloned_workspace(&root, &base_url);
+    assert!(!workspace.join("frontend").exists());
+
+    let frontend = root.join("frontend-source");
+    init_repo(&frontend, "frontend");
+    git(&frontend, ["branch", "knit/feature-a"]);
+    export["data"]["repositories"]
+        .as_array_mut()
+        .unwrap()
+        .push(serde_json::json!({
+            "id":"r-2", "localId":"frontend", "name":"frontend", "defaultBranch":"main",
+            "remoteUrl":frontend.to_string_lossy(), "visibility":"public", "metadata":{}
+        }));
+    let bundle = &mut export["data"]["bundles"][0]["currentArtifact"]["payload"];
+    bundle["repos"].as_array_mut().unwrap().push(serde_json::json!({
+        "id":"frontend", "path":"/elsewhere/frontend", "baseBranch":"main", "featureBranch":"knit/feature-a"
+    }));
+    bundle["nodes"] = serde_json::json!([{
+        "id":"frontend-added", "type":"repo.added", "createdAt":"2026-09-05T12:00:00Z", "repoIds":["frontend"]
+    }]);
+    bundle["headNodeId"] = serde_json::json!("frontend-added");
+    export["data"]["bundles"][0]["currentArtifact"]["artifactHash"] =
+        serde_json::json!("hash-with-frontend");
+    fs::write(fake_dir.join("export.json"), export.to_string()).unwrap();
+
+    let (stdout, stderr, success) =
+        knit_split_output(&workspace, &["bundle", "pull", "feature-a", "--json"], &[]);
+    assert!(success, "bundle pull failed: {stderr}\n{stdout}");
+    let document: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    assert_eq!(document["repos"].as_array().unwrap().len(), 2);
+    assert!(workspace.join("frontend/.git").exists());
+    let tree = workspace.join(".knit/worktrees/feature-a/frontend");
+    assert!(tree.join(".git").exists());
+    assert_eq!(
+        git(&tree, ["rev-parse", "HEAD"]).trim(),
+        git(&frontend, ["rev-parse", "main"]).trim()
+    );
+    let project: serde_json::Value = serde_json::from_str(
+        &fs::read_to_string(workspace.join(".knit/projects/demo.project.json")).unwrap(),
+    )
+    .unwrap();
+    assert_eq!(
+        project["repos"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter(|repo| repo["id"] == "frontend")
+            .count(),
+        1
+    );
+    fs::remove_dir_all(root).unwrap();
+}

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1689,6 +1689,7 @@ fn respond_with_json(stream: &mut std::net::TcpStream, body: &str) -> std::io::R
 ///   set both differently to simulate a concurrent push between GET and POST)
 /// - `enforce-fast-forward`: POSTs without `force: true` are refused with a
 ///   plain 409, like a remote whose ledger is ahead
+/// - `reject-node-type`: artifact POSTs containing this node type fail with 503
 pub fn spawn_fake_remote_push_api(dir: &Path) -> String {
     let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
     let base_url = format!("http://{}", listener.local_addr().unwrap());
@@ -1746,7 +1747,19 @@ fn handle_fake_remote_push_request(
         .trim_start_matches('/')
         .to_string();
     let segments: Vec<&str> = path.split('/').collect();
+    if method == "PATCH" && matches!(segments.as_slice(), ["api", "v1", "projects", _]) {
+        let record = dir.join("project-shape-writes.jsonl");
+        let mut existing = fs::read_to_string(&record).unwrap_or_default();
+        existing.push_str(&body.to_string());
+        existing.push('\n');
+        fs::write(record, existing)?;
+    }
     let (status, response) = match (method.as_str(), segments.as_slice()) {
+        ("GET", ["api", "v1", "me", "access-token"]) => (
+            200,
+            r#"{"data":{"scopes":["bundle:push","bundle:read"]}}"#.to_string(),
+        ),
+        ("GET", ["api", "v1", "me", "forge-credentials"]) => (200, r#"{"data":[]}"#.to_string()),
         // Project export: served from `<dir>/export.json` when a test staged
         // one, so prune's remote-orphan scan sees a configurable bundle list.
         ("GET", ["api", "v1", "projects", _, "export"]) => {
@@ -1885,7 +1898,17 @@ fn handle_fake_remote_push_request(
                 .map(|hash| hash.trim().to_string());
             let accepted =
                 "{\"data\":{\"id\":\"art-1\",\"artifactHash\":\"fakehash\"}}".to_string();
-            if let Some(expected) = expected {
+            let rejected_node = fs::read_to_string(dir.join("reject-node-type")).ok();
+            let reject = rejected_node.as_deref().is_some_and(|kind| {
+                body["payload"]["nodes"].as_array().is_some_and(|nodes| {
+                    nodes
+                        .iter()
+                        .any(|node| node["type"].as_str() == Some(kind.trim()))
+                })
+            });
+            if reject {
+                (503, r#"{"error":{"kind":"unavailable","message":"injected artifact publication failure"}}"#.to_string())
+            } else if let Some(expected) = expected {
                 // Compare-and-swap: accept only when the lease matches the
                 // hash this server currently holds.
                 if force && server_hash.as_deref() == Some(expected) {

--- a/tests/handoff.rs
+++ b/tests/handoff.rs
@@ -1,3 +1,7 @@
+// Target readiness currently uses Unix statvfs and du. Exercise the supported
+// Linux/macOS flow here; platform-independent model/schema tests still run everywhere.
+#![cfg(unix)]
+
 mod common;
 use common::*;
 use serde_json::{json, Value};

--- a/tests/handoff.rs
+++ b/tests/handoff.rs
@@ -1,0 +1,588 @@
+mod common;
+use common::*;
+use serde_json::{json, Value};
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
+
+struct Fixture {
+    root: PathBuf,
+    source: PathBuf,
+    target: PathBuf,
+    api: PathBuf,
+    home: PathBuf,
+}
+impl Fixture {
+    fn new() -> Self {
+        let root = unique_temp_dir();
+        let source = root.join("source");
+        let target = root.join("target");
+        let api = root.join("api");
+        let home = root.join("knit-home");
+        let (_origin, repo, _) = init_remote_repo(&root, "backend");
+        fs::create_dir_all(&source).unwrap();
+        fs::create_dir_all(&home).unwrap();
+        knit(&source, ["init", "demo"]);
+        knit(
+            &source,
+            ["project", "add", "backend", repo.to_str().unwrap()],
+        );
+        knit(&source, ["bundle", "travel"]);
+        let url = spawn_fake_remote_push_api(&api);
+        fs::write(home.join("config.json"),json!({"schemaVersion":"0.1","syncRemote":"hosted","remotes":{"hosted":{"url":url,"token":"test-token"}}}).to_string()).unwrap();
+        let f = Self {
+            root,
+            source,
+            target,
+            api,
+            home,
+        };
+        f.stage_export(&f.source);
+        f
+    }
+    fn run(&self, cwd: &Path, args: &[&str], environment: &str) -> (String, String, bool) {
+        knit_split_output(
+            cwd,
+            args,
+            &[
+                ("KNIT_HOME", self.home.to_str().unwrap()),
+                ("KNIT_ENVIRONMENT_ID", environment),
+                ("GIT_AUTHOR_NAME", "Test"),
+                ("GIT_AUTHOR_EMAIL", "test@example.test"),
+                ("GIT_COMMITTER_NAME", "Test"),
+                ("GIT_COMMITTER_EMAIL", "test@example.test"),
+            ],
+        )
+    }
+    fn ok(&self, cwd: &Path, args: &[&str], env: &str) -> Value {
+        let (o, e, s) = self.run(cwd, args, env);
+        assert!(s, "{args:?}: {e}\n{o}");
+        serde_json::from_str(&o).unwrap_or_else(|e| panic!("JSON parse: {e}: {o}"))
+    }
+    fn bundle(&self, cwd: &Path) -> Value {
+        serde_json::from_str(
+            &fs::read_to_string(cwd.join(".knit/bundles/travel.bundle.json")).unwrap(),
+        )
+        .unwrap()
+    }
+    fn stage_export(&self, cwd: &Path) {
+        let payload = self.bundle(cwd);
+        let project: Value = serde_json::from_str(
+            &fs::read_to_string(cwd.join(".knit/projects/demo.project.json")).unwrap(),
+        )
+        .unwrap();
+        let repos:Vec<_>=project["repos"].as_array().unwrap().iter().map(|r|json!({"localId":r["id"],"name":r["id"],"defaultBranch":r["baseBranch"],"remoteUrl":r["remote"],"visibility":"public","metadata":{}})).collect();
+        fs::write(self.api.join("export.json"),json!({"data":{"project":{"id":"p-1","slug":"demo"},"knitProject":project,"repositories":repos,"bundles":[{"id":"rb-travel","slug":"travel","lifecycleState":"open","currentArtifact":{"artifactHash":"fakehash","payload":payload}}]}}).to_string()).unwrap();
+    }
+    fn accept(&self, cwd: &Path, env: &str) -> Value {
+        self.ok(
+            &self.root,
+            &[
+                "handoff",
+                "in",
+                "acme/demo",
+                "travel",
+                "--workspace",
+                cwd.to_str().unwrap(),
+                "--json",
+            ],
+            env,
+        )
+    }
+}
+impl Drop for Fixture {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.root);
+    }
+}
+
+#[test]
+fn checkpoint_round_trip_and_idempotent_acceptance() {
+    let f = Fixture::new();
+    let source_tree = f.source.join(".knit/worktrees/travel/backend");
+    fs::write(source_tree.join("wip.txt"), "laptop work\n").unwrap();
+    let out = f.ok(
+        &f.source,
+        &["handoff", "out", "--to", "vps", "--json"],
+        "laptop",
+    );
+    assert_eq!(out["checkpointCommitGroupIds"].as_array().unwrap().len(), 1);
+    assert_eq!(git(&source_tree, ["status", "--porcelain"]).trim(), "");
+    let (_, error, success) = f.run(&f.source, &["handoff", "out", "--json"], "laptop");
+    assert!(!success);
+    assert!(error.contains("already handed off"));
+    f.stage_export(&f.source);
+    let incoming = f.accept(&f.target, "vps");
+    assert_eq!(incoming["bundleId"], "travel");
+    let target_tree = f.target.join(".knit/worktrees/travel/backend");
+    assert_eq!(
+        fs::read_to_string(target_tree.join("wip.txt")).unwrap(),
+        "laptop work\n"
+    );
+    f.stage_export(&f.target);
+    f.accept(&f.target, "vps");
+    assert_eq!(
+        f.bundle(&f.target)["nodes"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter(|n| n["type"] == "handoff.in")
+            .count(),
+        1
+    );
+    fs::write(target_tree.join("return.txt"), "VPS work\n").unwrap();
+    f.ok(
+        &f.target,
+        &["handoff", "out", "--to", "laptop", "--json"],
+        "vps",
+    );
+    f.stage_export(&f.target);
+    f.accept(&f.source, "laptop");
+    assert_eq!(
+        fs::read_to_string(source_tree.join("return.txt")).unwrap(),
+        "VPS work\n"
+    );
+    let status = f.ok(&f.source, &["handoff", "status", "--json"], "laptop");
+    assert_eq!(status["location"]["state"], "active");
+    assert_eq!(status["location"]["origin"]["environmentId"], "laptop");
+}
+
+#[test]
+fn force_never_overwrites_dirty_target() {
+    let f = Fixture::new();
+    f.ok(&f.source, &["handoff", "out", "--json"], "laptop");
+    f.stage_export(&f.source);
+    f.accept(&f.target, "vps");
+    let file = f
+        .target
+        .join(".knit/worktrees/travel/backend/private-wip.txt");
+    fs::write(&file, "keep me").unwrap();
+    let (_, error, success) = f.run(
+        &f.root,
+        &[
+            "handoff",
+            "in",
+            "demo",
+            "travel",
+            "--workspace",
+            f.target.to_str().unwrap(),
+            "--force",
+            "--json",
+        ],
+        "vps",
+    );
+    assert!(!success);
+    assert!(error.contains("blocking") || error.contains("uncommitted"));
+    assert_eq!(fs::read_to_string(file).unwrap(), "keep me");
+}
+
+#[test]
+fn failed_artifact_publication_resumes_without_duplicate_checkpoints() {
+    let f = Fixture::new();
+    fs::write(
+        f.source.join(".knit/worktrees/travel/backend/wip.txt"),
+        "keep\n",
+    )
+    .unwrap();
+    fs::write(f.api.join("enforce-fast-forward"), "").unwrap();
+    let (_, _, success) = f.run(
+        &f.source,
+        &["handoff", "out", "--to", "vps", "--json"],
+        "laptop",
+    );
+    assert!(!success);
+    assert_eq!(
+        f.bundle(&f.source)["commitGroups"]
+            .as_array()
+            .unwrap()
+            .len(),
+        1
+    );
+    fs::remove_file(f.api.join("enforce-fast-forward")).unwrap();
+    f.ok(
+        &f.source,
+        &["handoff", "out", "--to", "vps", "--json"],
+        "laptop",
+    );
+    let b = f.bundle(&f.source);
+    assert_eq!(b["commitGroups"].as_array().unwrap().len(), 1);
+    assert_eq!(
+        b["nodes"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter(|n| n["type"] == "handoff.out")
+            .count(),
+        1
+    );
+}
+
+#[test]
+fn probe_distinguishes_required_optional_and_runtime_tools() {
+    let f = Fixture::new();
+    let path = f.api.join("export.json");
+    let mut export: Value = serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
+    export["data"]["knitProject"]["requirements"] = json!({"tools":[{"name":"knit-nonexistent-required-tool"},{"name":"knit-nonexistent-optional-tool","optional":true},{"name":"knit-nonexistent-runtime-tool","for":"runtime"}]});
+    fs::write(path, export.to_string()).unwrap();
+    let (o, _, s) = f.run(
+        &f.root,
+        &[
+            "handoff",
+            "probe",
+            "demo",
+            "travel",
+            "--workspace",
+            f.target.to_str().unwrap(),
+            "--json",
+        ],
+        "vps",
+    );
+    assert!(!s);
+    let r: Value = serde_json::from_str(&o).unwrap();
+    assert_eq!(r["verdict"], "fail");
+    let checks = r["checks"].as_array().unwrap();
+    assert_eq!(
+        checks
+            .iter()
+            .find(|c| c["id"] == "tool:knit-nonexistent-required-tool")
+            .unwrap()["status"],
+        "fail"
+    );
+    assert_eq!(
+        checks
+            .iter()
+            .find(|c| c["id"] == "tool:knit-nonexistent-optional-tool")
+            .unwrap()["status"],
+        "warn"
+    );
+    assert_eq!(
+        checks
+            .iter()
+            .find(|c| c["id"] == "tool:knit-nonexistent-runtime-tool")
+            .unwrap()["status"],
+        "warn"
+    );
+}
+
+#[test]
+fn partial_multi_repo_commit_records_success_before_retry() {
+    let f = Fixture::new();
+    let (_, other, _) = init_remote_repo(&f.root, "frontend");
+    knit(
+        &f.source,
+        ["project", "add", "frontend", other.to_str().unwrap()],
+    );
+    knit(&f.source, ["bundle", "add", "frontend"]);
+    for repo in ["backend", "frontend"] {
+        fs::write(
+            f.source
+                .join(format!(".knit/worktrees/travel/{repo}/wip.txt")),
+            repo,
+        )
+        .unwrap();
+    }
+    let hook = other.join(".git/hooks/pre-commit");
+    fs::write(&hook, "#!/bin/sh\nexit 1\n").unwrap();
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(&hook, fs::Permissions::from_mode(0o755)).unwrap();
+    }
+    let (_, e, s) = f.run(&f.source, &["handoff", "out", "--json"], "laptop");
+    assert!(!s, "{e}");
+    assert_eq!(
+        f.bundle(&f.source)["commitGroups"]
+            .as_array()
+            .unwrap()
+            .len(),
+        1
+    );
+    fs::remove_file(hook).unwrap();
+    f.ok(&f.source, &["handoff", "out", "--json"], "laptop");
+    assert_eq!(
+        f.bundle(&f.source)["commitGroups"]
+            .as_array()
+            .unwrap()
+            .len(),
+        2
+    );
+}
+
+#[test]
+fn existing_workspace_clones_missing_bundle_repositories() {
+    let f = Fixture::new();
+    let (_, frontend, _) = init_remote_repo(&f.root, "frontend");
+    knit(
+        &f.source,
+        ["project", "add", "frontend", frontend.to_str().unwrap()],
+    );
+    knit(&f.source, ["bundle", "add", "frontend"]);
+    let source_tree = f.source.join(".knit/worktrees/travel/frontend");
+    fs::write(source_tree.join("handoff.txt"), "frontend checkpoint").unwrap();
+    f.ok(&f.source, &["handoff", "out", "--json"], "laptop");
+    f.stage_export(&f.source);
+
+    fs::create_dir_all(&f.target).unwrap();
+    knit(&f.target, ["init", "demo"]);
+    fs::write(f.target.join("workspace-notes.txt"), "keep workspace notes").unwrap();
+    let accepted = f.accept(&f.target, "vps");
+    assert_eq!(accepted["bundleSlug"], "travel");
+    for repo in ["backend", "frontend"] {
+        assert!(f.target.join(repo).join(".git").exists());
+        assert!(f
+            .target
+            .join(format!(".knit/worktrees/travel/{repo}/.git"))
+            .exists());
+    }
+    assert_eq!(
+        fs::read_to_string(f.target.join(".knit/worktrees/travel/frontend/handoff.txt")).unwrap(),
+        "frontend checkpoint"
+    );
+    assert_eq!(
+        fs::read_to_string(f.target.join("workspace-notes.txt")).unwrap(),
+        "keep workspace notes"
+    );
+    f.accept(&f.target, "vps");
+    assert_eq!(f.bundle(&f.target)["repos"].as_array().unwrap().len(), 2);
+}
+
+#[test]
+fn failed_acceptance_publication_reuses_the_saved_incoming_node() {
+    let f = Fixture::new();
+    let outgoing = f.ok(&f.source, &["handoff", "out", "--json"], "laptop");
+    f.stage_export(&f.source);
+    fs::write(f.api.join("reject-node-type"), "handoff.in").unwrap();
+    let (_, error, success) = f.run(
+        &f.root,
+        &[
+            "handoff",
+            "in",
+            "acme/demo",
+            "travel",
+            "--workspace",
+            f.target.to_str().unwrap(),
+            "--json",
+        ],
+        "vps",
+    );
+    assert!(!success);
+    assert!(error.contains("Acceptance saved locally"), "{error}");
+    let before = f.bundle(&f.target);
+    let incoming: Vec<_> = before["nodes"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter(|n| n["type"] == "handoff.in")
+        .cloned()
+        .collect();
+    assert_eq!(incoming.len(), 1);
+    assert_eq!(incoming[0]["handoff"]["id"], outgoing["handoffId"]);
+    fs::remove_file(f.api.join("reject-node-type")).unwrap();
+    // Keep the remote export at the outgoing checkpoint: acceptance never arrived.
+    let resumed = f.accept(&f.target, "vps");
+    assert_eq!(resumed["handoffId"], outgoing["handoffId"]);
+    let after = f.bundle(&f.target);
+    let retried: Vec<_> = after["nodes"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter(|n| n["type"] == "handoff.in")
+        .cloned()
+        .collect();
+    assert_eq!(retried, incoming);
+}
+
+#[test]
+fn failure_after_outgoing_node_is_saved_republishes_the_same_handoff() {
+    let f = Fixture::new();
+    fs::write(
+        f.source.join(".knit/worktrees/travel/backend/wip.txt"),
+        "checkpoint once",
+    )
+    .unwrap();
+    fs::write(f.api.join("reject-node-type"), "handoff.out").unwrap();
+    let (_, error, success) = f.run(
+        &f.source,
+        &["handoff", "out", "--to", "vps", "--json"],
+        "laptop",
+    );
+    assert!(!success);
+    assert!(error.contains("Handoff saved locally"), "{error}");
+    let before = f.bundle(&f.source);
+    let outgoing: Vec<_> = before["nodes"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter(|n| n["type"] == "handoff.out")
+        .cloned()
+        .collect();
+    assert_eq!(outgoing.len(), 1);
+    assert_eq!(before["commitGroups"].as_array().unwrap().len(), 1);
+    let attempted: Vec<Value> = fs::read_to_string(f.api.join("artifact-travel.bodies"))
+        .unwrap()
+        .lines()
+        .map(|line| serde_json::from_str(line).unwrap())
+        .collect();
+    assert!(attempted.iter().any(|body| !body["payload"]["nodes"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|n| n["type"] == "handoff.out")));
+    assert!(attempted.iter().any(|body| body["payload"]["nodes"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|n| n["type"] == "handoff.out")));
+    fs::remove_file(f.api.join("reject-node-type")).unwrap();
+    let resumed = f.ok(
+        &f.source,
+        &["handoff", "out", "--to", "vps", "--json"],
+        "laptop",
+    );
+    assert_eq!(resumed["handoffId"], outgoing[0]["handoff"]["id"]);
+    let after = f.bundle(&f.source);
+    assert_eq!(after["commitGroups"], before["commitGroups"]);
+    let retried: Vec<_> = after["nodes"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter(|n| n["type"] == "handoff.out")
+        .cloned()
+        .collect();
+    assert_eq!(retried, outgoing);
+}
+
+#[test]
+fn diverged_ledgers_are_preserved_and_force_still_requires_merge() {
+    let f = Fixture::new();
+    f.ok(&f.source, &["handoff", "out", "--json"], "laptop");
+    f.stage_export(&f.source);
+    f.accept(&f.target, "vps");
+    let mut remote = f.bundle(&f.source);
+    remote["nodes"].as_array_mut().unwrap().push(json!({"id":"source-only", "type":"checkpoint", "message":"source event", "createdAt":"2026-09-05T12:00:00Z"}));
+    remote["headNodeId"] = json!("source-only");
+    fs::write(
+        f.source.join(".knit/bundles/travel.bundle.json"),
+        remote.to_string(),
+    )
+    .unwrap();
+    f.stage_export(&f.source);
+    let path = f.target.join(".knit/bundles/travel.bundle.json");
+    let before = fs::read(&path).unwrap();
+    let (_, error, success) = f.run(
+        &f.root,
+        &[
+            "handoff",
+            "in",
+            "acme/demo",
+            "travel",
+            "--workspace",
+            f.target.to_str().unwrap(),
+            "--force",
+            "--json",
+        ],
+        "vps",
+    );
+    assert!(!success);
+    assert!(error.contains("pull --merge"), "{error}");
+    assert_eq!(fs::read(path).unwrap(), before);
+}
+
+#[test]
+fn diverged_feature_branches_preserve_local_commits_and_need_git_resolution() {
+    let f = Fixture::new();
+    f.ok(&f.source, &["handoff", "out", "--json"], "laptop");
+    f.stage_export(&f.source);
+    f.accept(&f.target, "vps");
+    f.stage_export(&f.target);
+    let source_tree = f.source.join(".knit/worktrees/travel/backend");
+    let target_tree = f.target.join(".knit/worktrees/travel/backend");
+    for (tree, file) in [
+        (&source_tree, "source-only.txt"),
+        (&target_tree, "target-only.txt"),
+    ] {
+        configure_git_user(tree);
+        fs::write(tree.join(file), file).unwrap();
+        git(tree, ["add", file]);
+        git(tree, ["commit", "-m", file]);
+    }
+    git(&source_tree, ["push", "origin", "knit/travel"]);
+    let before = git(&target_tree, ["rev-parse", "HEAD"]);
+    let (_, error, success) = f.run(
+        &f.root,
+        &[
+            "handoff",
+            "in",
+            "acme/demo",
+            "travel",
+            "--workspace",
+            f.target.to_str().unwrap(),
+            "--force",
+            "--json",
+        ],
+        "vps",
+    );
+    assert!(!success);
+    assert!(
+        error.contains("fast-forward") || error.contains("diverg"),
+        "{error}"
+    );
+    assert_eq!(git(&target_tree, ["rev-parse", "HEAD"]), before);
+    assert_eq!(
+        fs::read_to_string(target_tree.join("target-only.txt")).unwrap(),
+        "target-only.txt"
+    );
+    assert!(!target_tree.join("source-only.txt").exists());
+}
+
+#[test]
+fn retry_does_not_add_new_edits_to_an_already_recorded_snapshot() {
+    let f = Fixture::new();
+    let tree = f.source.join(".knit/worktrees/travel/backend");
+    fs::write(tree.join("wip.txt"), "original checkpoint\n").unwrap();
+    fs::write(f.api.join("reject-node-type"), "handoff.out").unwrap();
+    let (_, _, success) = f.run(&f.source, &["handoff", "out", "--json"], "laptop");
+    assert!(!success);
+    let before = f.bundle(&f.source);
+    fs::write(tree.join("new.txt"), "newer work\n").unwrap();
+    fs::remove_file(f.api.join("reject-node-type")).unwrap();
+    let (_, error, success) = f.run(&f.source, &["handoff", "out", "--json"], "laptop");
+    assert!(!success);
+    assert!(error.contains("immutable"), "{error}");
+    assert_eq!(f.bundle(&f.source), before);
+    assert_eq!(
+        fs::read_to_string(tree.join("new.txt")).unwrap(),
+        "newer work\n"
+    );
+}
+
+#[test]
+fn handoff_preserves_project_membership_without_reshaping_the_remote() {
+    let f = Fixture::new();
+    let (_, spare, _) = init_remote_repo(&f.root, "spare");
+    knit(
+        &f.source,
+        [
+            "project",
+            "add",
+            "spare",
+            spare.to_str().unwrap(),
+            "--observe",
+        ],
+    );
+    f.ok(&f.source, &["handoff", "out", "--json"], "laptop");
+    f.stage_export(&f.source);
+    fs::remove_file(f.api.join("project-shape-writes.jsonl")).unwrap();
+    f.accept(&f.target, "vps");
+    let project: Value = serde_json::from_str(
+        &fs::read_to_string(f.target.join(".knit/projects/demo.project.json")).unwrap(),
+    )
+    .unwrap();
+    assert_eq!(project["repos"].as_array().unwrap().len(), 2);
+    assert!(
+        !f.target.join("spare").exists(),
+        "unselected repo must not be cloned"
+    );
+    assert!(!f.api.join("project-shape-writes.jsonl").exists());
+}

--- a/tests/project.rs
+++ b/tests/project.rs
@@ -1634,3 +1634,34 @@ fn project_schema_accepts_a_null_lane_branch() {
 
     fs::remove_dir_all(root).unwrap();
 }
+
+#[test]
+fn project_pull_imports_requirements_from_the_resolved_bundle_checkout() {
+    let root = unique_temp_dir();
+    let repo = root.join("stack");
+    let workspace = root.join("workspace");
+    fs::create_dir_all(&workspace).unwrap();
+    init_repo(&repo, "stack");
+    let source = serde_json::json!({"schemaVersion":"0.1","kind":"KnitProject","id":"demo","createdAt":"2026-01-01T00:00:00Z","updatedAt":"2026-01-01T00:00:00Z","repos":[],"requirements":{"tools":[{"name":"node","minVersion":"20"}]}});
+    fs::write(repo.join("knit.project.json"), source.to_string()).unwrap();
+    git(&repo, ["add", "knit.project.json"]);
+    git(&repo, ["commit", "-m", "Project configuration"]);
+    knit(&workspace, ["init", "demo"]);
+    knit(
+        &workspace,
+        ["project", "add", "stack", repo.to_str().unwrap()],
+    );
+    knit(&workspace, ["bundle", "requirements"]);
+    let checkout = workspace.join(".knit/worktrees/requirements/stack");
+    let mut changed = source;
+    changed["requirements"]["tools"][0]["minVersion"] = serde_json::json!("24");
+    fs::write(checkout.join("knit.project.json"), changed.to_string()).unwrap();
+    knit(&checkout, ["project", "pull", "--repo", "stack"]);
+    let saved: serde_json::Value = serde_json::from_str(
+        &fs::read_to_string(workspace.join(".knit/projects/demo.project.json")).unwrap(),
+    )
+    .unwrap();
+    assert_eq!(saved["requirements"]["tools"][0]["minVersion"], "24");
+    assert_eq!(saved["repos"][0]["path"], repo.to_string_lossy().as_ref());
+    fs::remove_dir_all(root).unwrap();
+}


### PR DESCRIPTION
Add `knit handoff out`, `probe`, `in`, and `status` for moving bundle work between machines. Dirty tracked/untracked files become feature-branch checkpoint commits, branches and ledger are published, target requirements are probed, and missing repositories/worktrees are materialized. Structured transfer IDs, causal location tracking, origin identity, and acceptance retries preserve local work and detect conflicting continuations. Project requirements cover platform, tools, disk, memory and environment-variable presence; secrets and ignored outputs are excluded.

The readiness probe honors cgroup memory limits, and HTTPS fallback uses the same repository URL for probing and cloning. Additive artifact/schema and documentation updates accompany the shared pending-state helper and location display.

Validation: full cargo test, handoff integration tests, rustfmt and Clippy passed; Linux/macOS/Windows CI and MSRV passed. Real Ivaldi-driven laptop → personal VPS → laptop round trip passed against hosted Svartal, including tracked/untracked checkpointing, ignored-file exclusion, missing-repo cloning, target dirty checkpoint return, idempotent acceptance, and active location returning to the laptop. A 1 GiB VPS reports cgroup-constrained available memory. Return checkpoint a220d59 contains the VPS proof edit and the working tree is clean.

<!-- BEGIN KNIT BUNDLE -->
This is part of Knit bundle `continue-a-bundle-on-another-machine`.

Companion reviews: [Knit #183](https://github.com/knit-cli/knit/pull/183), [Ivaldi #248](https://github.com/marc-merino/ivaldi/pull/248), [SDK #2](https://github.com/marc-merino/knit-typescript-sdk/pull/2), [KnitHub #226](https://github.com/marc-merino/knithub/pull/226), [Brok #55](https://github.com/svartal-cli/brok/pull/55).
<!-- END KNIT BUNDLE -->
