### PR TITLE
a land request names a destination not a flag (knit)

### DIFF
--- a/src/commands/land/mod.rs
+++ b/src/commands/land/mod.rs
@@ -107,6 +107,7 @@ pub fn land_default(target_branch: Option<&str>, lane_name: Option<&str>) -> Res
         // destination of its own, so a finished lane or target run does not
         // answer it either.
         let same_destination = ensure_requested_selection_matches_plan(
+            &active,
             target_branch.as_deref(),
             lane_name.as_deref(),
             &plan,
@@ -154,6 +155,7 @@ pub fn land_default(target_branch: Option<&str>, lane_name: Option<&str>) -> Res
     if plan_path.exists() {
         let plan: LandPlan = read_json(&plan_path)?;
         ensure_requested_selection_matches_plan(
+            &active,
             target_branch.as_deref(),
             lane_name.as_deref(),
             &plan,
@@ -201,7 +203,12 @@ pub fn apply_land_plan(
         );
     }
     let plan: LandPlan = read_json(&path)?;
-    ensure_requested_selection_matches_plan(target_branch.as_deref(), lane_name.as_deref(), &plan)?;
+    ensure_requested_selection_matches_plan(
+        &active,
+        target_branch.as_deref(),
+        lane_name.as_deref(),
+        &plan,
+    )?;
     validate::validate_plan_for_bundle(&active, &plan)?;
     ensure_tag_matches_destination(&plan, tag.as_deref())?;
     validate::preflight_required_checks(&active, &plan.require_checks, skip_checks)?;
@@ -326,6 +333,7 @@ pub(super) fn normalize_lane_name(lane_name: Option<&str>) -> Result<Option<Stri
 }
 
 fn ensure_requested_selection_matches_plan(
+    active: &ActiveBundle,
     requested_target: Option<&str>,
     requested_lane: Option<&str>,
     plan: &LandPlan,
@@ -343,6 +351,17 @@ fn ensure_requested_selection_matches_plan(
         if plan.target_branch.as_deref() == Some(requested_target) {
             return Ok(());
         }
+        // A request names a destination, not a flag. A bare plan whose
+        // recorded review bases are all `main` already lands into `main`, so
+        // `--target main` asks for exactly the landing it describes; refusing
+        // it would strand the operator behind a plan that is already right.
+        if plan.lane.is_none()
+            && plan_lands_every_repo_into(active, plan, |_, destination| {
+                destination == requested_target
+            })
+        {
+            return Ok(());
+        }
         let planned = plan.target_branch.as_deref().unwrap_or("recorded PR bases");
         bail!(
             "Land plan targets {planned}, not `{requested_target}`. Regenerate it with `knit land --target {requested_target} plan --force`, inspect it, then apply again."
@@ -358,11 +377,54 @@ fn ensure_requested_selection_matches_plan(
         );
     }
     if let Some(planned_target) = plan.target_branch.as_deref() {
+        // The mirror image: a `--target main` plan whose reviews all already
+        // record `main` as their base lands into the recorded review bases.
+        if plan_lands_every_repo_into(active, plan, |repo_id, destination| {
+            publication_for_repo(&active.bundle, repo_id)
+                .is_some_and(|publication| publication.base_branch == destination)
+        }) {
+            return Ok(());
+        }
         bail!(
             "Land plan targets `{planned_target}`, not the recorded review bases. Pass `--target {planned_target}` to use it, or regenerate it with `knit land plan --force`."
         );
     }
     Ok(())
+}
+
+/// Whether every merge step in the plan lands its repository somewhere
+/// `accepts` agrees with. A step's destination is its own branch, the plan's
+/// per-repo projection, the plan's one raw target, or the base its recorded
+/// review points at. A plan with no merge step, or one whose destination
+/// cannot be resolved, lands nowhere knowable and never matches.
+fn plan_lands_every_repo_into(
+    active: &ActiveBundle,
+    plan: &LandPlan,
+    accepts: impl Fn(&str, &str) -> bool,
+) -> bool {
+    let mut saw_merge = false;
+    for step in plan.steps.iter().filter(|step| plan::is_merge_step(step)) {
+        let Some(repo_id) = step.repo_id.as_deref() else {
+            return false;
+        };
+        let destination = step
+            .target_branch
+            .as_deref()
+            .or_else(|| plan.target_branches.get(repo_id).map(String::as_str))
+            .or(plan.target_branch.as_deref())
+            .or_else(|| {
+                publication_for_repo(&active.bundle, repo_id)
+                    .map(|publication| publication.base_branch.as_str())
+            });
+        let Some(destination) = destination else {
+            return false;
+        };
+        if !accepts(repo_id, destination) {
+            return false;
+        }
+        saw_merge = true;
+    }
+    saw_merge
 }
 
 /// Apply the plan's native target contract to the recorded review objects

--- a/tests/land.rs
+++ b/tests/land.rs
@@ -4234,6 +4234,148 @@ fn a_terminal_target_still_merges_the_reviews() {
     fs::remove_dir_all(root).unwrap();
 }
 
+/// Publish one backend review against `main` and return the workspace with
+/// the fake forge wired up, ready for `knit land`.
+fn publish_main_review_bundle(
+    root: &Path,
+    title: &str,
+) -> (std::path::PathBuf, std::path::PathBuf, std::path::PathBuf) {
+    let (_backend_remote, backend, _backend_collaborator) = init_remote_repo(root, "backend");
+    let workspace = root.join("workspace");
+    fs::create_dir_all(&workspace).unwrap();
+
+    knit(&workspace, ["init", "demo"]);
+    knit(
+        &workspace,
+        ["project", "add", "backend", backend.to_str().unwrap()],
+    );
+    let project_path = workspace.join(".knit/projects/demo.project.json");
+    let mut project: Value =
+        serde_json::from_str(&fs::read_to_string(&project_path).unwrap()).unwrap();
+    project["landing"] = json!({ "provider": "github" });
+    fs::write(
+        &project_path,
+        format!("{}\n", serde_json::to_string_pretty(&project).unwrap()),
+    )
+    .unwrap();
+
+    knit(&workspace, ["bundle", title]);
+    let slug = title.replace(' ', "-");
+    let feature = workspace.join(format!(".knit/worktrees/{slug}/backend"));
+    append_line(&feature.join("app.txt"), "main change");
+    knit(&workspace, ["commit", "--all", "-m", "Main change"]);
+
+    let fake_gh_dir = root.join("fake-gh");
+    let fake_bin = root.join("fake-bin");
+    write_fake_gh(&fake_bin, &fake_gh_dir);
+    knit_with_fake_gh(
+        &workspace,
+        ["publish", "create", "--github", "--no-sync"],
+        &fake_bin,
+        &fake_gh_dir,
+    );
+    (workspace, fake_bin, fake_gh_dir)
+}
+
+/// A request names a destination, not a flag. A plan written bare lands every
+/// review into the base it records — `main` here — so `--target main` asks for
+/// exactly that plan. This is the resume path a one-click "land to main" takes
+/// after an earlier bare `knit land` left its plan behind: the plan step is
+/// refused as already existing, and the apply must then accept the plan
+/// rather than demand a `--force` regeneration of the same landing.
+#[test]
+fn a_target_request_accepts_a_bare_plan_that_already_lands_there() {
+    let root = unique_temp_dir();
+    let (workspace, fake_bin, fake_gh_dir) = publish_main_review_bundle(&root, "bare then target");
+
+    knit_with_fake_gh(&workspace, ["land"], &fake_bin, &fake_gh_dir);
+    let plan_json = read_land_plan(&workspace, "bare-then-target");
+    assert!(plan_json["targetBranch"].is_null(), "{plan_json}");
+
+    let existing = knit_fails_with_fake_gh(
+        &workspace,
+        ["land", "--target", "main", "plan"],
+        &fake_bin,
+        &fake_gh_dir,
+    );
+    assert!(existing.contains("Land plan already exists"), "{existing}");
+
+    // Showing the plan under the same destination is not a mismatch either.
+    let shown = knit_with_fake_gh(
+        &workspace,
+        ["land", "--target", "main"],
+        &fake_bin,
+        &fake_gh_dir,
+    );
+    assert!(shown.contains("backend -> main"), "{shown}");
+
+    let apply = knit_with_fake_gh(
+        &workspace,
+        ["land", "--target", "main", "apply", "--no-remote"],
+        &fake_bin,
+        &fake_gh_dir,
+    );
+    assert!(apply.contains("landed bare-then-target"), "{apply}");
+    assert!(fake_gh_dir.join("merged-backend").exists());
+    assert!(!fake_gh_dir.join("retarget-order.txt").exists());
+
+    let bundle = read_named_bundle(&workspace, "bare-then-target");
+    assert_eq!(bundle["state"].as_str(), Some("archived"));
+
+    fs::remove_dir_all(root).unwrap();
+}
+
+/// A different destination is still refused: the plan lands into `main`, and
+/// `--target release` asks for somewhere else.
+#[test]
+fn a_target_request_still_refuses_a_bare_plan_that_lands_elsewhere() {
+    let root = unique_temp_dir();
+    let (workspace, fake_bin, fake_gh_dir) = publish_main_review_bundle(&root, "bare then release");
+
+    knit_with_fake_gh(&workspace, ["land"], &fake_bin, &fake_gh_dir);
+    let mismatched = knit_fails_with_fake_gh(
+        &workspace,
+        ["land", "--target", "release", "apply", "--no-remote"],
+        &fake_bin,
+        &fake_gh_dir,
+    );
+    assert!(
+        mismatched.contains("Land plan targets recorded PR bases, not `release`"),
+        "{mismatched}"
+    );
+    assert!(!fake_gh_dir.join("merged-backend").exists());
+
+    fs::remove_dir_all(root).unwrap();
+}
+
+/// The mirror image: a `--target main` plan whose reviews already record
+/// `main` lands into the recorded review bases, so a bare apply may use it.
+#[test]
+fn a_bare_request_accepts_a_target_plan_for_the_recorded_bases() {
+    let root = unique_temp_dir();
+    let (workspace, fake_bin, fake_gh_dir) = publish_main_review_bundle(&root, "target then bare");
+
+    knit_with_fake_gh(
+        &workspace,
+        ["land", "--target", "main"],
+        &fake_bin,
+        &fake_gh_dir,
+    );
+    let plan_json = read_land_plan(&workspace, "target-then-bare");
+    assert_eq!(plan_json["targetBranch"].as_str(), Some("main"));
+
+    let apply = knit_with_fake_gh(
+        &workspace,
+        ["land", "apply", "--no-remote"],
+        &fake_bin,
+        &fake_gh_dir,
+    );
+    assert!(apply.contains("landed target-then-bare"), "{apply}");
+    assert!(fake_gh_dir.join("merged-backend").exists());
+
+    fs::remove_dir_all(root).unwrap();
+}
+
 /// The artifact path follows the same rule: an intermediate `--target` merges
 /// the feature branch on the host and leaves the review untouched.
 #[test]


### PR DESCRIPTION
<!-- BEGIN KNIT BUNDLE -->
## Knit Bundle

This PR is part of Knit bundle `a-land-request-names-a-destination-not-a-flag`.

See the other review objects in this bundle:
- `knit`: https://github.com/knit-cli/knit/pull/186 (this PR)

Bundle id: `a-land-request-names-a-destination-not-a-flag`
Bundle title: a land request names a destination not a flag
<!-- END KNIT BUNDLE -->